### PR TITLE
Add minimum support for IPv6 to VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| assign_generated_ipv6_cidr_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `false` | no |
 | azs | A list of availability zones in the region | string | `<list>` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
 | create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
@@ -278,6 +279,8 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | vpc_endpoint_s3_pl_id | The prefix list for the S3 VPC endpoint. |
 | vpc_id | VPC |
 | vpc_instance_tenancy | Tenancy of instances spin up within VPC |
+| vpc_ipv6_association_id | The association ID for the IPv6 CIDR block |
+| vpc_ipv6_cidr_block | The IPv6 CIDR block |
 | vpc_main_route_table_id | The ID of the main route table associated with this VPC |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -25,6 +25,8 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | nat_public_ips | NAT gateways |
 | private_subnets | Subnets |
 | public_subnets | List of IDs of public subnets |
+| vpc_cidr_block | CIDR blocks |
 | vpc_id | VPC |
+| vpc_ipv6_cidr_block | The IPv6 CIDR block |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -13,7 +13,7 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
-  assign_generated_ipv6_cidr_block = false
+  assign_generated_ipv6_cidr_block = true
 
   enable_nat_gateway = true
   single_nat_gateway = true

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -13,6 +13,8 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
+  assign_generated_ipv6_cidr_block = false
+
   enable_nat_gateway = true
   single_nat_gateway = true
 

--- a/examples/simple-vpc/outputs.tf
+++ b/examples/simple-vpc/outputs.tf
@@ -4,6 +4,17 @@ output "vpc_id" {
   value       = "${module.vpc.vpc_id}"
 }
 
+# CIDR blocks
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = ["${module.vpc.vpc_cidr_block}"]
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = ["${module.vpc.vpc_ipv6_cidr_block}"]
+}
+
 # Subnets
 output "private_subnets" {
   description = "List of IDs of private subnets"

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,11 @@ locals {
 resource "aws_vpc" "this" {
   count = "${var.create_vpc ? 1 : 0}"
 
-  cidr_block           = "${var.cidr}"
-  instance_tenancy     = "${var.instance_tenancy}"
-  enable_dns_hostnames = "${var.enable_dns_hostnames}"
-  enable_dns_support   = "${var.enable_dns_support}"
+  cidr_block                       = "${var.cidr}"
+  instance_tenancy                 = "${var.instance_tenancy}"
+  enable_dns_hostnames             = "${var.enable_dns_hostnames}"
+  enable_dns_support               = "${var.enable_dns_support}"
+  assign_generated_ipv6_cidr_block = "${var.assign_generated_ipv6_cidr_block}"
 
   tags = "${merge(map("Name", format("%s", var.name)), var.vpc_tags, var.tags)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,15 +49,15 @@ output "vpc_main_route_table_id" {
   value       = "${element(concat(aws_vpc.this.*.main_route_table_id, list("")), 0)}"
 }
 
-//output "vpc_ipv6_association_id" {
-//  description = "The association ID for the IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
-//}
-//
-//output "vpc_ipv6_cidr_block" {
-//  description = "The IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
-//}
+output "vpc_ipv6_association_id" {
+  description = "The association ID for the IPv6 CIDR block"
+  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
+}
 
 # Subnets
 output "private_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable "cidr" {
   default     = "0.0.0.0/0"
 }
 
+variable "assign_generated_ipv6_cidr_block" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block"
+  default     = false
+}
+
 variable "instance_tenancy" {
   description = "A tenancy option for instances launched into the VPC"
   default     = "default"


### PR DESCRIPTION
Set `assign_generated_ipv6_cidr_block = true` to enable it on VPC.