### PR TITLE
Add secondary CIDR block support using a local variable to derive the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | assign_generated_ipv6_cidr_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `false` | no |
 | azs | A list of availability zones in the region | string | `<list>` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
-| create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
+  secondary_cidr_blocks | A List of secondary CIDR blocks to add to the vpc. Will append the CIDR blocks before subnet operations are applied | string | `<list>` | no |
+  create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
 | create_database_subnet_route_table | Controls if separate route table for database should be created | string | `false` | no |
 | create_elasticache_subnet_route_table | Controls if separate route table for elasticache should be created | string | `false` | no |
 | create_redshift_subnet_route_table | Controls if separate route table for redshift should be created | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | assign_generated_ipv6_cidr_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `false` | no |
 | azs | A list of availability zones in the region | string | `<list>` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
-  secondary_cidr_blocks | A List of secondary CIDR blocks to add to the vpc. Will append the CIDR blocks before subnet operations are applied | string | `<list>` | no |
-  create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
+| secondary_cidr_blocks | A List of secondary CIDR blocks to add to the vpc. Will append the CIDR blocks before subnet operations are applied | string | `<list>` | no |
+| create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
 | create_database_subnet_route_table | Controls if separate route table for database should be created | string | `false` | no |
 | create_elasticache_subnet_route_table | Controls if separate route table for elasticache should be created | string | `false` | no |
 | create_redshift_subnet_route_table | Controls if separate route table for redshift should be created | string | `false` | no |

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -1,0 +1,22 @@
+# Simple VPC with secondary CIDR blocks
+ Configuration in this directory creates set of VPC resources across multiple CIDR blocks.
+ There is a public and private subnet created per availability zone in addition to single NAT Gateway shared between all 3 availability zones.
+ ## Usage
+ To run this example you need to execute:
+ ```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+ Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+ <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+ ## Outputs
+ | Name | Description |
+|------|-------------|
+| nat_public_ips | NAT gateways |
+| private_subnets | Subnets |
+| public_subnets | List of IDs of public subnets |
+| vpc_cidr_block | CIDR blocks |
+| vpc_secondary_cidr_blocks | Secondary CIDR blocks |
+| vpc_id | VPC |
+ <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+module "vpc" {
+  source = "../../"
+  name = "secondary-cidr-blocks-example"
+  cidr = "10.0.0.0/16"
+  secondary_cidrs = ["10.1.0.0/16", "10.2.0.0/16"]
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.1.2.0/24", "10.2.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.1.102.0/24", "10.2.103.0/24"]
+  assign_generated_ipv6_cidr_block = true
+  enable_nat_gateway = true
+  single_nat_gateway = true
+  public_subnet_tags = {
+    Name = "overridden-name-public"
+  }
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+  vpc_tags = {
+    Name = "vpc-name"
+  }
+}

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -5,7 +5,7 @@ module "vpc" {
   source = "../../"
   name = "secondary-cidr-blocks-example"
   cidr = "10.0.0.0/16"
-  secondary_cidrs = ["10.1.0.0/16", "10.2.0.0/16"]
+  secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
   azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnets = ["10.0.1.0/24", "10.1.2.0/24", "10.2.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.1.102.0/24", "10.2.103.0/24"]

--- a/examples/secondary-cidr-blocks/outputs.tf
+++ b/examples/secondary-cidr-blocks/outputs.tf
@@ -1,0 +1,29 @@
+# VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc.vpc_id}"
+}
+# CIDR blocks
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = ["${module.vpc.vpc_cidr_block}"]
+}
+output "vpc_secondary_cidr_blocks" {
+  description = "Secondary CIDR blocks of the VPC"
+  value       = ["${module.vpc.vpc_secondary_cidr_blocks}"]
+}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${module.vpc.private_subnets}"]
+}
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${module.vpc.public_subnets}"]
+}
+# NAT gateways
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = ["${module.vpc.nat_public_ips}"]
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ terraform {
 locals {
   max_subnet_length = "${max(length(var.private_subnets), length(var.elasticache_subnets), length(var.database_subnets), length(var.redshift_subnets))}"
   nat_gateway_count = "${var.single_nat_gateway ? 1 : (var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length)}"
+  vpc_id = "${length(var.secondary_cidr_blocks) > 0 ? element(concat(aws_vpc_ipv4_cidr_block_association.this.*.vpc_id, list("")), 0) : aws_vpc.this.id}"
 }
 
 ######
@@ -20,6 +21,14 @@ resource "aws_vpc" "this" {
   assign_generated_ipv6_cidr_block = "${var.assign_generated_ipv6_cidr_block}"
 
   tags = "${merge(map("Name", format("%s", var.name)), var.vpc_tags, var.tags)}"
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "this" {
+  count = "${length(var.secondary_cidr_blocks)}"
+
+  vpc_id = "${aws_vpc.this.id}"
+
+  cidr_block = "${element(var.secondary_cidr_blocks, count.index)}"
 }
 
 ###################
@@ -43,7 +52,7 @@ resource "aws_vpc_dhcp_options" "this" {
 resource "aws_vpc_dhcp_options_association" "this" {
   count = "${var.create_vpc && var.enable_dhcp_options ? 1 : 0}"
 
-  vpc_id          = "${aws_vpc.this.id}"
+  vpc_id          = "${local.vpc_id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.this.id}"
 }
 
@@ -53,7 +62,7 @@ resource "aws_vpc_dhcp_options_association" "this" {
 resource "aws_internet_gateway" "this" {
   count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(map("Name", format("%s", var.name)), var.igw_tags, var.tags)}"
 }
@@ -64,7 +73,7 @@ resource "aws_internet_gateway" "this" {
 resource "aws_route_table" "public" {
   count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(map("Name", format("%s-public", var.name)), var.public_route_table_tags, var.tags)}"
 }
@@ -88,7 +97,7 @@ resource "aws_route" "public_internet_gateway" {
 resource "aws_route_table" "private" {
   count = "${var.create_vpc && local.max_subnet_length > 0 ? local.nat_gateway_count : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(map("Name", (var.single_nat_gateway ? "${var.name}-private" : format("%s-private-%s", var.name, element(var.azs, count.index)))), var.private_route_table_tags, var.tags)}"
 
@@ -105,7 +114,7 @@ resource "aws_route_table" "private" {
 resource "aws_route_table" "database" {
   count = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(var.tags, var.database_route_table_tags, map("Name", "${var.name}-database"))}"
 }
@@ -116,7 +125,7 @@ resource "aws_route_table" "database" {
 resource "aws_route_table" "redshift" {
   count = "${var.create_vpc && var.create_redshift_subnet_route_table && length(var.redshift_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(var.tags, var.redshift_route_table_tags, map("Name", "${var.name}-redshift"))}"
 }
@@ -127,7 +136,7 @@ resource "aws_route_table" "redshift" {
 resource "aws_route_table" "elasticache" {
   count = "${var.create_vpc && var.create_elasticache_subnet_route_table && length(var.elasticache_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(var.tags, var.elasticache_route_table_tags, map("Name", "${var.name}-elasticache"))}"
 }
@@ -138,7 +147,7 @@ resource "aws_route_table" "elasticache" {
 resource "aws_route_table" "intra" {
   count = "${var.create_vpc && length(var.intra_subnets) > 0 ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(map("Name", "${var.name}-intra"), var.intra_route_table_tags, var.tags)}"
 }
@@ -149,7 +158,7 @@ resource "aws_route_table" "intra" {
 resource "aws_subnet" "public" {
   count = "${var.create_vpc && length(var.public_subnets) > 0 && (!var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0}"
 
-  vpc_id                  = "${aws_vpc.this.id}"
+  vpc_id                  = "${local.vpc_id}"
   cidr_block              = "${var.public_subnets[count.index]}"
   availability_zone       = "${element(var.azs, count.index)}"
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
@@ -163,7 +172,7 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0}"
 
-  vpc_id            = "${aws_vpc.this.id}"
+  vpc_id            = "${local.vpc_id}"
   cidr_block        = "${var.private_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
@@ -176,7 +185,7 @@ resource "aws_subnet" "private" {
 resource "aws_subnet" "database" {
   count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0}"
 
-  vpc_id            = "${aws_vpc.this.id}"
+  vpc_id            = "${local.vpc_id}"
   cidr_block        = "${var.database_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
@@ -199,7 +208,7 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_subnet" "redshift" {
   count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0}"
 
-  vpc_id            = "${aws_vpc.this.id}"
+  vpc_id            = "${local.vpc_id}"
   cidr_block        = "${var.redshift_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
@@ -222,7 +231,7 @@ resource "aws_redshift_subnet_group" "redshift" {
 resource "aws_subnet" "elasticache" {
   count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0}"
 
-  vpc_id            = "${aws_vpc.this.id}"
+  vpc_id            = "${local.vpc_id}"
   cidr_block        = "${var.elasticache_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
@@ -243,7 +252,7 @@ resource "aws_elasticache_subnet_group" "elasticache" {
 resource "aws_subnet" "intra" {
   count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0}"
 
-  vpc_id            = "${aws_vpc.this.id}"
+  vpc_id            = "${local.vpc_id}"
   cidr_block        = "${var.intra_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
@@ -308,7 +317,7 @@ data "aws_vpc_endpoint_service" "s3" {
 resource "aws_vpc_endpoint" "s3" {
   count = "${var.create_vpc && var.enable_s3_endpoint ? 1 : 0}"
 
-  vpc_id       = "${aws_vpc.this.id}"
+  vpc_id       = "${local.vpc_id}"
   service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
 }
 
@@ -345,7 +354,7 @@ data "aws_vpc_endpoint_service" "dynamodb" {
 resource "aws_vpc_endpoint" "dynamodb" {
   count = "${var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0}"
 
-  vpc_id       = "${aws_vpc.this.id}"
+  vpc_id       = "${local.vpc_id}"
   service_name = "${data.aws_vpc_endpoint_service.dynamodb.service_name}"
 }
 
@@ -421,7 +430,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_vpn_gateway" "this" {
   count = "${var.create_vpc && var.enable_vpn_gateway ? 1 : 0}"
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = "${local.vpc_id}"
 
   tags = "${merge(map("Name", format("%s", var.name)), var.vpn_gateway_tags, var.tags)}"
 }
@@ -429,7 +438,7 @@ resource "aws_vpn_gateway" "this" {
 resource "aws_vpn_gateway_attachment" "this" {
   count = "${var.vpn_gateway_id != "" ? 1 : 0}"
 
-  vpc_id         = "${aws_vpc.this.id}"
+  vpc_id         = "${local.vpc_id}"
   vpn_gateway_id = "${var.vpn_gateway_id}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -231,6 +231,11 @@ output "default_vpc_cidr_block" {
   value       = "${element(concat(aws_default_vpc.this.*.cidr_block, list("")), 0)}"
 }
 
+output "vpc_secondary_cidr_blocks" {
+  description = "Secondary CIDR blocks of the VPC"
+  value       = ["${aws_vpc_ipv4_cidr_block_association.this.*.cidr_block}"]
+}
+
 output "default_vpc_default_security_group_id" {
   description = "The ID of the security group created by default on VPC creation"
   value       = "${element(concat(aws_default_vpc.this.*.default_security_group_id, list("")), 0)}"

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "assign_generated_ipv6_cidr_block" {
 
 variable "secondary_cidr_blocks" {
   type = "list"
-  description = "Seceibdary CIDR blocks to associate with the VPC to extend the IP Address pool."
+  description = "Secondary CIDR blocks to associate with the VPC to extend the IP Address pool."
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "assign_generated_ipv6_cidr_block" {
   default     = false
 }
 
+variable "secondary_cidr_blocks" {
+  type = "list"
+  description = "Seceibdary CIDR blocks to associate with the VPC to extend the IP Address pool."
+  default = []
+}
+
 variable "instance_tenancy" {
   description = "A tenancy option for instances launched into the VPC"
   default     = "default"


### PR DESCRIPTION
Addresses https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/160

Use a local variable with the `aws_vpc_ipv4_cidr_block_association` resource to assign as there are many secondary CIDR blocks..

To  ensure the secondary blocks get assigned before subnet creation so we can also pass in the subnets utilizing the new CIDR blocks to `private_subnets` and `public_subnets` respectively.

I believe that will work. Please tell me what you think! I like to add tests and I saw some kitchen stuff, if you want me to add some additional tests to that, then I would be more than happy to do that.