### PR TITLE
Provide separate route tables for db/elasticache/redshift

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,42 @@ resource "aws_route_table" "private" {
   }
 }
 
+#################
+# Database routes
+#################
+resource "aws_route_table" "database" {
+
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0}"
+
+  vpc_id = "${aws_vpc.this.id}"
+
+  tags = "${merge(var.tags, var.database_route_table_tags, map("Name", format("%s-db-%s", var.name, element(var.azs, count.index))))}"
+}
+
+#################
+# Redshift routes
+#################
+resource "aws_route_table" "redshift" {
+
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0}"
+
+  vpc_id = "${aws_vpc.this.id}"
+
+  tags = "${merge(var.tags, var.redshift_route_table_tags, map("Name", format("%s-redshift-%s", var.name, element(var.azs, count.index))))}"
+}
+
+#################
+# Elasticache routes
+#################
+resource "aws_route_table" "elasticache" {
+
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0}"
+
+  vpc_id = "${aws_vpc.this.id}"
+
+  tags = "${merge(var.tags, var.elasticache_route_table_tags,  map("Name", format("%s-elasticache-%s", var.name, element(var.azs, count.index))))}"
+}
+
 ################
 # Public subnet
 ################
@@ -312,21 +348,21 @@ resource "aws_route_table_association" "database" {
   count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0}"
 
   subnet_id      = "${element(aws_subnet.database.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  route_table_id = "${element(aws_route_table.database.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "redshift" {
   count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0}"
 
   subnet_id      = "${element(aws_subnet.redshift.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  route_table_id = "${element(aws_route_table.redshift.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "elasticache" {
   count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0}"
 
   subnet_id      = "${element(aws_subnet.elasticache.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  route_table_id = "${element(aws_route_table.elasticache.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "public" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -141,6 +141,23 @@ output "private_route_table_ids" {
   value       = ["${aws_route_table.private.*.id}"]
 }
 
+output "database_route_table_ids" {
+  description = "List of IDs of database route tables"
+  value       = ["${aws_route_table.database.*.id}"]
+}
+
+output "redshift_route_table_ids" {
+  description = "List of IDs of redshift route tables"
+  value       = ["${aws_route_table.redshift.*.id}"]
+}
+
+output "elasticache_route_table_ids" {
+  description = "List of IDs of elasticache route tables"
+  value       = ["${aws_route_table.elasticache.*.id}"]
+}
+
+# NAT Gateway
+
 output "nat_ids" {
   description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
   value       = ["${aws_eip.nat.*.id}"]

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,21 @@ variable "private_route_table_tags" {
   default     = {}
 }
 
+variable "database_route_table_tags" {
+  description = "Additional tags for the private route tables"
+  default     = {}
+}
+
+variable "redshift_route_table_tags" {
+  description = "Additional tags for the private route tables"
+  default     = {}
+}
+
+variable "elasticache_route_table_tags" {
+  description = "Additional tags for the private route tables"
+  default     = {}
+}
+
 variable "database_subnet_tags" {
   description = "Additional tags for the database subnets"
   default     = {}


### PR DESCRIPTION
Hi,

I've created separate route tables for the database, elasticache and redshift subnets.

Currently the db subnets automatically attach to the private subnet (which in turn is NAT'd out). This means the databases by default have a route to the internet.

This breaks the standard 3 tier dmz approach and I believe this shouldn't be the default. If users want to allow this, they can manually add in routes so their database subnets can be NAT'd out.

Let me know what you think and if you require any changes. Thanks for your hard work :smile: 