### PR TITLE
Downgraded require_version from 0.10.13 to 0.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Passing the IPs into the module is done by setting variable `external_nat_ip_ids
 Terraform version
 -----------------
 
-Terraform version 0.10.13 or newer is required for this module to work.
+Terraform version 0.10.3 or newer is required for this module to work.
 
 Examples
 --------

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.10.13" # introduction of Local Values configuration language feature
+  required_version = ">= 0.10.3" # introduction of Local Values configuration language feature
 }
 
 ######


### PR DESCRIPTION
There was a previous commit ( https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/38 ) to enforce version **0.10.13** to be able to use the **Local Values** feature.

https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0103-august-30-2017

The right version was **0.10.3** and not **0.10.13** which doesn't exist.This is causing us issues now when we are running terraform:

> The currently running version of Terraform doesn't meet the
> version requirements explicitly specified by the configuration.
> Please use the required version or update the configuration.
> Note that version requirements are usually set for a reason, so
> we recommend verifying with whoever set the version requirements
> prior to making any manual changes.
> 
>   Module: module.vpc
>   Required version: >= 0.10.13
>   Current version: 0.10.8