### PR TITLE
Use aws_vpn_gateway_route_propagation instead of propagating_vgws

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,6 @@ resource "aws_route_table" "public" {
   count = "${length(var.public_subnets) > 0 ? 1 : 0}"
 
   vpc_id           = "${aws_vpc.this.id}"
-  propagating_vgws = ["${var.public_propagating_vgws}"]
 
   tags = "${merge(var.tags, var.public_route_table_tags, map("Name", format("%s-public", var.name)))}"
 }
@@ -41,6 +40,13 @@ resource "aws_route" "public_internet_gateway" {
   gateway_id             = "${aws_internet_gateway.this.id}"
 }
 
+resource "aws_vpn_gateway_route_propagation" "public" {
+  count = "${length(var.public_propagating_vgws)}"
+
+  route_table_id = "${aws_route_table.public.id}"
+  vpn_gateway_id = "${element(var.public_propagating_vgws, count.index)}"
+}
+
 #################
 # Private routes
 #################
@@ -48,9 +54,15 @@ resource "aws_route_table" "private" {
   count = "${length(var.azs)}"
 
   vpc_id           = "${aws_vpc.this.id}"
-  propagating_vgws = ["${var.private_propagating_vgws}"]
 
   tags = "${merge(var.tags, var.private_route_table_tags, map("Name", format("%s-private-%s", var.name, element(var.azs, count.index))))}"
+}
+
+resource "aws_vpn_gateway_route_propagation" "private" {
+  count = "${length(var.private_propagating_vgws)}"
+
+  route_table_id = "${aws_route_table.private.id}"
+  vpn_gateway_id = "${element(var.private_propagating_vgws, count.index)}"
 }
 
 ################


### PR DESCRIPTION
Use the `aws_vpn_gateway_route_propagation` resource instead of the `propagating_vgws` property on the `aws_route_table`. This allows to attach additional `aws_vpn_gateway_route_propagation` resources outside of this module and doesn't delete them.

Same principle like using `aws_route` resources instead of the `routes` property within `aws_route_table`.

### Use case

Imagine the following structure to split up states:

```
└── dev
    ├── 10-vpc
    │   └── main.tf
    ├── 20-website
    │   └── main.tf
    └── 30-vpn
        └── main.tf
```

The `10-vpc` uses this module to create the VPC and all subnets. The variables `public_propagating_vgws` and `private_propagating_vgws` are not used, thus both an empty list.

In `30-vpn` a VPN is created and `aws_vpn_gateway_route_propagation` resources are added to the `aws_route_table`s from `10-vpn` (IDs retrieved via remote state).

Problem: If you replan/reapply the VPC module after creating the VPN, the VPC module wants to delete all existing route propagations from `30-vpn` because it defaults to an empty list.
```
Terraform will perform the following actions:

  ~ module.vpc.aws_route_table.public
      propagating_vgws.#:          "1" => "0"
      propagating_vgws.1234567890: "vgw-abcde123" => ""

  ~ module.vpc.aws_route_table.private
      propagating_vgws.#:          "1" => "0"
      propagating_vgws.1234567890: "vgw-abcde123" => ""
```

With using the dedicated `aws_vpn_gateway_route_propagation` resource this is not a problem anymore.

### Additional references

See also the note on [aws_route_table](https://www.terraform.io/docs/providers/aws/r/route_table.html) itself:

> **NOTE on propagating_vgws and the aws_vpn_gateway_route_propagation resource:** If the propagating_vgws argument is present, it's not supported to also define route propagations using aws_vpn_gateway_route_propagation, since this resource will delete any propagating gateways not explicitly listed in propagating_vgws. Omit this argument when defining route propagation using the separate resource.