### PR TITLE
Re-ordering tag merging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_vpc" "this" {
   enable_dns_hostnames = "${var.enable_dns_hostnames}"
   enable_dns_support   = "${var.enable_dns_support}"
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.vpc_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.vpc_tags)}"
 }
 
 ###################
@@ -33,7 +33,7 @@ resource "aws_vpc_dhcp_options" "this" {
   netbios_name_servers = ["${var.dhcp_options_netbios_name_servers}"]
   netbios_node_type    = "${var.dhcp_options_netbios_node_type}"
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.dhcp_options_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.dhcp_options_tags)}"
 }
 
 ###############################
@@ -54,7 +54,7 @@ resource "aws_internet_gateway" "this" {
 
   vpc_id = "${aws_vpc.this.id}"
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.igw_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.igw_tags)}"
 }
 
 ################
@@ -65,7 +65,7 @@ resource "aws_route_table" "public" {
 
   vpc_id = "${aws_vpc.this.id}"
 
-  tags = "${merge(map("Name", format("%s-public", var.name)), var.public_route_table_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-public", var.name)), var.tags, var.public_route_table_tags)}"
 }
 
 resource "aws_route" "public_internet_gateway" {
@@ -89,7 +89,7 @@ resource "aws_route_table" "private" {
 
   vpc_id = "${aws_vpc.this.id}"
 
-  tags = "${merge(map("Name", (var.single_nat_gateway ? "${var.name}-private" : format("%s-private-%s", var.name, element(var.azs, count.index)))), var.private_route_table_tags, var.tags)}"
+  tags = "${merge(map("Name", (var.single_nat_gateway ? "${var.name}-private" : format("%s-private-%s", var.name, element(var.azs, count.index)))), var.tags, var.private_route_table_tags)}"
 
   lifecycle {
     # When attaching VPN gateways it is common to define aws_vpn_gateway_route_propagation
@@ -106,7 +106,7 @@ resource "aws_route_table" "intra" {
 
   vpc_id = "${aws_vpc.this.id}"
 
-  tags = "${merge(map("Name", "${var.name}-intra"), var.intra_route_table_tags, var.tags)}"
+  tags = "${merge(map("Name", "${var.name}-intra"), var.tags, var.intra_route_table_tags)}"
 }
 
 ################
@@ -120,7 +120,7 @@ resource "aws_subnet" "public" {
   availability_zone       = "${element(var.azs, count.index)}"
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 
-  tags = "${merge(map("Name", format("%s-public-%s", var.name, element(var.azs, count.index))), var.public_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-public-%s", var.name, element(var.azs, count.index))), var.tags, var.public_subnet_tags)}"
 }
 
 #################
@@ -133,7 +133,7 @@ resource "aws_subnet" "private" {
   cidr_block        = "${var.private_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
-  tags = "${merge(map("Name", format("%s-private-%s", var.name, element(var.azs, count.index))), var.private_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-private-%s", var.name, element(var.azs, count.index))), var.tags, var.private_subnet_tags)}"
 }
 
 ##################
@@ -146,7 +146,7 @@ resource "aws_subnet" "database" {
   cidr_block        = "${var.database_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
-  tags = "${merge(map("Name", format("%s-db-%s", var.name, element(var.azs, count.index))), var.database_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-db-%s", var.name, element(var.azs, count.index))), var.tags, var.database_subnet_tags)}"
 }
 
 resource "aws_db_subnet_group" "database" {
@@ -156,7 +156,7 @@ resource "aws_db_subnet_group" "database" {
   description = "Database subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.database.*.id}"]
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.database_subnet_group_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.database_subnet_group_tags)}"
 }
 
 ##################
@@ -169,7 +169,7 @@ resource "aws_subnet" "redshift" {
   cidr_block        = "${var.redshift_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
-  tags = "${merge(map("Name", format("%s-redshift-%s", var.name, element(var.azs, count.index))), var.redshift_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-redshift-%s", var.name, element(var.azs, count.index))), var.tags, var.redshift_subnet_tags)}"
 }
 
 resource "aws_redshift_subnet_group" "redshift" {
@@ -179,7 +179,7 @@ resource "aws_redshift_subnet_group" "redshift" {
   description = "Redshift subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.redshift.*.id}"]
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.redshift_subnet_group_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.redshift_subnet_group_tags)}"
 }
 
 #####################
@@ -192,7 +192,7 @@ resource "aws_subnet" "elasticache" {
   cidr_block        = "${var.elasticache_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
-  tags = "${merge(map("Name", format("%s-elasticache-%s", var.name, element(var.azs, count.index))), var.elasticache_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-elasticache-%s", var.name, element(var.azs, count.index))), var.tags, var.elasticache_subnet_tags)}"
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
@@ -213,7 +213,7 @@ resource "aws_subnet" "intra" {
   cidr_block        = "${var.intra_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
-  tags = "${merge(map("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.intra_subnet_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
 }
 
 ##############
@@ -236,7 +236,7 @@ resource "aws_eip" "nat" {
 
   vpc = true
 
-  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.nat_eip_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.tags, var.nat_eip_tags)}"
 }
 
 resource "aws_nat_gateway" "this" {
@@ -245,7 +245,7 @@ resource "aws_nat_gateway" "this" {
   allocation_id = "${element(local.nat_gateway_ips, (var.single_nat_gateway ? 0 : count.index))}"
   subnet_id     = "${element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))}"
 
-  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.nat_gateway_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.tags, var.nat_gateway_tags)}"
 
   depends_on = ["aws_internet_gateway.this"]
 }
@@ -389,7 +389,7 @@ resource "aws_vpn_gateway" "this" {
 
   vpc_id = "${aws_vpc.this.id}"
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.vpn_gateway_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.vpn_gateway_tags)}"
 }
 
 resource "aws_vpn_gateway_attachment" "this" {
@@ -423,5 +423,5 @@ resource "aws_default_vpc" "this" {
   enable_dns_hostnames = "${var.default_vpc_enable_dns_hostnames}"
   enable_classiclink   = "${var.default_vpc_enable_classiclink}"
 
-  tags = "${merge(map("Name", format("%s", var.default_vpc_name)), var.default_vpc_tags, var.tags)}"
+  tags = "${merge(map("Name", format("%s", var.default_vpc_name)), var.tags, var.default_vpc_tags)}"
 }


### PR DESCRIPTION
## Description
Re-orders the tag merging to be consistent with Terraform's map merging strategy, and provides the user greater control over specific resource tagging when tags are inherited from upstream.

## Motivation and Context

**Short version**

The merging strategy of merging maps for a given object should always follow the pattern:

```hcl
tags = "${merge(map(default_map, least_specific_map, ..., ..., most_specific_map)}"
```

This is also documented on the [Terraform Interpolation](https://www.terraform.io/docs/configuration/interpolation.html) page:

> Returns the union of 2 or more maps. The maps are consumed in the order provided, and duplicate keys overwrite previous entries.

This PR changes the tag merging strategy to honor that.

**Long version**

I use CloudPosse's [terraform-null-label](https://github.com/cloudposse/terraform-null-label) module to enforce standard naming within my entire Terraform infrastructure. Using a module block like the following:

```hcl
module "vpc_label" {
  delimiter = "-"
  name      = "vpc"
  namespace = "eu-west-1"
  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
  stage     = "prod"
  tags      = "${map("LastModified", "${timestamp()}")}"
}
```

I can ensure that not only are tags created in a standard way, but that more complicated tagging schemes (like for auto-scaling groups) are already created for me. However, I discovered a conflict with the way that this VPC module handles merging of tags for resources.

The problem is that the [terraform-null-label](https://github.com/cloudposse/terraform-null-label) module above automatically creates a "Name" tag that I cannot drop. For that labeling module, the output `${module.vpc_label.tags}` will return a map of tags it creates. The problem is with the way that this VPC module is currently written, if I set ...

```hcl
module "vpc" {
  ...
  source  = "terraform-aws-modules/vpc/aws"
  tags    = "${module.vpc_label.tags}"
  version = "1.37.0"
}
```

...and then run a `terraform apply`, all of my `Name` tags look like the following:

```
  ~ module.vpc.aws_subnet.private[2]
      tags.LastModified:     "2018-06-30T20:50:31Z" => "2018-06-30T21:26:01Z"
      tags.Name:             "pb-euw1-prod-vpc-private-eu-west-1c" => "pb-euw1-prod-vpc"

  ~ module.vpc.aws_subnet.public[0]
      tags.LastModified:     "2018-06-30T20:50:31Z" => "2018-06-30T21:26:01Z"
      tags.Name:             "pb-euw1-prod-vpc-public-eu-west-1a" => "pb-euw1-prod-vpc"

  ~ module.vpc.aws_subnet.redshift[0]
      tags.LastModified:     "2018-06-30T20:50:31Z" => "2018-06-30T21:26:01Z"
      tags.Name:             "pb-euw1-prod-vpc-redshift-eu-west-1a" => "pb-euw1-prod-vpc"
```

Even if I specifically try and reset the `Name` tag using the `<resource>_tags` inputs available like so:

```hcl
private_subnet_tags {
  "Name" = "some-random-name"
}
```

The tag still is not honored for the `private_subnet` resources, in this case. In general, the merging strategy of merging maps for a given object should always follow the pattern:

```hcl
tags = "${merge(map(default_map, least_specific_map, ..., ..., most_specific_map)}"
```

## How Has This Been Tested?
Ran `terraform apply` on the following modification of the Simple VPC example code:

```hcl
provider "aws" {
  region = "eu-west-1"
}

module "vpc" {
  source = "../../"

  name = "simple-example"

  cidr = "10.0.0.0/16"

  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]

  enable_nat_gateway = true
  single_nat_gateway = true

  public_subnet_tags = {
    Name = "overriden-name-public"
  }

  tags = {
    Owner       = "user"
    Environment = "dev"
    Name        = "default-name-public"
  }

  vpc_tags = {
    Name = "vpc-name"
  }
}
```

The output shows that the `Name` tag specified in the `public_subnet_tags` block is honored even though there is already a `Name` tag in the `tags` block:

```
  + module.vpc.aws_subnet.public[0]
      id:                               <computed>
      assign_ipv6_address_on_creation:  "false"
      availability_zone:                "eu-west-1a"
      cidr_block:                       "10.0.101.0/24"
      ipv6_cidr_block:                  <computed>
      ipv6_cidr_block_association_id:   <computed>
      map_public_ip_on_launch:          "true"
      tags.%:                           "3"
      tags.Environment:                 "dev"
      tags.Name:                        "overriden-name-public"
      tags.Owner:                       "user"
      vpc_id:                           "${aws_vpc.this.id}"

  + module.vpc.aws_subnet.public[1]
      id:                               <computed>
      assign_ipv6_address_on_creation:  "false"
      availability_zone:                "eu-west-1b"
      cidr_block:                       "10.0.102.0/24"
      ipv6_cidr_block:                  <computed>
      ipv6_cidr_block_association_id:   <computed>
      map_public_ip_on_launch:          "true"
      tags.%:                           "3"
      tags.Environment:                 "dev"
      tags.Name:                        "overriden-name-public"
      tags.Owner:                       "user"
      vpc_id:                           "${aws_vpc.this.id}"

  + module.vpc.aws_subnet.public[2]
      id:                               <computed>
      assign_ipv6_address_on_creation:  "false"
      availability_zone:                "eu-west-1c"
      cidr_block:                       "10.0.103.0/24"
      ipv6_cidr_block:                  <computed>
      ipv6_cidr_block_association_id:   <computed>
      map_public_ip_on_launch:          "true"
      tags.%:                           "3"
      tags.Environment:                 "dev"
      tags.Name:                        "overriden-name-public"
      tags.Owner:                       "user"
      vpc_id:                           "${aws_vpc.this.id}"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
