### PR TITLE
Configure network ACLs for public/private/intra subnets

### DIFF
--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -1,0 +1,31 @@
+# Simple VPC with Network ACLs
+
+Configuration in this directory creates set of VPC resources along with network ACLs for public subnets.
+
+There is a public and private subnet created per availability zone in addition to single NAT Gateway shared between all 3 availability zones. Network ACL rules for inbound and outbound traffic are defined.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| nat_public_ips | NAT gateways |
+| private_subnets | Subnets |
+| public_subnets | List of IDs of public subnets |
+| vpc_cidr_block | CIDR blocks |
+| vpc_id | VPC |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -13,7 +13,7 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
-  public_inbound_acls = [
+  public_inbound_acl_rules = [
     "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows inbound HTTP traffic from any IPv4 address",
     "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows inbound HTTPS traffic from any IPv4 address",
     "120", "allow", 22,    22,    "tcp", "0.0.0.0/0",       "Allows inbound SSH traffic from any IPv4 address",
@@ -21,7 +21,7 @@ module "vpc" {
     "140", "allow", 1024,  65535, "tcp", "0.0.0.0/0",       "Allows inbound return traffic from hosts"
   ]
 
-  public_outbound_acls = [
+  public_outbound_acl_rules = [
     "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows outbound HTTP traffic from the subnet to the Internet",
     "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows outbound HTTPS traffic from the subnet to the Internet",
     "120", "allow", 1433,  1433,  "tcp", "10.0.100.0/22",   "Allows outbound MS SQL access to database servers in the private subnet",

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -13,101 +13,8 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
-  public_inbound_acl_rules = [
-    {
-      rule_number = 100
-      rule_action = "allow"
-      from_port   = 80
-      to_port     = 80
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow inbound HTTP traffic from any IPv4 address"
-    },
-    {
-      rule_number = 110
-      rule_action = "allow"
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow inbound HTTPS traffic from any IPv4 address"
-    },
-    {
-      rule_number = 120
-      rule_action = "allow"
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow inbound SSH traffic from any IPv4 address"
-    },
-    {
-      rule_number = 130
-      rule_action = "allow"
-      from_port   = 3389
-      to_port     = 3389
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow inbound RDP traffic from any IPv4 address"
-    },
-    {
-      rule_number = 140
-      rule_action = "allow"
-      from_port   = 1024
-      to_port     = 65535
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow inbound return traffic from hosts"
-    },
-  ]
-
-  public_outbound_acl_rules = [
-    {
-      rule_number = 100
-      rule_action = "allow"
-      from_port   = 80
-      to_port     = 80
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow outbound HTTP traffic from the subnet to the Internet"
-    },
-    {
-      rule_number = 110
-      rule_action = "allow"
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allow outbound HTTPS traffic from the subnet to the Internet"
-    },
-    {
-      rule_number = 120
-      rule_action = "allow"
-      from_port   = 1433
-      to_port     = 1433
-      protocol    = "tcp"
-      cidr_block  = "10.0.100.0/22"
-      description = "Allow outbound MS SQL access to database servers in the private subnet"
-    },
-    {
-      rule_number = 130
-      rule_action = "allow"
-      from_port   = 32768
-      to_port     = 65535
-      protocol    = "tcp"
-      cidr_block  = "0.0.0.0/0"
-      description = "Allows outbound responses to clients on the Internet"
-    },
-    {
-      rule_number = 140
-      rule_action = "allow"
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_block  = "10.0.100.0/22"
-      description = "Allows outbound SSH access to instances in your private subnet"
-    },
-  ]
+  public_inbound_acl_rules = "${concat(local.network_acls["default_inbound"], local.network_acls["public_inbound"])}"
+  public_outbound_acl_rules = "${concat(local.network_acls["default_outbound"], local.network_acls["public_outbound"])}"
 
   assign_generated_ipv6_cidr_block = true
 
@@ -125,5 +32,112 @@ module "vpc" {
 
   vpc_tags = {
     Name = "vpc-name"
+  }
+}
+
+locals {
+  network_acls = {
+    default_inbound = [
+      {
+        rule_number = 900
+        rule_action = "allow"
+        from_port   = 1024
+        to_port     = 65535
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow inbound return traffic from hosts"
+      },
+    ]
+
+    default_outbound = [
+      {
+        rule_number = 900
+        rule_action = "allow"
+        from_port   = 32768
+        to_port     = 65535
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allows outbound responses to clients"
+      },
+    ]
+
+    public_inbound = [
+      {
+        rule_number = 100
+        rule_action = "allow"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow inbound HTTP traffic from any IPv4 address"
+      },
+      {
+        rule_number = 110
+        rule_action = "allow"
+        from_port   = 443
+        to_port     = 443
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow inbound HTTPS traffic from any IPv4 address"
+      },
+      {
+        rule_number = 120
+        rule_action = "allow"
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow inbound SSH traffic from any IPv4 address"
+      },
+      {
+        rule_number = 130
+        rule_action = "allow"
+        from_port   = 3389
+        to_port     = 3389
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow inbound RDP traffic from any IPv4 address"
+      },
+    ]
+
+    public_outbound = [
+      {
+        rule_number = 100
+        rule_action = "allow"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow outbound HTTP traffic from the subnet to the Internet"
+      },
+      {
+        rule_number = 110
+        rule_action = "allow"
+        from_port   = 443
+        to_port     = 443
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+        description = "Allow outbound HTTPS traffic from the subnet to the Internet"
+      },
+      {
+        rule_number = 120
+        rule_action = "allow"
+        from_port   = 1433
+        to_port     = 1433
+        protocol    = "tcp"
+        cidr_block  = "10.0.100.0/22"
+        description = "Allow outbound MS SQL access to database servers in the private subnet"
+      },
+
+      {
+        rule_number = 130
+        rule_action = "allow"
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_block  = "10.0.100.0/22"
+        description = "Allows outbound SSH access to instances in your private subnet"
+      },
+    ]
   }
 }

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -14,19 +14,99 @@ module "vpc" {
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   public_inbound_acl_rules = [
-    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows inbound HTTP traffic from any IPv4 address",
-    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows inbound HTTPS traffic from any IPv4 address",
-    "120", "allow", 22,    22,    "tcp", "0.0.0.0/0",       "Allows inbound SSH traffic from any IPv4 address",
-    "130", "allow", 3389,  3389,  "tcp", "0.0.0.0/0",       "Allows inbound RDP traffic from any IPv4 address",
-    "140", "allow", 1024,  65535, "tcp", "0.0.0.0/0",       "Allows inbound return traffic from hosts"
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow inbound HTTP traffic from any IPv4 address"
+    },
+    {
+      rule_number = 110
+      rule_action = "allow"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow inbound HTTPS traffic from any IPv4 address"
+    },
+    {
+      rule_number = 120
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow inbound SSH traffic from any IPv4 address"
+    },
+    {
+      rule_number = 130
+      rule_action = "allow"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow inbound RDP traffic from any IPv4 address"
+    },
+    {
+      rule_number = 140
+      rule_action = "allow"
+      from_port   = 1024
+      to_port     = 65535
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow inbound return traffic from hosts"
+    },
   ]
 
   public_outbound_acl_rules = [
-    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows outbound HTTP traffic from the subnet to the Internet",
-    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows outbound HTTPS traffic from the subnet to the Internet",
-    "120", "allow", 1433,  1433,  "tcp", "10.0.100.0/22",   "Allows outbound MS SQL access to database servers in the private subnet",
-    "140", "allow", 32768, 65535, "tcp", "0.0.0.0/0",       "Allows outbound responses to clients on the Internet",
-    "150", "allow", 22,    22,    "tcp", "10.0.100.0/22",   "Allows outbound SSH access to instances in your private subnet"
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow outbound HTTP traffic from the subnet to the Internet"
+    },
+    {
+      rule_number = 110
+      rule_action = "allow"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow outbound HTTPS traffic from the subnet to the Internet"
+    },
+    {
+      rule_number = 120
+      rule_action = "allow"
+      from_port   = 1433
+      to_port     = 1433
+      protocol    = "tcp"
+      cidr_block  = "10.0.100.0/22"
+      description = "Allow outbound MS SQL access to database servers in the private subnet"
+    },
+    {
+      rule_number = 130
+      rule_action = "allow"
+      from_port   = 32768
+      to_port     = 65535
+      protocol    = "tcp"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allows outbound responses to clients on the Internet"
+    },
+    {
+      rule_number = 140
+      rule_action = "allow"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_block  = "10.0.100.0/22"
+      description = "Allows outbound SSH access to instances in your private subnet"
+    },
   ]
 
   assign_generated_ipv6_cidr_block = true

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -1,0 +1,49 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "vpc" {
+  source = "../../"
+
+  name = "network-acls-example"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  public_inbound_acls = [
+    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows inbound HTTP traffic from any IPv4 address",
+    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows inbound HTTPS traffic from any IPv4 address",
+    "120", "allow", 22,    22,    "tcp", "0.0.0.0/0",       "Allows inbound SSH traffic from any IPv4 address",
+    "130", "allow", 3389,  3389,  "tcp", "0.0.0.0/0",       "Allows inbound RDP traffic from any IPv4 address",
+    "140", "allow", 1024,  65535, "tcp", "0.0.0.0/0",       "Allows inbound return traffic from hosts"
+  ]
+
+  public_outbound_acls = [
+    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows outbound HTTP traffic from the subnet to the Internet",
+    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows outbound HTTPS traffic from the subnet to the Internet",
+    "120", "allow", 1433,  1433,  "tcp", "10.0.100.0/22",   "Allows outbound MS SQL access to database servers in the private subnet",
+    "140", "allow", 32768, 65535, "tcp", "0.0.0.0/0",       "Allows outbound responses to clients on the Internet",
+    "150", "allow", 22,    22,    "tcp", "10.0.100.0/22",   "Allows outbound SSH access to instances in your private subnet"
+  ]
+
+  assign_generated_ipv6_cidr_block = true
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  public_subnet_tags = {
+    Name = "overridden-name-public"
+  }
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+
+  vpc_tags = {
+    Name = "vpc-name"
+  }
+}

--- a/examples/network-acls/outputs.tf
+++ b/examples/network-acls/outputs.tf
@@ -1,0 +1,33 @@
+# VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc.vpc_id}"
+}
+
+# CIDR blocks
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = ["${module.vpc.vpc_cidr_block}"]
+}
+
+//output "vpc_ipv6_cidr_block" {
+//  description = "The IPv6 CIDR block"
+//  value       = ["${module.vpc.vpc_ipv6_cidr_block}"]
+//}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = ["${module.vpc.private_subnets}"]
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = ["${module.vpc.public_subnets}"]
+}
+
+# NAT gateways
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = ["${module.vpc.nat_public_ips}"]
+}

--- a/main.tf
+++ b/main.tf
@@ -297,7 +297,7 @@ resource "aws_default_network_acl" "default" {
 # Public Network ACLs
 ########################
 resource "aws_network_acl" "public" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.public.*.id}"]
@@ -306,7 +306,7 @@ resource "aws_network_acl" "public" {
 }
 
 resource "aws_network_acl_rule" "public_inbound" {
-  count = "${var.create_vpc ? length(var.public_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
@@ -320,7 +320,7 @@ resource "aws_network_acl_rule" "public_inbound" {
 }
 
 resource "aws_network_acl_rule" "public_outbound" {
-  count = "${var.create_vpc ? length(var.public_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
@@ -337,7 +337,7 @@ resource "aws_network_acl_rule" "public_outbound" {
 # Private Network ACLs
 #######################
 resource "aws_network_acl" "private" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.private_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.private.*.id}"]
@@ -346,7 +346,7 @@ resource "aws_network_acl" "private" {
 }
 
 resource "aws_network_acl_rule" "private_inbound" {
-  count = "${var.create_vpc ? length(var.private_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
@@ -360,7 +360,7 @@ resource "aws_network_acl_rule" "private_inbound" {
 }
 
 resource "aws_network_acl_rule" "private_outbound" {
-  count = "${var.create_vpc ? length(var.private_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
@@ -377,7 +377,7 @@ resource "aws_network_acl_rule" "private_outbound" {
 # Intra Network ACLs
 ########################
 resource "aws_network_acl" "intra" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.intra.*.id}"]
@@ -386,7 +386,7 @@ resource "aws_network_acl" "intra" {
 }
 
 resource "aws_network_acl_rule" "intra_inbound" {
-  count = "${var.create_vpc ? length(var.intra_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
@@ -400,7 +400,7 @@ resource "aws_network_acl_rule" "intra_inbound" {
 }
 
 resource "aws_network_acl_rule" "intra_outbound" {
-  count = "${var.create_vpc ? length(var.intra_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
@@ -417,7 +417,7 @@ resource "aws_network_acl_rule" "intra_outbound" {
 # Database Network ACLs
 ########################
 resource "aws_network_acl" "database" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.database.*.id}"]
@@ -426,7 +426,7 @@ resource "aws_network_acl" "database" {
 }
 
 resource "aws_network_acl_rule" "database_inbound" {
-  count = "${var.create_vpc ? length(var.database_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.database.id}"
 
@@ -440,7 +440,7 @@ resource "aws_network_acl_rule" "database_inbound" {
 }
 
 resource "aws_network_acl_rule" "database_outbound" {
-  count = "${var.create_vpc ? length(var.database_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.database.id}"
 
@@ -457,7 +457,7 @@ resource "aws_network_acl_rule" "database_outbound" {
 # Redshift Network ACLs
 ########################
 resource "aws_network_acl" "redshift" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.redshift.*.id}"]
@@ -466,7 +466,7 @@ resource "aws_network_acl" "redshift" {
 }
 
 resource "aws_network_acl_rule" "redshift_inbound" {
-  count = "${var.create_vpc ? length(var.redshift_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.redshift.id}"
 
@@ -480,7 +480,7 @@ resource "aws_network_acl_rule" "redshift_inbound" {
 }
 
 resource "aws_network_acl_rule" "redshift_outbound" {
-  count = "${var.create_vpc ? length(var.redshift_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.redshift.id}"
 
@@ -497,7 +497,7 @@ resource "aws_network_acl_rule" "redshift_outbound" {
 # Elasticache Network ACLs
 ###########################
 resource "aws_network_acl" "elasticache" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? 1 : 0}"
 
   vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
   subnet_ids = ["${aws_subnet.elasticache.*.id}"]
@@ -506,7 +506,7 @@ resource "aws_network_acl" "elasticache" {
 }
 
 resource "aws_network_acl_rule" "elasticache_inbound" {
-  count = "${var.create_vpc ? length(var.elasticache_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.elasticache.id}"
 
@@ -520,7 +520,7 @@ resource "aws_network_acl_rule" "elasticache_inbound" {
 }
 
 resource "aws_network_acl_rule" "elasticache_outbound" {
-  count = "${var.create_vpc ? length(var.elasticache_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.elasticache.id}"
 

--- a/main.tf
+++ b/main.tf
@@ -284,6 +284,16 @@ resource "aws_subnet" "intra" {
   tags = "${merge(map("Name", format("%s-${var.intra_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
 }
 
+#######################
+# Default Network ACLs
+#######################
+
+resource "aws_default_network_acl" "default" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  default_network_acl_id = "${element(concat(aws_vpc.this.*.default_network_acl_id, list("")), 0)}"
+}
+
 ########################
 # Public Network ACLs
 ########################

--- a/main.tf
+++ b/main.tf
@@ -306,31 +306,31 @@ resource "aws_network_acl" "public" {
 }
 
 resource "aws_network_acl_rule" "public_inbound" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
   egress      = false
-  rule_number = "${element(var.public_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.public_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.public_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.public_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.public_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.public_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.public_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.public_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.public_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.public_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.public_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.public_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "public_outbound" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
   egress      = true
-  rule_number = "${element(var.public_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.public_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.public_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.public_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.public_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.public_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.public_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.public_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.public_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.public_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.public_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.public_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 #######################
@@ -346,31 +346,31 @@ resource "aws_network_acl" "private" {
 }
 
 resource "aws_network_acl_rule" "private_inbound" {
-  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
   egress      = false
-  rule_number = "${element(var.private_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.private_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.private_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.private_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.private_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.private_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.private_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.private_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.private_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.private_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.private_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.private_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "private_outbound" {
-  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
   egress      = true
-  rule_number = "${element(var.private_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.private_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.private_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.private_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.private_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.private_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.private_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.private_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.private_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.private_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.private_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.private_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 ########################
@@ -386,31 +386,31 @@ resource "aws_network_acl" "intra" {
 }
 
 resource "aws_network_acl_rule" "intra_inbound" {
-  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
   egress      = false
-  rule_number = "${element(var.intra_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.intra_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.intra_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.intra_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.intra_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.intra_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.intra_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.intra_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.intra_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.intra_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.intra_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.intra_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "intra_outbound" {
-  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
   egress      = true
-  rule_number = "${element(var.intra_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.intra_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.intra_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.intra_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.intra_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.intra_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.intra_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.intra_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.intra_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.intra_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.intra_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.intra_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 ########################
@@ -426,31 +426,31 @@ resource "aws_network_acl" "database" {
 }
 
 resource "aws_network_acl_rule" "database_inbound" {
-  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.database.id}"
 
   egress      = false
-  rule_number = "${element(var.database_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.database_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.database_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.database_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.database_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.database_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.database_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.database_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.database_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.database_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.database_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.database_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "database_outbound" {
-  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.database.id}"
 
   egress      = true
-  rule_number = "${element(var.database_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.database_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.database_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.database_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.database_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.database_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.database_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.database_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.database_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.database_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.database_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.database_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 ########################
@@ -466,31 +466,31 @@ resource "aws_network_acl" "redshift" {
 }
 
 resource "aws_network_acl_rule" "redshift_inbound" {
-  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.redshift.id}"
 
   egress      = false
-  rule_number = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.redshift_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.redshift_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.redshift_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.redshift_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.redshift_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.redshift_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "redshift_outbound" {
-  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.redshift.id}"
 
   egress      = true
-  rule_number = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.redshift_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.redshift_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.redshift_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.redshift_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.redshift_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.redshift_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 ###########################
@@ -506,31 +506,31 @@ resource "aws_network_acl" "elasticache" {
 }
 
 resource "aws_network_acl_rule" "elasticache_inbound" {
-  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_inbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_inbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.elasticache.id}"
 
   egress      = false
-  rule_number = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.elasticache_inbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.elasticache_inbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.elasticache_inbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.elasticache_inbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.elasticache_inbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.elasticache_inbound_acl_rules[count.index], "cidr_block")}"
 }
 
 resource "aws_network_acl_rule" "elasticache_outbound" {
-  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_outbound_acl_rules) / 7 : 0}"
+  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_outbound_acl_rules) : 0}"
 
   network_acl_id = "${aws_network_acl.elasticache.id}"
 
   egress      = true
-  rule_number = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 0)}"
-  rule_action = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 1)}"
-  from_port   = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 2)}"
-  to_port     = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 3)}"
-  protocol    = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 5)}"
+  rule_number = "${lookup(var.elasticache_outbound_acl_rules[count.index], "rule_number")}"
+  rule_action = "${lookup(var.elasticache_outbound_acl_rules[count.index], "rule_action")}"
+  from_port   = "${lookup(var.elasticache_outbound_acl_rules[count.index], "from_port")}"
+  to_port     = "${lookup(var.elasticache_outbound_acl_rules[count.index], "to_port")}"
+  protocol    = "${lookup(var.elasticache_outbound_acl_rules[count.index], "protocol")}"
+  cidr_block  = "${lookup(var.elasticache_outbound_acl_rules[count.index], "cidr_block")}"
 }
 
 ##############

--- a/main.tf
+++ b/main.tf
@@ -306,31 +306,31 @@ resource "aws_network_acl" "public" {
 }
 
 resource "aws_network_acl_rule" "public_inbound" {
-  count = "${var.create_vpc ? length(var.public_inbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.public_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
   egress      = false
-  rule_number = "${element(var.public_inbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.public_inbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.public_inbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.public_inbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.public_inbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.public_inbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.public_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.public_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.public_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.public_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.public_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.public_inbound_acl_rules, count.index * 7 + 5)}"
 }
 
 resource "aws_network_acl_rule" "public_outbound" {
-  count = "${var.create_vpc ? length(var.public_outbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.public_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.public.id}"
 
   egress      = true
-  rule_number = "${element(var.public_outbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.public_outbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.public_outbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.public_outbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.public_outbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.public_outbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.public_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.public_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.public_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.public_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.public_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.public_outbound_acl_rules, count.index * 7 + 5)}"
 }
 
 #######################
@@ -346,31 +346,31 @@ resource "aws_network_acl" "private" {
 }
 
 resource "aws_network_acl_rule" "private_inbound" {
-  count = "${var.create_vpc ? length(var.private_inbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.private_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
   egress      = false
-  rule_number = "${element(var.private_inbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.private_inbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.private_inbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.private_inbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.private_inbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.private_inbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.private_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.private_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.private_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.private_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.private_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.private_inbound_acl_rules, count.index * 7 + 5)}"
 }
 
 resource "aws_network_acl_rule" "private_outbound" {
-  count = "${var.create_vpc ? length(var.private_outbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.private_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.private.id}"
 
   egress      = true
-  rule_number = "${element(var.private_outbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.private_outbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.private_outbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.private_outbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.private_outbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.private_outbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.private_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.private_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.private_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.private_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.private_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.private_outbound_acl_rules, count.index * 7 + 5)}"
 }
 
 ########################
@@ -386,31 +386,31 @@ resource "aws_network_acl" "intra" {
 }
 
 resource "aws_network_acl_rule" "intra_inbound" {
-  count = "${var.create_vpc ? length(var.intra_inbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.intra_inbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
   egress      = false
-  rule_number = "${element(var.intra_inbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.intra_inbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.intra_inbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.intra_inbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.intra_inbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.intra_inbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.intra_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.intra_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.intra_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.intra_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.intra_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.intra_inbound_acl_rules, count.index * 7 + 5)}"
 }
 
 resource "aws_network_acl_rule" "intra_outbound" {
-  count = "${var.create_vpc ? length(var.intra_outbound_acls) / 7 : 0}"
+  count = "${var.create_vpc ? length(var.intra_outbound_acl_rules) / 7 : 0}"
 
   network_acl_id = "${aws_network_acl.intra.id}"
 
   egress      = true
-  rule_number = "${element(var.intra_outbound_acls, count.index * 7 + 0)}"
-  rule_action = "${element(var.intra_outbound_acls, count.index * 7 + 1)}"
-  from_port   = "${element(var.intra_outbound_acls, count.index * 7 + 2)}"
-  to_port     = "${element(var.intra_outbound_acls, count.index * 7 + 3)}"
-  protocol    = "${element(var.intra_outbound_acls, count.index * 7 + 4)}"
-  cidr_block  = "${element(var.intra_outbound_acls, count.index * 7 + 5)}"
+  rule_number = "${element(var.intra_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.intra_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.intra_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.intra_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.intra_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.intra_outbound_acl_rules, count.index * 7 + 5)}"
 }
 
 ##############

--- a/main.tf
+++ b/main.tf
@@ -287,7 +287,6 @@ resource "aws_subnet" "intra" {
 #######################
 # Default Network ACLs
 #######################
-
 resource "aws_default_network_acl" "default" {
   count = "${var.create_vpc ? 1 : 0}"
 
@@ -297,7 +296,6 @@ resource "aws_default_network_acl" "default" {
 ########################
 # Public Network ACLs
 ########################
-
 resource "aws_network_acl" "public" {
   count = "${var.create_vpc ? 1 : 0}"
 
@@ -338,7 +336,6 @@ resource "aws_network_acl_rule" "public_outbound" {
 #######################
 # Private Network ACLs
 #######################
-
 resource "aws_network_acl" "private" {
   count = "${var.create_vpc ? 1 : 0}"
 
@@ -379,7 +376,6 @@ resource "aws_network_acl_rule" "private_outbound" {
 ########################
 # Intra Network ACLs
 ########################
-
 resource "aws_network_acl" "intra" {
   count = "${var.create_vpc ? 1 : 0}"
 

--- a/main.tf
+++ b/main.tf
@@ -284,6 +284,129 @@ resource "aws_subnet" "intra" {
   tags = "${merge(map("Name", format("%s-${var.intra_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
 }
 
+########################
+# Public Network ACLs
+########################
+
+resource "aws_network_acl" "public" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.public.*.id}"]
+
+  tags = "${merge(var.tags, var.public_acl_tags, map("Name", format("%s-public", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "public_inbound" {
+  count = "${var.create_vpc ? length(var.public_inbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.public.id}"
+
+  egress      = false
+  rule_number = "${element(var.public_inbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.public_inbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.public_inbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.public_inbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.public_inbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.public_inbound_acls, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "public_outbound" {
+  count = "${var.create_vpc ? length(var.public_outbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.public.id}"
+
+  egress      = true
+  rule_number = "${element(var.public_outbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.public_outbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.public_outbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.public_outbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.public_outbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.public_outbound_acls, count.index * 7 + 5)}"
+}
+
+#######################
+# Private Network ACLs
+#######################
+
+resource "aws_network_acl" "private" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.private.*.id}"]
+
+  tags = "${merge(var.tags, var.private_acl_tags, map("Name", format("%s-private", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "private_inbound" {
+  count = "${var.create_vpc ? length(var.private_inbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.private.id}"
+
+  egress      = false
+  rule_number = "${element(var.private_inbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.private_inbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.private_inbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.private_inbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.private_inbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.private_inbound_acls, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "private_outbound" {
+  count = "${var.create_vpc ? length(var.private_outbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.private.id}"
+
+  egress      = true
+  rule_number = "${element(var.private_outbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.private_outbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.private_outbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.private_outbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.private_outbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.private_outbound_acls, count.index * 7 + 5)}"
+}
+
+########################
+# Intra Network ACLs
+########################
+
+resource "aws_network_acl" "intra" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.intra.*.id}"]
+
+  tags = "${merge(var.tags, var.intra_acl_tags, map("Name", format("%s-intra", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "intra_inbound" {
+  count = "${var.create_vpc ? length(var.intra_inbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.intra.id}"
+
+  egress      = false
+  rule_number = "${element(var.intra_inbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.intra_inbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.intra_inbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.intra_inbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.intra_inbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.intra_inbound_acls, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "intra_outbound" {
+  count = "${var.create_vpc ? length(var.intra_outbound_acls) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.intra.id}"
+
+  egress      = true
+  rule_number = "${element(var.intra_outbound_acls, count.index * 7 + 0)}"
+  rule_action = "${element(var.intra_outbound_acls, count.index * 7 + 1)}"
+  from_port   = "${element(var.intra_outbound_acls, count.index * 7 + 2)}"
+  to_port     = "${element(var.intra_outbound_acls, count.index * 7 + 3)}"
+  protocol    = "${element(var.intra_outbound_acls, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.intra_outbound_acls, count.index * 7 + 5)}"
+}
+
 ##############
 # NAT Gateway
 ##############

--- a/main.tf
+++ b/main.tf
@@ -413,6 +413,126 @@ resource "aws_network_acl_rule" "intra_outbound" {
   cidr_block  = "${element(var.intra_outbound_acl_rules, count.index * 7 + 5)}"
 }
 
+########################
+# Database Network ACLs
+########################
+resource "aws_network_acl" "database" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.database.*.id}"]
+
+  tags = "${merge(var.tags, var.database_acl_tags, map("Name", format("%s-database", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "database_inbound" {
+  count = "${var.create_vpc ? length(var.database_inbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.database.id}"
+
+  egress      = false
+  rule_number = "${element(var.database_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.database_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.database_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.database_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.database_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.database_inbound_acl_rules, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "database_outbound" {
+  count = "${var.create_vpc ? length(var.database_outbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.database.id}"
+
+  egress      = true
+  rule_number = "${element(var.database_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.database_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.database_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.database_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.database_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.database_outbound_acl_rules, count.index * 7 + 5)}"
+}
+
+########################
+# Redshift Network ACLs
+########################
+resource "aws_network_acl" "redshift" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.redshift.*.id}"]
+
+  tags = "${merge(var.tags, var.redshift_acl_tags, map("Name", format("%s-redshift", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "redshift_inbound" {
+  count = "${var.create_vpc ? length(var.redshift_inbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.redshift.id}"
+
+  egress      = false
+  rule_number = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.redshift_inbound_acl_rules, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "redshift_outbound" {
+  count = "${var.create_vpc ? length(var.redshift_outbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.redshift.id}"
+
+  egress      = true
+  rule_number = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.redshift_outbound_acl_rules, count.index * 7 + 5)}"
+}
+
+###########################
+# Elasticache Network ACLs
+###########################
+resource "aws_network_acl" "elasticache" {
+  count = "${var.create_vpc ? 1 : 0}"
+
+  vpc_id     = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  subnet_ids = ["${aws_subnet.elasticache.*.id}"]
+
+  tags = "${merge(var.tags, var.elasticache_acl_tags, map("Name", format("%s-elasticache", var.name)))}"
+}
+
+resource "aws_network_acl_rule" "elasticache_inbound" {
+  count = "${var.create_vpc ? length(var.elasticache_inbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.elasticache.id}"
+
+  egress      = false
+  rule_number = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.elasticache_inbound_acl_rules, count.index * 7 + 5)}"
+}
+
+resource "aws_network_acl_rule" "elasticache_outbound" {
+  count = "${var.create_vpc ? length(var.elasticache_outbound_acl_rules) / 7 : 0}"
+
+  network_acl_id = "${aws_network_acl.elasticache.id}"
+
+  egress      = true
+  rule_number = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 0)}"
+  rule_action = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 1)}"
+  from_port   = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 2)}"
+  to_port     = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 3)}"
+  protocol    = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 4)}"
+  cidr_block  = "${element(var.elasticache_outbound_acl_rules, count.index * 7 + 5)}"
+}
+
 ##############
 # NAT Gateway
 ##############

--- a/variables.tf
+++ b/variables.tf
@@ -545,3 +545,33 @@ variable "intra_outbound_acl_rules" {
   description = "Intra subnets outbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
 }
+
+variable "database_inbound_acl_rules" {
+  description = "database subnets inbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "database_outbound_acl_rules" {
+  description = "database subnets outbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}
+
+variable "redshift_inbound_acl_rules" {
+  description = "redshift subnets inbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "redshift_outbound_acl_rules" {
+  description = "redshift subnets outbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}
+
+variable "elasticache_inbound_acl_rules" {
+  description = "elasticache subnets inbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "elasticache_outbound_acl_rules" {
+  description = "elasticache subnets outbound network ACL rules"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -533,60 +533,180 @@ variable "default_vpc_tags" {
 
 variable "public_inbound_acl_rules" {
   description = "Public subnets inbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "public_outbound_acl_rules" {
   description = "Public subnets outbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }
 
 variable "private_inbound_acl_rules" {
   description = "Private subnets inbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "private_outbound_acl_rules" {
   description = "Private subnets outbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }
 
 variable "intra_inbound_acl_rules" {
   description = "Intra subnets inbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "intra_outbound_acl_rules" {
   description = "Intra subnets outbound network ACLs"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }
 
 variable "database_inbound_acl_rules" {
   description = "database subnets inbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "database_outbound_acl_rules" {
   description = "database subnets outbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }
 
 variable "redshift_inbound_acl_rules" {
   description = "redshift subnets inbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "redshift_outbound_acl_rules" {
   description = "redshift subnets outbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }
 
 variable "elasticache_inbound_acl_rules" {
   description = "elasticache subnets inbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL inbound"
+    }
+  ]
 }
 
 variable "elasticache_outbound_acl_rules" {
   description = "elasticache subnets outbound network ACL rules"
-  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+  default     = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+      description = "Allow ALL outbound"
+    }
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -418,6 +418,21 @@ variable "intra_subnet_tags" {
   default     = {}
 }
 
+variable "public_acl_tags" {
+  description = "Additional tags for the public subnets network ACLs"
+  default     = {}
+}
+
+variable "private_acl_tags" {
+  description = "Additional tags for the private subnets network ACLs"
+  default     = {}
+}
+
+variable "intra_acl_tags" {
+  description = "Additional tags for the intra subnets network ACLs"
+  default     = {}
+}
+
 variable "dhcp_options_tags" {
   description = "Additional tags for the DHCP option set"
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -419,32 +419,32 @@ variable "intra_subnet_tags" {
 }
 
 variable "public_acl_tags" {
-  description = "Additional tags for the public subnets network ACLs"
+  description = "Additional tags for the public subnets network ACL"
   default     = {}
 }
 
 variable "private_acl_tags" {
-  description = "Additional tags for the private subnets network ACLs"
+  description = "Additional tags for the private subnets network ACL"
   default     = {}
 }
 
 variable "intra_acl_tags" {
-  description = "Additional tags for the intra subnets network ACLs"
+  description = "Additional tags for the intra subnets network ACL"
   default     = {}
 }
 
 variable "database_acl_tags" {
-  description = "Additional tags for the database subnets network ACLs"
+  description = "Additional tags for the database subnets network ACL"
   default     = {}
 }
 
 variable "redshift_acl_tags" {
-  description = "Additional tags for the redshift subnets network ACLs"
+  description = "Additional tags for the redshift subnets network ACL"
   default     = {}
 }
 
 variable "elasticache_acl_tags" {
-  description = "Additional tags for the elasticache subnets network ACLs"
+  description = "Additional tags for the elasticache subnets network ACL"
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -500,3 +500,33 @@ variable "default_vpc_tags" {
   description = "Additional tags for the Default VPC"
   default     = {}
 }
+
+variable "public_inbound_acls" {
+  description = "Public subnets inbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "public_outbound_acls" {
+  description = "Public subnets outbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}
+
+variable "private_inbound_acls" {
+  description = "Private subnets inbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "private_outbound_acls" {
+  description = "Private subnets outbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}
+
+variable "intra_inbound_acls" {
+  description = "Intra subnets inbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
+}
+
+variable "intra_outbound_acls" {
+  description = "Intra subnets outbound network ACLs"
+  default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -516,32 +516,32 @@ variable "default_vpc_tags" {
   default     = {}
 }
 
-variable "public_inbound_acls" {
+variable "public_inbound_acl_rules" {
   description = "Public subnets inbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
 }
 
-variable "public_outbound_acls" {
+variable "public_outbound_acl_rules" {
   description = "Public subnets outbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
 }
 
-variable "private_inbound_acls" {
+variable "private_inbound_acl_rules" {
   description = "Private subnets inbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
 }
 
-variable "private_outbound_acls" {
+variable "private_outbound_acl_rules" {
   description = "Private subnets outbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
 }
 
-variable "intra_inbound_acls" {
+variable "intra_inbound_acl_rules" {
   description = "Intra subnets inbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL inbound"]
 }
 
-variable "intra_outbound_acls" {
+variable "intra_outbound_acl_rules" {
   description = "Intra subnets outbound network ACLs"
   default     = ["100", "allow", 0, 0, "-1", "0.0.0.0/0", "Allow ALL outbound"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -433,6 +433,21 @@ variable "intra_acl_tags" {
   default     = {}
 }
 
+variable "database_acl_tags" {
+  description = "Additional tags for the database subnets network ACLs"
+  default     = {}
+}
+
+variable "redshift_acl_tags" {
+  description = "Additional tags for the redshift subnets network ACLs"
+  default     = {}
+}
+
+variable "elasticache_acl_tags" {
+  description = "Additional tags for the elasticache subnets network ACLs"
+  default     = {}
+}
+
 variable "dhcp_options_tags" {
   description = "Additional tags for the DHCP option set"
   default     = {}


### PR DESCRIPTION
Network ACLs provide a layer of security to VPCs with stateless rules for inbound and outbound network connections. This PR adds support for configuring network ACLs for public, private, and intra subnets using a series of variables.

Here is an example that implements some of the rules from [Recommended Rules for Scenario 2](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-recommended-nacl-rules.html#nacl-rules-scenario-2).

```hcl
module "vpc" {
  source = "terraform-aws-modules/vpc/aws"
  version = "1.x.x"

  name = "acl-example"
  cidr = "10.64.0.0/16"

  azs              = ["us-east-2a", "us-east-2b", "us-east-2c"]
  private_subnets  = ["10.64.0.0/20", "10.64.16.0/20", "10.64.32.0/20"]
  public_subnets   = ["10.64.192.0/22", "10.64.196.0/22", "10.64.200.0/22"]

  public_inbound_acls = [
    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows inbound HTTP traffic from any IPv4 address",
    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows inbound HTTPS traffic from any IPv4 address",
    "120", "allow", 22,    22,    "tcp", "198.51.100.0/24", "Allows inbound SSH traffic from your home network",
    "130", "allow", 3389,  3389,  "tcp", "198.51.100.0/24", "Allows inbound RDP traffic from your home network",
    "140", "allow", 1024,  65535, "tcp", "0.0.0.0/0",       "Allows inbound return traffic from hosts"
  ]

  public_outbound_acls = [
    "100", "allow", 80,    80,    "tcp", "0.0.0.0/0",       "Allows outbound HTTP traffic from the subnet to the Internet",
    "110", "allow", 443,   443,   "tcp", "0.0.0.0/0",       "Allows outbound HTTPS traffic from the subnet to the Internet",
    "120", "allow", 1433,  1433,  "tcp", "10.64.0.0/17",    "Allows outbound MS SQL access to database servers in the private subnet",
    "140", "allow", 32768, 65535, "tcp", "0.0.0.0/0",       "Allows outbound responses to clients on the Internet",
    "150", "allow", 22,    22,    "tcp", "10.64.0.0/17",    "Allows outbound SSH access to instances in your private subnet"
  ]
}
```

[aws_network_acl](https://www.terraform.io/docs/providers/aws/r/network_acl.html) and [aws_network_acl_rule](https://www.terraform.io/docs/providers/aws/r/network_acl_rule.html) resources are created for the ACL rules. An [aws_default_network_acl](https://www.terraform.io/docs/providers/aws/r/default_network_acl.html) resource is also created to adopt the default network ACL in the VPC.

Closes #173.