### PR TITLE
Fixing typo overriden -> overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | azs | A list of availability zones in the region | string | `<list>` | no |
-| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overriden | string | `0.0.0.0/0` | no |
+| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
 | create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
 | create_vpc | Controls if VPC should be created (it affects almost all resources) | string | `true` | no |
 | database_subnet_group_tags | Additional tags for the database subnet group | string | `<map>` | no |

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -17,7 +17,7 @@ module "vpc" {
   single_nat_gateway = true
 
   public_subnet_tags = {
-    Name = "overriden-name-public"
+    Name = "overridden-name-public"
   }
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "cidr" {
-  description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overriden"
+  description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
   default     = "0.0.0.0/0"
 }
 


### PR DESCRIPTION
just a typo in the docs and in the
public_subnet_tags in the simple example