### PR TITLE
Fix *dns* vars description according to AWS Docs

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,12 +46,12 @@ variable "azs" {
 }
 
 variable "enable_dns_hostnames" {
-  description = "Should be true if you want to use private DNS within the VPC"
+  description = "Should be true if you want to use public DNS hostnames within the VPC"
   default     = false
 }
 
 variable "enable_dns_support" {
-  description = "Should be true if you want to use private DNS within the VPC"
+  description = "Should be true if you want to use public DNS servers within the VPC"
   default     = false
 }
 


### PR DESCRIPTION
This is a request to fix description of 2 variables. According to the official documentation, *dns* variables are about public hostnames and the public DNS server(s) of AWS: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html