### PR TITLE
Add tags to the DHCP Options resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,8 @@ resource "aws_vpc_dhcp_options" "this" {
   ntp_servers          = "${var.dhcp_options_ntp_servers}"
   netbios_name_servers = "${var.dhcp_options_netbios_name_servers}"
   netbios_node_type    = "${var.dhcp_options_netbios_node_type}"
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
 }
 
 ###############################


### PR DESCRIPTION
The aws_vpc_dhcp_options resource [supports tags](https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options.html#tags) so we should add them to be consistent.