### PR TITLE
disable dynamodb data source when not needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,6 +182,8 @@ resource "aws_vpc_endpoint_route_table_association" "public_s3" {
 # VPC Endpoint for DynamoDB
 ############################
 data "aws_vpc_endpoint_service" "dynamodb" {
+  count = "${var.enable_dynamodb_endpoint}"
+
   service = "dynamodb"
 }
 


### PR DESCRIPTION
dynamodb is not supported in govcloud so this module will always fail to run.  Setting count to false allows this to run correctly.