### PR TITLE
Fix for RouteAlreadyExist error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ These types of resources are supported:
 * [ElastiCache Subnet Group](https://www.terraform.io/docs/providers/aws/r/elasticache_subnet_group.html)
 * [Redshift Subnet Group](https://www.terraform.io/docs/providers/aws/r/redshift_subnet_group.html)
 * [DHCP Options Set](https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options.html)
-* [Main VPC Routing Table](https://www.terraform.io/docs/providers/aws/r/main_route_table_assoc.html)
-* [Default VPC Routing Table](https://www.terraform.io/docs/providers/aws/r/default_route_table.html)
 * [Default VPC](https://www.terraform.io/docs/providers/aws/r/default_vpc.html)
 
 Usage
@@ -109,7 +107,7 @@ Examples
 * [Simple VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc)
 * [Complete VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/complete-vpc)
 * [Manage Default VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/manage-default-vpc)
-* Few tests and edge cases examples: [#46](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/issue-46-no-private-subnets), [#44](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/issue-44-asymmetric-private-subnets)
+* Few tests and edge cases examples: [#46](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/issue-46-no-private-subnets), [#44](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/issue-44-asymmetric-private-subnets), [#108](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/issue-108-route-already-exists)
 
 
 Tests

--- a/examples/issue-108-route-already-exists/README.md
+++ b/examples/issue-108-route-already-exists/README.md
@@ -1,0 +1,21 @@
+Issue 108 - VPC
+==============
+
+Configuration in this directory creates set of VPC resources to cover issues reported on GitHub:
+
+* https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/108#issue-308084655
+* https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/102#issuecomment-374877706
+* https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/44#issuecomment-378679404
+
+Usage
+=====
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.

--- a/examples/issue-108-route-already-exists/main.tf
+++ b/examples/issue-108-route-already-exists/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "vpc" {
+  source = "../../"
+
+  name = "route-already-exists"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.254.240/28", "10.0.254.224/28", "10.0.254.208/28"]
+
+  single_nat_gateway = true
+  enable_nat_gateway = true
+
+  enable_s3_endpoint       = true
+  enable_dynamodb_endpoint = true
+}

--- a/examples/issue-108-route-already-exists/outputs.tf
+++ b/examples/issue-108-route-already-exists/outputs.tf
@@ -1,0 +1,32 @@
+# VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc.vpc_id}"
+}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${module.vpc.private_subnets}"]
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${module.vpc.public_subnets}"]
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = ["${module.vpc.database_subnets}"]
+}
+
+output "elasticache_subnets" {
+  description = "List of IDs of elasticache subnets"
+  value       = ["${module.vpc.elasticache_subnets}"]
+}
+
+# NAT gateways
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = ["${module.vpc.nat_public_ips}"]
+}

--- a/main.tf
+++ b/main.tf
@@ -371,18 +371,3 @@ resource "aws_default_vpc" "this" {
 
   tags = "${merge(var.tags, var.default_vpc_tags, map("Name", format("%s", var.default_vpc_name)))}"
 }
-
-resource "aws_default_route_table" "this" {
-  count = "${var.create_vpc ? 1 : 0}"
-
-  default_route_table_id = "${aws_vpc.this.default_route_table_id}"
-
-  tags = "${merge(var.tags, var.default_route_table_tags, map("Name", format("%s-default", var.name)))}"
-}
-
-resource "aws_main_route_table_association" "this" {
-  count = "${var.create_vpc ? 1 : 0}"
-
-  vpc_id         = "${aws_vpc.this.id}"
-  route_table_id = "${aws_default_route_table.this.default_route_table_id}"
-}


### PR DESCRIPTION
Multiple issues are related:
- #108
- #102
- #95

To-do:
- [x] Removed aws_default_route_table and aws_main_route_table_association
- [x] Added potentially failed example. Word "potential" means that I did my best to make it fail, but could not make it.