### PR TITLE
Create input "create_database_internet_gateway_route"

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | azs | A list of availability zones in the region | string | `<list>` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
 | create_database_subnet_group | Controls if database subnet group should be created | string | `true` | no |
+| create_database_internet_gateway_route | Controls if an internet gateway route for public database access should be created | string | `false` | no |
 | create_database_subnet_route_table | Controls if separate route table for database should be created | string | `false` | no |
 | create_elasticache_subnet_route_table | Controls if separate route table for elasticache should be created | string | `false` | no |
 | create_redshift_subnet_route_table | Controls if separate route table for redshift should be created | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,14 @@ resource "aws_route" "public_internet_gateway" {
   }
 }
 
+resource "aws_route" "database_internet_gateway" {
+  count = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 ? 1 : 0}"
+
+  route_table_id         = "${aws_route_table.database.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.this.id}"
+}
+
 #################
 # Private routes
 # There are so many routing tables as the largest amount of subnets of each type (really?)

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "database_internet_gateway" {
-  count = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 ? 1 : 0}"
+  count = "${aws_internet_gateway.this.count > 0 && var.create_database_subnet_route_table && length(var.database_subnets) > 0  ? 1 : 0}"
 
   route_table_id         = "${aws_route_table.database.id}"
   destination_cidr_block = "0.0.0.0/0"

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,11 @@ variable "create_database_subnet_group" {
   default     = true
 }
 
+variable "create_database_internet_gateway_route" {
+  description = "Controls if an internet gateway route for public database access should be created"
+  default     = false
+}
+
 variable "azs" {
   description = "A list of availability zones in the region"
   default     = []


### PR DESCRIPTION
This will allow easy creation of publicly accessible RDS endpoints instead of having to add a separate `aws_route` resource next to/outside of the `module "vpc { .. }"` block.

Default value is false for full backward compatibility.