### PR TITLE
Extend endpoints for AWS Systems Manager use

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,87 +179,95 @@ Terraform version 0.10.3 or newer is required for this module to work.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | string | `"64512"` | no |
-| assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `"false"` | no |
+| amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | string | `64512` | no |
+| assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `false` | no |
 | azs | A list of availability zones in the region | list | `[]` | no |
-| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `"0.0.0.0/0"` | no |
-| create\_database\_internet\_gateway\_route | Controls if an internet gateway route for public database access should be created | string | `"false"` | no |
-| create\_database\_nat\_gateway\_route | Controls if a nat gateway route should be created to give internet access to the database subnets | string | `"false"` | no |
-| create\_database\_subnet\_group | Controls if database subnet group should be created | string | `"true"` | no |
-| create\_database\_subnet\_route\_table | Controls if separate route table for database should be created | string | `"false"` | no |
-| create\_elasticache\_subnet\_group | Controls if elasticache subnet group should be created | string | `"true"` | no |
-| create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `"false"` | no |
-| create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `"true"` | no |
-| create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `"false"` | no |
-| create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `"true"` | no |
+| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
+| create\_database\_internet\_gateway\_route | Controls if an internet gateway route for public database access should be created | string | `false` | no |
+| create\_database\_nat\_gateway\_route | Controls if a nat gateway route should be created to give internet access to the database subnets | string | `false` | no |
+| create\_database\_subnet\_group | Controls if database subnet group should be created | string | `true` | no |
+| create\_database\_subnet\_route\_table | Controls if separate route table for database should be created | string | `false` | no |
+| create\_elasticache\_subnet\_group | Controls if elasticache subnet group should be created | string | `true` | no |
+| create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `false` | no |
+| create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `true` | no |
+| create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `false` | no |
+| create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `true` | no |
 | database\_route\_table\_tags | Additional tags for the database route tables | map | `{}` | no |
 | database\_subnet\_group\_tags | Additional tags for the database subnet group | map | `{}` | no |
-| database\_subnet\_suffix | Suffix to append to database subnets name | string | `"db"` | no |
+| database\_subnet\_suffix | Suffix to append to database subnets name | string | `db` | no |
 | database\_subnet\_tags | Additional tags for the database subnets | map | `{}` | no |
 | database\_subnets | A list of database subnets | list | `[]` | no |
-| default\_vpc\_enable\_classiclink | Should be true to enable ClassicLink in the Default VPC | string | `"false"` | no |
-| default\_vpc\_enable\_dns\_hostnames | Should be true to enable DNS hostnames in the Default VPC | string | `"false"` | no |
-| default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `"true"` | no |
-| default\_vpc\_name | Name to be used on the Default VPC | string | `""` | no |
+| default\_vpc\_enable\_classiclink | Should be true to enable ClassicLink in the Default VPC | string | `false` | no |
+| default\_vpc\_enable\_dns\_hostnames | Should be true to enable DNS hostnames in the Default VPC | string | `false` | no |
+| default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `true` | no |
+| default\_vpc\_name | Name to be used on the Default VPC | string | `` | no |
 | default\_vpc\_tags | Additional tags for the Default VPC | map | `{}` | no |
-| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set | string | `""` | no |
+| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set | string | `` | no |
 | dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided | list | `[ "AmazonProvidedDNS" ]` | no |
 | dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set | list | `[]` | no |
-| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set | string | `""` | no |
+| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set | string | `` | no |
 | dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set | list | `[]` | no |
 | dhcp\_options\_tags | Additional tags for the DHCP option set | map | `{}` | no |
-| ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `"false"` | no |
+| ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `false` | no |
 | ec2\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 endpoint | list | `[]` | no |
 | ec2\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
+| ec2messages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint | string | `false` | no |
+| ec2messages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2MESSAGES endpoint | list | `[]` | no |
+| ec2messages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2MESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
 | elasticache\_route\_table\_tags | Additional tags for the elasticache route tables | map | `{}` | no |
-| elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | string | `"elasticache"` | no |
+| elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | string | `elasticache` | no |
 | elasticache\_subnet\_tags | Additional tags for the elasticache subnets | map | `{}` | no |
 | elasticache\_subnets | A list of elasticache subnets | list | `[]` | no |
-| enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | string | `"false"` | no |
-| enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | string | `"false"` | no |
-| enable\_dns\_support | Should be true to enable DNS support in the VPC | string | `"true"` | no |
-| enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | string | `"false"` | no |
-| enable\_ec2\_endpoint | Should be true if you want to provision an EC2 endpoint to the VPC | string | `"false"` | no |
-| enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | string | `"false"` | no |
-| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | string | `"false"` | no |
-| enable\_ssm\_endpoint | Should be true if you want to provision an SSM endpoint to the VPC | string | `"false"` | no |
-| enable\_vpn\_gateway | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | string | `"false"` | no |
+| enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | string | `false` | no |
+| enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | string | `false` | no |
+| enable\_dns\_support | Should be true to enable DNS support in the VPC | string | `true` | no |
+| enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | string | `false` | no |
+| enable\_ec2\_endpoint | Should be true if you want to provision an EC2 endpoint to the VPC | string | `false` | no |
+| enable\_ec2messages\_endpoint | Should be true if you want to provision an EC2MESSAGES endpoint to the VPC | string | `false` | no |
+| enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | string | `false` | no |
+| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | string | `false` | no |
+| enable\_ssm\_endpoint | Should be true if you want to provision an SSM endpoint to the VPC | string | `false` | no |
+| enable\_ssmmessages\_endpoint | Should be true if you want to provision a SSMMESSAGES endpoint to the VPC | string | `false` | no |
+| enable\_vpn\_gateway | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | string | `false` | no |
 | external\_nat\_ip\_ids | List of EIP IDs to be assigned to the NAT Gateways (used in combination with reuse_nat_ips) | list | `[]` | no |
 | igw\_tags | Additional tags for the internet gateway | map | `{}` | no |
-| instance\_tenancy | A tenancy option for instances launched into the VPC | string | `"default"` | no |
+| instance\_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | intra\_route\_table\_tags | Additional tags for the intra route tables | map | `{}` | no |
 | intra\_subnet\_tags | Additional tags for the intra subnets | map | `{}` | no |
 | intra\_subnets | A list of intra subnets | list | `[]` | no |
-| manage\_default\_vpc | Should be true to adopt and manage Default VPC | string | `"false"` | no |
-| map\_public\_ip\_on\_launch | Should be false if you do not want to auto-assign public IP on launch | string | `"true"` | no |
-| name | Name to be used on all the resources as identifier | string | `""` | no |
+| manage\_default\_vpc | Should be true to adopt and manage Default VPC | string | `false` | no |
+| map\_public\_ip\_on\_launch | Should be false if you do not want to auto-assign public IP on launch | string | `true` | no |
+| name | Name to be used on all the resources as identifier | string | `` | no |
 | nat\_eip\_tags | Additional tags for the NAT EIP | map | `{}` | no |
 | nat\_gateway\_tags | Additional tags for the NAT gateways | map | `{}` | no |
-| one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | string | `"false"` | no |
+| one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | string | `false` | no |
 | private\_route\_table\_tags | Additional tags for the private route tables | map | `{}` | no |
-| private\_subnet\_suffix | Suffix to append to private subnets name | string | `"private"` | no |
+| private\_subnet\_suffix | Suffix to append to private subnets name | string | `private` | no |
 | private\_subnet\_tags | Additional tags for the private subnets | map | `{}` | no |
 | private\_subnets | A list of private subnets inside the VPC | list | `[]` | no |
-| propagate\_private\_route\_tables\_vgw | Should be true if you want route table propagation | string | `"false"` | no |
-| propagate\_public\_route\_tables\_vgw | Should be true if you want route table propagation | string | `"false"` | no |
+| propagate\_private\_route\_tables\_vgw | Should be true if you want route table propagation | string | `false` | no |
+| propagate\_public\_route\_tables\_vgw | Should be true if you want route table propagation | string | `false` | no |
 | public\_route\_table\_tags | Additional tags for the public route tables | map | `{}` | no |
-| public\_subnet\_suffix | Suffix to append to public subnets name | string | `"public"` | no |
+| public\_subnet\_suffix | Suffix to append to public subnets name | string | `public` | no |
 | public\_subnet\_tags | Additional tags for the public subnets | map | `{}` | no |
 | public\_subnets | A list of public subnets inside the VPC | list | `[]` | no |
 | redshift\_route\_table\_tags | Additional tags for the redshift route tables | map | `{}` | no |
 | redshift\_subnet\_group\_tags | Additional tags for the redshift subnet group | map | `{}` | no |
-| redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `"redshift"` | no |
+| redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `redshift` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | map | `{}` | no |
 | redshift\_subnets | A list of redshift subnets | list | `[]` | no |
-| reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `"false"` | no |
+| reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `false` | no |
 | secondary\_cidr\_blocks | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | list | `[]` | no |
-| single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `"false"` | no |
-| ssm\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSM endpoint | string | `"false"` | no |
+| single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `false` | no |
+| ssm\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSM endpoint | string | `false` | no |
 | ssm\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SSM endpoint | list | `[]` | no |
 | ssm\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SSM endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
+| ssmmessages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint | string | `false` | no |
+| ssmmessages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SSMMESSAGES endpoint | list | `[]` | no |
+| ssmmessages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SSMMESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
 | tags | A map of tags to add to all resources | map | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | map | `{}` | no |
-| vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | string | `""` | no |
+| vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | string | `` | no |
 | vpn\_gateway\_tags | Additional tags for the VPN gateway | map | `{}` | no |
 
 ## Outputs
@@ -314,11 +322,17 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | vpc\_endpoint\_ec2\_dns\_entry | The DNS entries for the VPC Endpoint for EC2. |
 | vpc\_endpoint\_ec2\_id | The ID of VPC endpoint for EC2 |
 | vpc\_endpoint\_ec2\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for EC2 |
+| vpc\_endpoint\_ec2messages\_dns\_entry | The DNS entries for the VPC Endpoint for EC2MESSAGES. |
+| vpc\_endpoint\_ec2messages\_id | The ID of VPC endpoint for EC2MESSAGES |
+| vpc\_endpoint\_ec2messages\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for EC2MESSAGES |
 | vpc\_endpoint\_s3\_id | The ID of VPC endpoint for S3 |
 | vpc\_endpoint\_s3\_pl\_id | The prefix list for the S3 VPC endpoint. |
 | vpc\_endpoint\_ssm\_dns\_entry | The DNS entries for the VPC Endpoint for SSM. |
 | vpc\_endpoint\_ssm\_id | The ID of VPC endpoint for SSM |
 | vpc\_endpoint\_ssm\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SSM. |
+| vpc\_endpoint\_ssmmessages\_dns\_entry | The DNS entries for the VPC Endpoint for SSMMESSAGES. |
+| vpc\_endpoint\_ssmmessages\_id | The ID of VPC endpoint for SSMMESSAGES |
+| vpc\_endpoint\_ssmmessages\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SSMMESSAGES. |
 | vpc\_id | The ID of the VPC |
 | vpc\_instance\_tenancy | Tenancy of instances spin up within VPC |
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |

--- a/README.md
+++ b/README.md
@@ -179,95 +179,95 @@ Terraform version 0.10.3 or newer is required for this module to work.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | string | `64512` | no |
-| assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `false` | no |
+| amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | string | `"64512"` | no |
+| assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | string | `"false"` | no |
 | azs | A list of availability zones in the region | list | `[]` | no |
-| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `0.0.0.0/0` | no |
-| create\_database\_internet\_gateway\_route | Controls if an internet gateway route for public database access should be created | string | `false` | no |
-| create\_database\_nat\_gateway\_route | Controls if a nat gateway route should be created to give internet access to the database subnets | string | `false` | no |
-| create\_database\_subnet\_group | Controls if database subnet group should be created | string | `true` | no |
-| create\_database\_subnet\_route\_table | Controls if separate route table for database should be created | string | `false` | no |
-| create\_elasticache\_subnet\_group | Controls if elasticache subnet group should be created | string | `true` | no |
-| create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `false` | no |
-| create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `true` | no |
-| create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `false` | no |
-| create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `true` | no |
+| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `"0.0.0.0/0"` | no |
+| create\_database\_internet\_gateway\_route | Controls if an internet gateway route for public database access should be created | string | `"false"` | no |
+| create\_database\_nat\_gateway\_route | Controls if a nat gateway route should be created to give internet access to the database subnets | string | `"false"` | no |
+| create\_database\_subnet\_group | Controls if database subnet group should be created | string | `"true"` | no |
+| create\_database\_subnet\_route\_table | Controls if separate route table for database should be created | string | `"false"` | no |
+| create\_elasticache\_subnet\_group | Controls if elasticache subnet group should be created | string | `"true"` | no |
+| create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `"false"` | no |
+| create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `"true"` | no |
+| create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `"false"` | no |
+| create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `"true"` | no |
 | database\_route\_table\_tags | Additional tags for the database route tables | map | `{}` | no |
 | database\_subnet\_group\_tags | Additional tags for the database subnet group | map | `{}` | no |
-| database\_subnet\_suffix | Suffix to append to database subnets name | string | `db` | no |
+| database\_subnet\_suffix | Suffix to append to database subnets name | string | `"db"` | no |
 | database\_subnet\_tags | Additional tags for the database subnets | map | `{}` | no |
 | database\_subnets | A list of database subnets | list | `[]` | no |
-| default\_vpc\_enable\_classiclink | Should be true to enable ClassicLink in the Default VPC | string | `false` | no |
-| default\_vpc\_enable\_dns\_hostnames | Should be true to enable DNS hostnames in the Default VPC | string | `false` | no |
-| default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `true` | no |
-| default\_vpc\_name | Name to be used on the Default VPC | string | `` | no |
+| default\_vpc\_enable\_classiclink | Should be true to enable ClassicLink in the Default VPC | string | `"false"` | no |
+| default\_vpc\_enable\_dns\_hostnames | Should be true to enable DNS hostnames in the Default VPC | string | `"false"` | no |
+| default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `"true"` | no |
+| default\_vpc\_name | Name to be used on the Default VPC | string | `""` | no |
 | default\_vpc\_tags | Additional tags for the Default VPC | map | `{}` | no |
-| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set | string | `` | no |
+| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set | string | `""` | no |
 | dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided | list | `[ "AmazonProvidedDNS" ]` | no |
 | dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set | list | `[]` | no |
-| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set | string | `` | no |
+| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set | string | `""` | no |
 | dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set | list | `[]` | no |
 | dhcp\_options\_tags | Additional tags for the DHCP option set | map | `{}` | no |
-| ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `false` | no |
+| ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `"false"` | no |
 | ec2\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 endpoint | list | `[]` | no |
 | ec2\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
-| ec2messages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint | string | `false` | no |
+| ec2messages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint | string | `"false"` | no |
 | ec2messages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2MESSAGES endpoint | list | `[]` | no |
 | ec2messages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2MESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
 | elasticache\_route\_table\_tags | Additional tags for the elasticache route tables | map | `{}` | no |
-| elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | string | `elasticache` | no |
+| elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | string | `"elasticache"` | no |
 | elasticache\_subnet\_tags | Additional tags for the elasticache subnets | map | `{}` | no |
 | elasticache\_subnets | A list of elasticache subnets | list | `[]` | no |
-| enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | string | `false` | no |
-| enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | string | `false` | no |
-| enable\_dns\_support | Should be true to enable DNS support in the VPC | string | `true` | no |
-| enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | string | `false` | no |
-| enable\_ec2\_endpoint | Should be true if you want to provision an EC2 endpoint to the VPC | string | `false` | no |
-| enable\_ec2messages\_endpoint | Should be true if you want to provision an EC2MESSAGES endpoint to the VPC | string | `false` | no |
-| enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | string | `false` | no |
-| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | string | `false` | no |
-| enable\_ssm\_endpoint | Should be true if you want to provision an SSM endpoint to the VPC | string | `false` | no |
-| enable\_ssmmessages\_endpoint | Should be true if you want to provision a SSMMESSAGES endpoint to the VPC | string | `false` | no |
-| enable\_vpn\_gateway | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | string | `false` | no |
+| enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | string | `"false"` | no |
+| enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | string | `"false"` | no |
+| enable\_dns\_support | Should be true to enable DNS support in the VPC | string | `"true"` | no |
+| enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | string | `"false"` | no |
+| enable\_ec2\_endpoint | Should be true if you want to provision an EC2 endpoint to the VPC | string | `"false"` | no |
+| enable\_ec2messages\_endpoint | Should be true if you want to provision an EC2MESSAGES endpoint to the VPC | string | `"false"` | no |
+| enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | string | `"false"` | no |
+| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | string | `"false"` | no |
+| enable\_ssm\_endpoint | Should be true if you want to provision an SSM endpoint to the VPC | string | `"false"` | no |
+| enable\_ssmmessages\_endpoint | Should be true if you want to provision a SSMMESSAGES endpoint to the VPC | string | `"false"` | no |
+| enable\_vpn\_gateway | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | string | `"false"` | no |
 | external\_nat\_ip\_ids | List of EIP IDs to be assigned to the NAT Gateways (used in combination with reuse_nat_ips) | list | `[]` | no |
 | igw\_tags | Additional tags for the internet gateway | map | `{}` | no |
-| instance\_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
+| instance\_tenancy | A tenancy option for instances launched into the VPC | string | `"default"` | no |
 | intra\_route\_table\_tags | Additional tags for the intra route tables | map | `{}` | no |
 | intra\_subnet\_tags | Additional tags for the intra subnets | map | `{}` | no |
 | intra\_subnets | A list of intra subnets | list | `[]` | no |
-| manage\_default\_vpc | Should be true to adopt and manage Default VPC | string | `false` | no |
-| map\_public\_ip\_on\_launch | Should be false if you do not want to auto-assign public IP on launch | string | `true` | no |
-| name | Name to be used on all the resources as identifier | string | `` | no |
+| manage\_default\_vpc | Should be true to adopt and manage Default VPC | string | `"false"` | no |
+| map\_public\_ip\_on\_launch | Should be false if you do not want to auto-assign public IP on launch | string | `"true"` | no |
+| name | Name to be used on all the resources as identifier | string | `""` | no |
 | nat\_eip\_tags | Additional tags for the NAT EIP | map | `{}` | no |
 | nat\_gateway\_tags | Additional tags for the NAT gateways | map | `{}` | no |
-| one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | string | `false` | no |
+| one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | string | `"false"` | no |
 | private\_route\_table\_tags | Additional tags for the private route tables | map | `{}` | no |
-| private\_subnet\_suffix | Suffix to append to private subnets name | string | `private` | no |
+| private\_subnet\_suffix | Suffix to append to private subnets name | string | `"private"` | no |
 | private\_subnet\_tags | Additional tags for the private subnets | map | `{}` | no |
 | private\_subnets | A list of private subnets inside the VPC | list | `[]` | no |
-| propagate\_private\_route\_tables\_vgw | Should be true if you want route table propagation | string | `false` | no |
-| propagate\_public\_route\_tables\_vgw | Should be true if you want route table propagation | string | `false` | no |
+| propagate\_private\_route\_tables\_vgw | Should be true if you want route table propagation | string | `"false"` | no |
+| propagate\_public\_route\_tables\_vgw | Should be true if you want route table propagation | string | `"false"` | no |
 | public\_route\_table\_tags | Additional tags for the public route tables | map | `{}` | no |
-| public\_subnet\_suffix | Suffix to append to public subnets name | string | `public` | no |
+| public\_subnet\_suffix | Suffix to append to public subnets name | string | `"public"` | no |
 | public\_subnet\_tags | Additional tags for the public subnets | map | `{}` | no |
 | public\_subnets | A list of public subnets inside the VPC | list | `[]` | no |
 | redshift\_route\_table\_tags | Additional tags for the redshift route tables | map | `{}` | no |
 | redshift\_subnet\_group\_tags | Additional tags for the redshift subnet group | map | `{}` | no |
-| redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `redshift` | no |
+| redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `"redshift"` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | map | `{}` | no |
 | redshift\_subnets | A list of redshift subnets | list | `[]` | no |
-| reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `false` | no |
+| reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `"false"` | no |
 | secondary\_cidr\_blocks | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | list | `[]` | no |
-| single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `false` | no |
-| ssm\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSM endpoint | string | `false` | no |
+| single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `"false"` | no |
+| ssm\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSM endpoint | string | `"false"` | no |
 | ssm\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SSM endpoint | list | `[]` | no |
 | ssm\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SSM endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
-| ssmmessages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint | string | `false` | no |
+| ssmmessages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint | string | `"false"` | no |
 | ssmmessages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SSMMESSAGES endpoint | list | `[]` | no |
 | ssmmessages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SSMMESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |
 | tags | A map of tags to add to all resources | map | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | map | `{}` | no |
-| vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | string | `` | no |
+| vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | string | `""` | no |
 | vpn\_gateway\_tags | Additional tags for the VPN gateway | map | `{}` | no |
 
 ## Outputs

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -43,16 +43,27 @@ module "vpc" {
   enable_dynamodb_endpoint = true
 
   # VPC endpoint for SSM
-  enable_ssm_endpoint              = true
-  ssm_endpoint_private_dns_enabled = true
-  ssm_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
+  enable_ssm_endpoint                      = true
+  ssm_endpoint_private_dns_enabled         = true
+  ssm_endpoint_security_group_ids          = ["${data.aws_security_group.default.id}"]
 
   //  ssm_endpoint_subnet_ids = ["..."]
 
+  # VPC endpoint for SSMMESSAGES
+  enable_ssmmessages_endpoint              = true
+  ssmmessages_endpoint_private_dns_enabled = true
+  ssmmessages_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
+
   # VPC Endpoint for EC2
-  enable_ec2_endpoint              = true
-  ec2_endpoint_private_dns_enabled = true
-  ec2_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
+  enable_ec2_endpoint                      = true
+  ec2_endpoint_private_dns_enabled         = true
+  ec2_endpoint_security_group_ids          = ["${data.aws_security_group.default.id}"]
+
+  # VPC Endpoint for EC2MESSAGES
+  enable_ec2messages_endpoint              = true
+  ec2messages_endpoint_private_dns_enabled = true
+  ec2messages_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
+
   tags = {
     Owner       = "user"
     Environment = "staging"

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -43,9 +43,9 @@ module "vpc" {
   enable_dynamodb_endpoint = true
 
   # VPC endpoint for SSM
-  enable_ssm_endpoint                      = true
-  ssm_endpoint_private_dns_enabled         = true
-  ssm_endpoint_security_group_ids          = ["${data.aws_security_group.default.id}"]
+  enable_ssm_endpoint              = true
+  ssm_endpoint_private_dns_enabled = true
+  ssm_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
 
   //  ssm_endpoint_subnet_ids = ["..."]
 
@@ -53,17 +53,14 @@ module "vpc" {
   enable_ssmmessages_endpoint              = true
   ssmmessages_endpoint_private_dns_enabled = true
   ssmmessages_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
-
   # VPC Endpoint for EC2
-  enable_ec2_endpoint                      = true
-  ec2_endpoint_private_dns_enabled         = true
-  ec2_endpoint_security_group_ids          = ["${data.aws_security_group.default.id}"]
-
+  enable_ec2_endpoint              = true
+  ec2_endpoint_private_dns_enabled = true
+  ec2_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
   # VPC Endpoint for EC2MESSAGES
   enable_ec2messages_endpoint              = true
   ec2messages_endpoint_private_dns_enabled = true
   ec2messages_endpoint_security_group_ids  = ["${data.aws_security_group.default.id}"]
-
   tags = {
     Owner       = "user"
     Environment = "staging"

--- a/examples/test_fixture/README.md
+++ b/examples/test_fixture/README.md
@@ -25,7 +25,7 @@ This will destroy any existing test resources, create the resources afresh, run 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| region |  | string | `"eu-west-1"` | no |
+| region | - | string | `eu-west-1` | no |
 
 ## Outputs
 

--- a/examples/test_fixture/README.md
+++ b/examples/test_fixture/README.md
@@ -25,7 +25,7 @@ This will destroy any existing test resources, create the resources afresh, run 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| region | - | string | `eu-west-1` | no |
+| region |  | string | `"eu-west-1"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -404,9 +404,9 @@ resource "aws_vpc_endpoint_route_table_association" "public_dynamodb" {
   route_table_id  = "${aws_route_table.public.id}"
 }
 
-######################
+#######################
 # VPC Endpoint for SSM
-######################
+#######################
 data "aws_vpc_endpoint_service" "ssm" {
   count = "${var.create_vpc && var.enable_ssm_endpoint ? 1 : 0}"
 
@@ -425,9 +425,30 @@ resource "aws_vpc_endpoint" "ssm" {
   private_dns_enabled = "${var.ssm_endpoint_private_dns_enabled}"
 }
 
-######################
+###############################
+# VPC Endpoint for SSMMESSAGES
+###############################
+data "aws_vpc_endpoint_service" "ssmmessages" {
+  count = "${var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0}"
+
+  service = "ssmmessages"
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  count = "${var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0}"
+
+  vpc_id            = "${local.vpc_id}"
+  service_name      = "${data.aws_vpc_endpoint_service.ssmmessages.service_name}"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = ["${var.ssmmessages_endpoint_security_group_ids}"]
+  subnet_ids          = ["${coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
+  private_dns_enabled = "${var.ssmmessages_endpoint_private_dns_enabled}"
+}
+
+#######################
 # VPC Endpoint for EC2
-######################
+#######################
 data "aws_vpc_endpoint_service" "ec2" {
   count = "${var.create_vpc && var.enable_ec2_endpoint ? 1 : 0}"
 
@@ -444,6 +465,27 @@ resource "aws_vpc_endpoint" "ec2" {
   security_group_ids  = ["${var.ec2_endpoint_security_group_ids}"]
   subnet_ids          = ["${coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
   private_dns_enabled = "${var.ec2_endpoint_private_dns_enabled}"
+}
+
+###############################
+# VPC Endpoint for EC2MESSAGES
+###############################
+data "aws_vpc_endpoint_service" "ec2messages" {
+  count = "${var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0}"
+
+  service = "ec2messages"
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  count = "${var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0}"
+
+  vpc_id            = "${local.vpc_id}"
+  service_name      = "${data.aws_vpc_endpoint_service.ec2messages.service_name}"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = ["${var.ec2messages_endpoint_security_group_ids}"]
+  subnet_ids          = ["${coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
+  private_dns_enabled = "${var.ec2messages_endpoint_private_dns_enabled}"
 }
 
 ##########################

--- a/outputs.tf
+++ b/outputs.tf
@@ -300,7 +300,7 @@ output "vpc_endpoint_ssmmessages_id" {
 }
 
 output "vpc_endpoint_ssmmessages_network_interface_ids" {
-  description = "One or more network interfaces for the VPC Endpoint for SSMMESSAGS."
+  description = "One or more network interfaces for the VPC Endpoint for SSMMESSAGES."
   value       = "${flatten(aws_vpc_endpoint.ssmmessages.*.network_interface_ids)}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -294,6 +294,21 @@ output "vpc_endpoint_ssm_dns_entry" {
   value       = "${flatten(aws_vpc_endpoint.ssm.*.dns_entry)}"
 }
 
+output "vpc_endpoint_ssmmessages_id" {
+  description = "The ID of VPC endpoint for SSMMESSAGES"
+  value       = "${element(concat(aws_vpc_endpoint.ssmmessages.*.id, list("")), 0)}"
+}
+
+output "vpc_endpoint_ssmmessages_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for SSMMESSAGS."
+  value       = "${flatten(aws_vpc_endpoint.ssmmessages.*.network_interface_ids)}"
+}
+
+output "vpc_endpoint_ssmmessages_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for SSMMESSAGES."
+  value       = "${flatten(aws_vpc_endpoint.ssmmessages.*.dns_entry)}"
+}
+
 output "vpc_endpoint_ec2_id" {
   description = "The ID of VPC endpoint for EC2"
   value       = "${element(concat(aws_vpc_endpoint.ec2.*.id, list("")), 0)}"
@@ -307,6 +322,21 @@ output "vpc_endpoint_ec2_network_interface_ids" {
 output "vpc_endpoint_ec2_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for EC2."
   value       = "${flatten(aws_vpc_endpoint.ec2.*.dns_entry)}"
+}
+
+output "vpc_endpoint_ec2messages_id" {
+  description = "The ID of VPC endpoint for EC2MESSAGES"
+  value       = "${element(concat(aws_vpc_endpoint.ec2messages.*.id, list("")), 0)}"
+}
+
+output "vpc_endpoint_ec2messages_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for EC2MESSAGES"
+  value       = "${flatten(aws_vpc_endpoint.ec2messages.*.network_interface_ids)}"
+}
+
+output "vpc_endpoint_ec2messages_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for EC2MESSAGES."
+  value       = "${flatten(aws_vpc_endpoint.ec2messages.*.dns_entry)}"
 }
 
 # Static values (arguments)

--- a/variables.tf
+++ b/variables.tf
@@ -198,6 +198,26 @@ variable "ssm_endpoint_private_dns_enabled" {
   default     = false
 }
 
+variable "enable_ssmmessages_endpoint" {
+  description = "Should be true if you want to provision a SSMMESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "ssmmessages_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for SSMMESSAGES endpoint"
+  default     = []
+}
+
+variable "ssmmessages_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for SSMMESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "ssmmessages_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint"
+  default     = false
+}
+
 variable "enable_ec2_endpoint" {
   description = "Should be true if you want to provision an EC2 endpoint to the VPC"
   default     = false
@@ -215,6 +235,26 @@ variable "ec2_endpoint_private_dns_enabled" {
 
 variable "ec2_endpoint_subnet_ids" {
   description = "The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "enable_ec2messages_endpoint" {
+  description = "Should be true if you want to provision an EC2MESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "ec2messages_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for EC2MESSAGES endpoint"
+  default     = []
+}
+
+variable "ec2messages_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint"
+  default     = false
+}
+
+variable "ec2messages_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for EC2MESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
   default     = []
 }
 


### PR DESCRIPTION
Extend endpoints so that AWS Systems Manager could be setup utilizing endpoints only.