### PR TITLE
Manage Default Route Table under Terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -334,7 +334,6 @@ resource "aws_vpn_gateway" "this" {
   tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
 }
 
-
 ###########
 # Defaults
 ###########

--- a/main.tf
+++ b/main.tf
@@ -53,14 +53,9 @@ resource "aws_internet_gateway" "this" {
 ################
 # Default Route Table
 ################
-resource "aws_route_table" "default" {
-  vpc_id = "${aws_vpc.this.id}"
+resource "aws_default_route_table" "default" {
+  default_route_table_id = "${aws_vpc.this.default_route_table_id}"
   tags = "${merge(var.tags, var.default_route_table_tags, map("Name", format("%s-default", var.name)))}"
-}
-
-resource "aws_main_route_table_association" "default" {
-  vpc_id          = "${aws_vpc.this.id}"
-  route_table_id  = "${aws_route_table.default.id}"
 }
 
 ################

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,19 @@ resource "aws_internet_gateway" "this" {
 }
 
 ################
+# Default Route Table
+################
+resource "aws_route_table" "default" {
+  vpc_id = "${aws_vpc.this.id}"
+  tags = "${merge(var.tags, var.default_route_table_tags, map("Name", format("%s-default", var.name)))}"
+}
+
+resource "aws_main_route_table_association" "default" {
+  vpc_id          = "${aws_vpc.this.id}"
+  route_table_id  = "${aws_route_table.default.id}"
+}
+
+################
 # Publiс routes
 ################
 resource "aws_route_table" "public" {

--- a/main.tf
+++ b/main.tf
@@ -51,14 +51,6 @@ resource "aws_internet_gateway" "this" {
 }
 
 ################
-# Default Route Table
-################
-resource "aws_default_route_table" "default" {
-  default_route_table_id = "${aws_vpc.this.default_route_table_id}"
-  tags = "${merge(var.tags, var.default_route_table_tags, map("Name", format("%s-default", var.name)))}"
-}
-
-################
 # Publiс routes
 ################
 resource "aws_route_table" "public" {
@@ -340,4 +332,19 @@ resource "aws_vpn_gateway" "this" {
   vpc_id = "${aws_vpc.this.id}"
 
   tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
+}
+
+
+###########
+# Defaults
+###########
+resource "aws_default_route_table" "default" {
+  default_route_table_id = "${aws_vpc.this.default_route_table_id}"
+
+  tags = "${merge(var.tags, var.default_route_table_tags, map("Name", format("%s-default", var.name)))}"
+}
+
+resource "aws_main_route_table_association" "default" {
+  vpc_id         = "${aws_vpc.this.id}"
+  route_table_id = "${aws_default_route_table.default.default_route_table_id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,11 @@ variable "private_subnet_tags" {
   default     = {}
 }
 
+variable "default_route_table_tags" {
+  description = "Additional tags for the default route table"
+  default     = {}
+}
+
 variable "public_route_table_tags" {
   description = "Additional tags for the public route tables"
   default     = {}


### PR DESCRIPTION
So that the default route table will be named and tagged accordingly instead of being unnamed and untagged.