### PR TITLE
Add support old db_subnet_group naming (before the move to the registry)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_subnet" "database" {
 resource "aws_db_subnet_group" "database" {
   count = "${var.create_vpc && length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0}"
 
-  name        = "${lower(var.name)}"
+  name        = "${var.create_database_subnet_group_with_old_naming ? format("%s-rds-subnet-group", var.name) : lower(var.name)}"
   description = "Database subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.database.*.id}"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,11 @@ variable "create_database_subnet_group" {
   default     = true
 }
 
+variable "create_database_subnet_group_with_old_naming" {
+  description = "Controls if database subnet group should be created with the old naming convention adding -rds-subnet-group to var.name"
+  default     = false
+}
+
 variable "create_elasticache_subnet_group" {
   description = "Controls if elasticache subnet group should be created"
   default     = true


### PR DESCRIPTION
Hi,

not sure if something like this is wanted, but I transitioned to this repo and I added this compatibility flag so the database security group naming stays the same.

All the best, Philipp