### PR TITLE
 Correctly handle different numbers of private subnets and NAT states 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,12 +45,12 @@ resource "aws_route" "public_internet_gateway" {
 # Private routes
 #################
 resource "aws_route_table" "private" {
-  count = "${length(var.azs)}"
+  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.private_subnets)) : 0}"
 
   vpc_id           = "${aws_vpc.this.id}"
   propagating_vgws = ["${var.private_propagating_vgws}"]
 
-  tags = "${merge(var.tags, var.private_route_table_tags, map("Name", format("%s-private-%s", var.name, element(var.azs, count.index))))}"
+  tags = "${merge(var.tags, var.private_route_table_tags, map("Name", (var.single_nat_gateway ? "${var.name}-private" : format("%s-private-%s", var.name, element(var.azs, count.index)))))}"
 }
 
 ################
@@ -128,13 +128,13 @@ resource "aws_elasticache_subnet_group" "elasticache" {
 # NAT Gateway
 ##############
 resource "aws_eip" "nat" {
-  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0}"
+  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.private_subnets)) : 0}"
 
   vpc = true
 }
 
 resource "aws_nat_gateway" "this" {
-  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0}"
+  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.private_subnets)) : 0}"
 
   allocation_id = "${element(aws_eip.nat.*.id, (var.single_nat_gateway ? 0 : count.index))}"
   subnet_id     = "${element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))}"
@@ -143,7 +143,7 @@ resource "aws_nat_gateway" "this" {
 }
 
 resource "aws_route" "private_nat_gateway" {
-  count = "${var.enable_nat_gateway ? length(var.azs) : 0}"
+  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.private_subnets)) : 0}"
 
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
@@ -212,7 +212,7 @@ resource "aws_vpc_endpoint_route_table_association" "public_dynamodb" {
 # Route table association
 ##########################
 resource "aws_route_table_association" "private" {
-  count = "${length(var.private_subnets)}"
+  count = "${var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.private_subnets)) : 0}"
 
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"


### PR DESCRIPTION
I'm not sure if this is exactly the right thing to be checking for but I know that without this or `enable_nat_gateway` set there are not likely to be any private subnets to check for. Perhaps we should use `var.enable_nat_gateway` instead?