### PR TITLE
Ignore changes to propagating_vgws of private routing table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,12 @@ resource "aws_route_table" "private" {
   propagating_vgws = ["${var.private_propagating_vgws}"]
 
   tags = "${merge(var.tags, var.private_route_table_tags, map("Name", format("%s-private-%s", var.name, element(var.azs, count.index))))}"
+
+  lifecycle {
+    # When attaching VPN gateways it is common to define aws_vpn_gateway_route_propagation
+    # resources that manipulate the attributes of the routing table (typically for the private subnets)
+    ignore_changes = ["propagating_vgws"]
+  }
 }
 
 ################


### PR DESCRIPTION
This PR makes the routing tables for the private subnets ignore changes to their `propagating_vgws`.

When configuring VPN Gateways it is normal to define `aws_vpn_gateway_route_propagation` resources to automatically configure route propagation between the VPN Gateway and a routing table. However, without this PR, terraform will continuously propose changes to the infrastructure, adding route propagation in one run and removing it the next.

First run:
```
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + aws_vpn_gateway_route_propagation.private_subnets_vpn_routing[0]
      id:             <computed>
      route_table_id: "rtb-aaa"
      vpn_gateway_id: "vgw-xxx"

  + aws_vpn_gateway_route_propagation.private_subnets_vpn_routing[1]
      id:             <computed>
      route_table_id: "rtb-bbb"
      vpn_gateway_id: "vgw-xxx"
```

Second run:
```
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.vpc.aws_route_table.private[0]
      propagating_vgws.#:          "1" => "0"
      propagating_vgws.3028428753: "vgw-xxx" => ""

  ~ module.vpc.aws_route_table.private[1]
      propagating_vgws.#:          "1" => "0"
      propagating_vgws.3028428753: "vgw-xxx" => ""
```