### PR TITLE
Only create one public route association for s3 endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  count = "${var.enable_s3_endpoint ? length(var.public_subnets) : 0}"
+  count = "${var.enable_s3_endpoint ? 1 : 0}"
 
   vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
   route_table_id  = "${aws_route_table.public.id}"


### PR DESCRIPTION
I noticed the module is currently creating one association per public subnet for the s3 endpoint, but there's only one public route table so it's only necessary to create one association.