### PR TITLE
Lowercase database subnet group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ resource "aws_subnet" "database" {
 resource "aws_db_subnet_group" "database" {
   count = "${length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0}"
 
-  name        = "${var.name}"
+  name        = "${lower(var.name)}"
   description = "Database subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.database.*.id}"]
 


### PR DESCRIPTION
If the name field doesn't contain lower-case only, it throws an error.