### PR TITLE
Removed IPv6 from outputs (fixed #157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,6 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | vpc_endpoint_s3_pl_id | The prefix list for the S3 VPC endpoint. |
 | vpc_id | VPC |
 | vpc_instance_tenancy | Tenancy of instances spin up within VPC |
-| vpc_ipv6_association_id | The association ID for the IPv6 CIDR block |
-| vpc_ipv6_cidr_block | The IPv6 CIDR block |
 | vpc_main_route_table_id | The ID of the main route table associated with this VPC |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -27,6 +27,5 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | public_subnets | List of IDs of public subnets |
 | vpc_cidr_block | CIDR blocks |
 | vpc_id | VPC |
-| vpc_ipv6_cidr_block | The IPv6 CIDR block |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc/outputs.tf
+++ b/examples/simple-vpc/outputs.tf
@@ -10,10 +10,10 @@ output "vpc_cidr_block" {
   value       = ["${module.vpc.vpc_cidr_block}"]
 }
 
-output "vpc_ipv6_cidr_block" {
-  description = "The IPv6 CIDR block"
-  value       = ["${module.vpc.vpc_ipv6_cidr_block}"]
-}
+//output "vpc_ipv6_cidr_block" {
+//  description = "The IPv6 CIDR block"
+//  value       = ["${module.vpc.vpc_ipv6_cidr_block}"]
+//}
 
 # Subnets
 output "private_subnets" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,15 +49,15 @@ output "vpc_main_route_table_id" {
   value       = "${element(concat(aws_vpc.this.*.main_route_table_id, list("")), 0)}"
 }
 
-output "vpc_ipv6_association_id" {
-  description = "The association ID for the IPv6 CIDR block"
-  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
-}
-
-output "vpc_ipv6_cidr_block" {
-  description = "The IPv6 CIDR block"
-  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
-}
+//output "vpc_ipv6_association_id" {
+//  description = "The association ID for the IPv6 CIDR block"
+//  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
+//}
+//
+//output "vpc_ipv6_cidr_block" {
+//  description = "The IPv6 CIDR block"
+//  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
+//}
 
 # Subnets
 output "private_subnets" {


### PR DESCRIPTION
The problem is related to difference in output (see https://github.com/terraform-providers/terraform-provider-aws/pull/2103) and it is safer to hide this from output until it is fixed in AWS provider