### PR TITLE
adding option to create a route to nat gateway in database subnets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,11 @@ variable "create_database_internet_gateway_route" {
   default     = false
 }
 
+variable "create_database_nat_gateway_route" {
+  description = "Controls if a nat gateway route should be created to give internet access to the database subnets"
+  default     = false
+}
+
 variable "azs" {
   description = "A list of availability zones in the region"
   default     = []


### PR DESCRIPTION
Similarly to `create_database_internet_gateway_route`, this adds the `create_database_nat_gateway_route` parameter to create routes in database subnets to the unique/per-AZ/per-subnet NAT Gateways.