### PR TITLE
Fix for the error: module.vpc.aws_redshift_subnet_group.redshift: onl…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_subnet" "redshift" {
 resource "aws_redshift_subnet_group" "redshift" {
   count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? 1 : 0}"
 
-  name        = "${var.name}"
+  name        = "${lower(var.name)}"
   description = "Redshift subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.redshift.*.id}"]
 


### PR DESCRIPTION
…y lowercase alphanumeric characters and hyphens allowed in name

Read more: https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/180