### PR TITLE
Fix #117 - Add `one_nat_gateway_per_az` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ Passing the IPs into the module is done by setting two variables `reuse_nat_ips 
 This module supports three scenarios for creating NAT gateways. Each will be explained in further detail in the corresponding sections.
 
 * One NAT Gateway per subnet (default behavior)
+    * `enable_nat_gateway = true`
     * `single_nat_gateway = false`
     * `one_nat_gateway_per_az = false`
 * Single NAT Gateway
+    * `enable_nat_gateway = true`
     * `single_nat_gateway = true`
     * `one_nat_gateway_per_az = false`
 * One NAT Gateway per availability zone
+    * `enable_nat_gateway = true`
     * `single_nat_gateway = false`
     * `one_nat_gateway_per_az = true`
 

--- a/README.md
+++ b/README.md
@@ -82,31 +82,24 @@ Passing the IPs into the module is done by setting two variables `reuse_nat_ips 
 
 This module supports three scenarios for creating NAT gateways. Each will be explained in further detail in the corresponding sections.
 
-* One NAT Gateway per availability zone (default behavior)
+* One NAT Gateway per subnet (default behavior)
     * `enable_nat_gateway = true`
-    * `one_nat_gateway_per_az = true`
     * `single_nat_gateway = false`
-* One NAT Gateway per subnet
-    * `enable_nat_gateway = true`
     * `one_nat_gateway_per_az = false`
-    * `single_nat_gateway = false`
 * Single NAT Gateway
     * `enable_nat_gateway = true`
-    * `one_nat_gateway_per_az = false`
     * `single_nat_gateway = true`
+    * `one_nat_gateway_per_az = false`
+* One NAT Gateway per availability zone
+    * `enable_nat_gateway = true`
+    * `single_nat_gateway = false`
+    * `one_nat_gateway_per_az = true`
 
 If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, then `single_nat_gateway` takes precedence.
 
-### One NAT Gateway per availability zone (default)
+### One NAT Gateway per subnet (default)
 
-By default, the module will place one NAT gateway in each availability zone you specify in `var.azs`. There are some requirements around this default behavior:
-
-* The variable `var.azs` **must** be specified.
-* The number of public subnet CIDR blocks specified in `public_subnets` **must** be greater than or equal to the number of availability zones specified in `var.azs`. This is to ensure that each NAT Gateway has a dedicated public subnet to deploy to.
-
-### One NAT Gateway per subnet
-
-If you set `one_nat_gateway_per_az = false`, then the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). For example, if your configuration looks like the following:
+By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). For example, if your configuration looks like the following:
 
 ```hcl
 database_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
@@ -119,7 +112,14 @@ Then `5` NAT Gateways will be created since `5` private subnet CIDR blocks were 
 
 ### Single NAT Gateway
 
-If `single_nat_gateway = true`, then the two previous NAT Gateway configurations are overridden, and all private subnets will route their Internet traffic through this single NAT gateway. The NAT gateway will be placed in the first public subnet in your `public_subnets` block.
+If `single_nat_gateway = true`, then all private subnets will route their Internet traffic through this single NAT gateway. The NAT gateway will be placed in the first public subnet in your `public_subnets` block.
+
+### One NAT Gateway per availability zone
+
+If `one_nat_gateway_per_az = true` and `single_nat_gateway = false`, then the module will place one NAT gateway in each availability zone you specify in `var.azs`. There are some requirements around using this feature flag:
+
+* The variable `var.azs` **must** be specified.
+* The number of public subnet CIDR blocks specified in `public_subnets` **must** be greater than or equal to the number of availability zones specified in `var.azs`. This is to ensure that each NAT Gateway has a dedicated public subnet to deploy to.
 
 ## Conditional creation
 
@@ -152,7 +152,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| azs | A list of availability zones in the region | string | `<list>` | yes |
+| azs | A list of availability zones in the region | string | `<list>` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overriden | string | `0.0.0.0/0` | no |
 | create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
 | create_vpc | Controls if VPC should be created (it affects almost all resources) | string | `true` | no |
@@ -192,7 +192,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | propagate_public_route_tables_vgw | Should be true if you want route table propagation | string | `false` | no |
 | public_route_table_tags | Additional tags for the public route tables | string | `<map>` | no |
 | public_subnet_tags | Additional tags for the public subnets | string | `<map>` | no |
-| public_subnets | A list of public subnets inside the VPC | string | `<list>` | yes |
+| public_subnets | A list of public subnets inside the VPC | string | `<list>` | no |
 | redshift_subnet_tags | Additional tags for the redshift subnets | string | `<map>` | no |
 | redshift_subnets | A list of redshift subnets | list | `<list>` | no |
 | reuse_nat_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `false` | no |
@@ -271,3 +271,4 @@ Module managed by [Anton Babenko](https://github.com/antonbabenko).
 ## License
 
 Apache 2 Licensed. See LICENSE for full details.
+

--- a/README.md
+++ b/README.md
@@ -78,6 +78,46 @@ Note that in the example we allocate 3 IPs because we will be provisioning 3 NAT
 If, on the other hand, `single_nat_gateway = true`, then `aws_eip.nat` would only need to allocate 1 IP.
 Passing the IPs into the module is done by setting two variables `reuse_nat_ips = true` and `external_nat_ip_ids = ["${aws_eip.nat.*.id}"]`.
 
+## NAT Gateway Scenarios
+
+This module supports three scenarios for creating NAT gateways. Each will be explained in further detail in the corresponding sections.
+
+* One NAT Gateway per subnet (default behavior)
+    * `single_nat_gateway = false`
+    * `one_nat_gateway_per_az = false`
+* Single NAT Gateway
+    * `single_nat_gateway = true`
+    * `one_nat_gateway_per_az = false`
+* One NAT Gateway per availability zone
+    * `single_nat_gateway = false`
+    * `one_nat_gateway_per_az = true`
+
+If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, then `single_nat_gateway` takes precedence.
+
+### One NAT Gateway per subnet (default)
+
+By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). For example, if your configuration looks like the following:
+
+```hcl
+database_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
+elasticache_subnets = ["10.0.31.0/24", "10.0.32.0/24"]
+private_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
+redshift_subnets    = ["10.0.41.0/24", "10.0.42.0/24"]
+```
+
+Then `5` NAT Gateways will be created since `5` private subnet CIDR blocks were specified.
+
+### Single NAT Gateway
+
+If `single_nat_gateway = true`, then all private subnets will route their Internet traffic through this single NAT gateway. The NAT gateway will be placed in the first public subnet in your `public_subnets` block.
+
+### One NAT Gateway per availability zone
+
+If `one_nat_gateway_per_az = true` and `single_nat_gateway = false`, then the module will place one NAT gateway in each availability zone you specify in `var.azs`. There are some requirements around using this feature flag:
+
+* The variable `var.azs` **must** be specified.
+* The number of public subnet CIDR blocks specified in `public_subnets` **must** be greater than or equal to the number of availability zones specified in `var.azs`. This is to ensure that each NAT Gateway has a dedicated public subnet to deploy to.
+
 ## Conditional creation
 
 Sometimes you need to have a way to create VPC resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_vpc`.
@@ -141,6 +181,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | manage_default_vpc | Should be true to adopt and manage Default VPC | string | `false` | no |
 | map_public_ip_on_launch | Should be false if you do not want to auto-assign public IP on launch | string | `true` | no |
 | name | Name to be used on all the resources as identifier | string | `` | no |
+| one_nat_gateway_per_az | Should be true if you want only one NAT Gateway per availability zone. Requires the input `azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `azs`. | string | `false` | no |
 | private_route_table_tags | Additional tags for the private route tables | string | `<map>` | no |
 | private_subnet_tags | Additional tags for the private subnets | string | `<map>` | no |
 | private_subnets | A list of private subnets inside the VPC | string | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 locals {
   max_subnet_length = "${max(length(var.private_subnets), length(var.elasticache_subnets), length(var.database_subnets), length(var.redshift_subnets))}"
-  nat_gateway_count = "${var.single_nat_gateway ? 1 : local.max_subnet_length}"
+  nat_gateway_count = "${var.single_nat_gateway ? 1 : (var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length)}"
 }
 
 ######
@@ -102,7 +102,7 @@ resource "aws_route_table" "private" {
 # Public subnet
 ################
 resource "aws_subnet" "public" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_subnets) : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 && (!var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0}"
 
   vpc_id                  = "${aws_vpc.this.id}"
   cidr_block              = "${var.public_subnets[count.index]}"

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,11 @@ variable "single_nat_gateway" {
   default     = false
 }
 
+variable "one_nat_gateway_per_az" {
+  description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`."
+  default     = false
+}
+
 variable "reuse_nat_ips" {
   description = "Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable"
   default     = false


### PR DESCRIPTION
## Description
Fixes https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/117 by adding a new variable called `one_nat_gateway_per_az`. This enables the feature that only one NAT gateway is created for each availability zone. By default, the number of NAT Gateways created is equal to `max_subnet_length`, which is calculated as follows

```hcl
max_subnet_length = "${max(length(var.private_subnets), length(var.elasticache_subnets), length(var.database_subnets), length(var.redshift_subnets))}"
```

For example, if a user specified three database subnet CIDR blocks, four ElastiCache subnet CIDR blocks, and five private subnet CIDR blocks, then five NAT Gateways would be created since five is the maximum of those lists.

## Motivation and Context
As per https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/117, the initial thought was that the default behavior of creating `max_subnet_length` number of NAT Gateways was a bit overkill considering that:

- Each NAT Gateway instance costs money per hour just being active: https://aws.amazon.com/vpc/pricing/#natgatewaypricing
- Most organizations will not hit the 5 - 45 Gbps limit set by each NAT Gateway instance: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html#nat-gateway-limits

However, as @antonbabenko suggested in the issue (https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/117#issuecomment-390398049), multiple scenarios should be supported.

## How Has This Been Tested?
Ran `terraform apply` on the following modification of the Complete VPC example code:

```hcl
provider "aws" {
  region = "us-east-1"
}

module "vpc" {
  source = "../../"

  name = "complete-example"

  cidr = "10.37.0.0/16"

  azs                 = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e"]
  private_subnets     = ["10.37.1.0/24", "10.37.2.0/24", "10.37.3.0/24", "10.37.4.0/24", "10.37.5.0/24", "10.37.6.0/24", "10.37.7.0/24", "10.37.8.0/24"]
  public_subnets      = ["10.37.11.0/24", "10.37.12.0/24", "10.37.13.0/24", "10.37.14.0/24", "10.37.15.0/24"]
  database_subnets    = ["10.37.21.0/24", "10.37.22.0/24", "10.37.23.0/24"]
  elasticache_subnets = ["10.37.31.0/24", "10.37.32.0/24", "10.37.33.0/24"]
  redshift_subnets    = ["10.37.41.0/24", "10.37.42.0/24", "10.37.43.0/24", "10.37.44.0/24"]

  create_database_subnet_group = false

  enable_nat_gateway = true
  enable_vpn_gateway = true

  enable_s3_endpoint       = true
  enable_dynamodb_endpoint = true

  one_nat_gateway_per_az = true

  enable_dhcp_options              = true
  dhcp_options_domain_name         = "service.consul"
  dhcp_options_domain_name_servers = ["127.0.0.1", "10.37.0.2"]

  tags = {
    Owner       = "user"
    Environment = "staging"
    Name        = "complete"
  }
}
```

It is confirmed that the number of NAT gateways (`5` since the AZ count is 5) created does not exceed the `8` number of private subnet CIDR blocks specified in `private_subnets`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
