### PR TITLE
Re-adds support for setting tags on the default route table

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | database_subnet_group_tags | Additional tags for the database subnet group | string | `<map>` | no |
 | database_subnet_tags | Additional tags for the database subnets | string | `<map>` | no |
 | database_subnets | A list of database subnets | list | `<list>` | no |
+| default_route_table_tags | Additional tags for the default route table | string | `<map>` | no |
 | default_vpc_enable_classiclink | Should be true to enable ClassicLink in the Default VPC | string | `false` | no |
 | default_vpc_enable_dns_hostnames | Should be true to enable DNS hostnames in the Default VPC | string | `false` | no |
 | default_vpc_enable_dns_support | Should be true to enable DNS support in the Default VPC | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -425,3 +425,23 @@ resource "aws_default_vpc" "this" {
 
   tags = "${merge(map("Name", format("%s", var.default_vpc_name)), var.default_vpc_tags, var.tags)}"
 }
+
+data "aws_route_table" "default" {
+  count = "${var.manage_default_vpc ? 1 : 0}"
+
+  vpc_id = "${element(aws_default_vpc.this.*.id, 0)}"
+
+  filter {
+    name   = "association.main"
+    values = ["true"]
+  }
+}
+
+resource "aws_default_route_table" "this" {
+  count = "${var.manage_default_vpc ? 1 : 0}"
+
+  default_route_table_id = "${element(data.aws_route_table.default.*.route_table_id, 0)}"
+  route                  = ["${data.aws_route_table.default.*.routes[0]}"]
+
+  tags = "${merge(map("Name", format("%s", var.default_vpc_name)), var.default_route_table_tags, var.tags)}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,11 @@ variable "private_subnet_tags" {
   default     = {}
 }
 
+variable "default_route_table_tags" {
+  description = "Additional tags for the default route table"
+  default     = {}
+}
+
 variable "public_route_table_tags" {
   description = "Additional tags for the public route tables"
   default     = {}


### PR DESCRIPTION
Uses a data source to retrieve and preserve the routes
that are currently associated with the route table. This
works around prior problems with supporting this resource,
as described in #95.

Fixes #146