### PR TITLE
Adds ipv6 support with user-specified prefixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -315,6 +315,9 @@ resource "aws_subnet" "intra" {
   cidr_block        = "${var.intra_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
 
+  # TODO: Does not unset, need null support or the like see: Terraform 0.12
+  ipv6_cidr_block = "${var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, element(concat(var.intra_subnet_ipv6_prefixes, list("0")), count.index)) : ""}"
+  
   tags = "${merge(map("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_internet_gateway" "this" {
 }
 
 resource "aws_egress_only_internet_gateway" "this" {
-  count = "${var.enable_ipv6 && length(var.database_subnets) > 0 && length(var.private_subnets) > 0 ? 1 : 0}"
+  count = "${var.enable_ipv6 && length(var.database_subnets) + length(var.private_subnets) > 0 ? 1 : 0}"
 
   vpc_id = "${aws_vpc.this.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -33,18 +33,6 @@ resource "aws_vpc_ipv4_cidr_block_association" "this" {
   cidr_block = "${element(var.secondary_cidr_blocks, count.index)}"
 }
 
-resource "aws_security_group_rule" "ipv6-egress" {
-  # VPC default has egress out
-  count            = "${var.create_vpc && var.enable_ipv6 ? 1 : 0}"
-  type             = "egress"
-  from_port        = 0
-  to_port          = 0
-  protocol         = "-1"
-  ipv6_cidr_blocks = ["::/0"]
-
-  security_group_id = "${aws_vpc.this.*.default_security_group_id[count.index]}"
-}
-
 ###################
 # DHCP Options Set
 ###################

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_internet_gateway" "this" {
 }
 
 resource "aws_egress_only_internet_gateway" "this" {
-  count = "${var.enable_ipv6 ? 1 : 0}"
+  count = "${var.enable_ipv6 && length(var.database_subnets) > 0 && length(var.private_subnets) > 0 ? 1 : 0}"
 
   vpc_id = "${aws_vpc.this.id}"
 }
@@ -159,9 +159,9 @@ resource "aws_route" "database_nat_gateway" {
 }
 
 resource "aws_route" "database_ipv6_egress" {
-  count = "${var.enable_ipv6 ? length(var.azs) : 0}"
+  count = "${var.enable_ipv6 ? length(var.database_subnets) : 0}"
 
-  route_table_id              = "${element(aws_route_table.private.*.id, count.index)}"
+  route_table_id              = "${element(aws_route_table.database.*.id, count.index)}"
   destination_ipv6_cidr_block = "::/0"
   egress_only_gateway_id      = "${element(aws_egress_only_internet_gateway.this.*.id, 0)}"
 }
@@ -368,7 +368,7 @@ resource "aws_route" "private_nat_gateway" {
 }
 
 resource "aws_route" "private_ipv6_egress" {
-  count = "${var.enable_ipv6 ? length(var.azs) : 0}"
+  count = "${var.enable_ipv6 ? length(var.private_subnets) : 0}"
 
   route_table_id              = "${element(aws_route_table.private.*.id, count.index)}"
   destination_ipv6_cidr_block = "::/0"

--- a/main.tf
+++ b/main.tf
@@ -317,7 +317,7 @@ resource "aws_subnet" "intra" {
 
   # TODO: Does not unset, need null support or the like see: Terraform 0.12
   ipv6_cidr_block = "${var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, element(concat(var.intra_subnet_ipv6_prefixes, list("0")), count.index)) : ""}"
-  
+
   tags = "${merge(map("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,15 +48,15 @@ output "vpc_main_route_table_id" {
   value       = "${element(concat(aws_vpc.this.*.main_route_table_id, list("")), 0)}"
 }
 
-//output "vpc_ipv6_association_id" {
-//  description = "The association ID for the IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
-//}
-//
-//output "vpc_ipv6_cidr_block" {
-//  description = "The IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
-//}
+output "vpc_ipv6_association_id" {
+ description = "The association ID for the IPv6 CIDR block"
+ value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
+}
+
+output "vpc_ipv6_cidr_block" {
+ description = "The IPv6 CIDR block"
+ value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
+}
 
 output "vpc_secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks of the VPC"

--- a/outputs.tf
+++ b/outputs.tf
@@ -364,3 +364,8 @@ output "database_subnets_ipv6_cidr_blocks" {
   description = "List of ipv6 cidr_blocks of database subnets in an ipv6 enabled VPC"
   value       = ["${aws_subnet.database.*.ipv6_cidr_block}"]
 }
+
+output "intra_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of intra subnets in an ipv6 enabled VPC"
+  value       = ["${aws_subnet.intra.*.ipv6_cidr_block}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -344,3 +344,23 @@ output "azs" {
   description = "A list of availability zones specified as argument to this module"
   value       = "${var.azs}"
 }
+
+output "ipv6_egress_only_igw_id" {
+  description = "The ID of the egress only Internet Gateway"
+  value       = "${element(concat(aws_egress_only_internet_gateway.this.*.id, list("")), 0)}"
+}
+
+output "public_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of public subnets in an ipv6 enabled VPC"
+  value       = ["${aws_subnet.public.*.ipv6_cidr_block}"]
+}
+
+output "private_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of private subnets in an ipv6 enabled VPC"
+  value       = ["${aws_subnet.private.*.ipv6_cidr_block}"]
+}
+
+output "database_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of database subnets in an ipv6 enabled VPC"
+  value       = ["${aws_subnet.database.*.ipv6_cidr_block}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,34 @@ variable "assign_generated_ipv6_cidr_block" {
   default     = false
 }
 
+variable "enable_ipv6" {
+  description = "Assigns ipv6 subnets and routes"
+  default     = false
+}
+
+variable "private_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "public_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "database_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "assign_ipv6_address_on_creation" {
+  description = "Assign ipv6 address on subnet, must be disabled to change ipv6 cidrs. This is the ipv6 equivalent of map_public_ip_on_launch"
+  default     = false
+}
+
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "database_subnet_ipv6_prefixes" {
   type        = "list"
 }
 
+variable "intra_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
 variable "assign_ipv6_address_on_creation" {
   description = "Assign ipv6 address on subnet, must be disabled to change ipv6 cidrs. This is the ipv6 equivalent of map_public_ip_on_launch"
   default     = false


### PR DESCRIPTION
Based on work done in #21. There didn't seem to be much going on that pull request. I apologize if this is undesirable.

Adds support for what I think are all the necessary components.

- [x] vpc
- [x] routes
- [x] gateways (egress only for private & database, internet gateway for public)
- [x] prefix assignment
- [x] infra subnet
- [ ] special subnets (elasticache, redshift, etc)
- [x] default vpc security group to permit egress traffic
- [ ] Currently two flags (`enable_ipv6`, `assign_generated_ipv6_cidr_block`), but I don't think that's good. Since they both must be set, and it doesn't seem to make sense to enable one without the other.
- [ ] Destroying the VPC appears to be unclean, results in `* aws_route...._ipv6_egress.2: InvalidRoute.NotFound: no route with destination-cidr-block ::/0 in route table rtb-0be2b413b6e783fc7` error messages. Not sure why, ipv4 route entries clean up correctly. Bug in provider?

I took a slightly different approach particularly on the prefix assignments as I found changing the assignments can cause an [error](https://github.com/terraform-providers/terraform-provider-aws/issues/1519) so I didn't want to use any `+length()` or hard-coded subnet spacing.

Usage:

```
variable "vpc_netblocks" {
  # third octet ~ availability zone
  description = "Network subnet layout"

  default = {
    vpc                = ["10.1.0.0/16"]
    product-private    = ["10.1.12.0/24", "10.1.14.0/24", "10.1.16.0/24"]
    product-private-ipv6-prefixes = [12, 14, 16]
   }
}

module "vpc" {
  ...
  private_subnets = "${var.vpc_netblocks["product-private"]}"
  private_subnet_ipv6_prefixes  = "${var.vpc_netblocks["product-private-ipv6-prefixes"]}"
  assign_generated_ipv6_cidr_block = true
  assign_ipv6_address_on_creation = true
  enable_ipv6                      = true
}
```