### PR TITLE
Redshift public subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Sometimes it is handy to have public access to RDS instances (it is not recommen
 
 ## Public access to Redshift cluster
 
-Sometimes it is handy to have public access to Redshift clusters (for example if you need to access it by kinesis - VPC endpoint for kinesis is not yet supported by redshift) by specifying these arguments:
+Sometimes it is handy to have public access to Redshift clusters (for example if you need to access it by Kinesis - VPC endpoint for Kinesis is not yet supported by Redshift) by specifying these arguments:
 
 ```hcl
   create_redshift_public_subnet_group       = true

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ Sometimes it is handy to have public access to RDS instances (it is not recommen
   enable_dns_support   = true
 ```
 
+## Public access to Redshift cluster
+
+Sometimes it is handy to have public access to Redshift clusters (for example if you need to access it by kinesis - VPC endpoint for kinesis is not yet supported by redshift) by specifying these arguments:
+
+```hcl
+  create_redshift_public_subnet_group       = true
+  create_redshift_public_subnet_route_table = true  # <= Default it will be placed into public subnet route table
+```
+
 ## Terraform version
 
 Terraform version 0.10.3 or newer is required for this module to work.
@@ -193,6 +202,8 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `"false"` | no |
 | create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `"true"` | no |
 | create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `"false"` | no |
+| create\_redshift\_public\_subnet\_group | Controls if redshift public subnet group should be created | string | `"true"` | no |
+| create\_redshift\_public\_subnet\_route\_table | Controls if separate route table for public redshift should be created | string | `"false"` | no |
 | create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `"true"` | no |
 | database\_route\_table\_tags | Additional tags for the database route tables | map | `{}` | no |
 | database\_subnet\_group\_tags | Additional tags for the database subnet group | map | `{}` | no |
@@ -266,6 +277,11 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `"redshift"` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | map | `{}` | no |
 | redshift\_subnets | A list of redshift subnets | list | `[]` | no |
+| redshift\_public\_route\_table\_tags | Additional tags for the public redshift route tables | map | `{}` | no |
+| redshift\_public\_subnet\_group\_tags | Additional tags for the redshift public subnet group | map | `{}` | no |
+| redshift\_public\_subnet\_suffix | Suffix to append to redshift public subnets name | string | `"redshift_public"` | no |
+| redshift\_public\_subnet\_tags | Additional tags for the redshift public subnets | map | `{}` | no |
+| redshift\_public\_subnets | A list of redshift public subnets | list | `[]` | no |
 | reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `"false"` | no |
 | secondary\_cidr\_blocks | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | list | `[]` | no |
 | single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `"false"` | no |
@@ -323,6 +339,10 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | redshift\_subnet\_group | ID of redshift subnet group |
 | redshift\_subnets | List of IDs of redshift subnets |
 | redshift\_subnets\_cidr\_blocks | List of cidr_blocks of redshift subnets |
+| redshift\_public\_route\_table\_ids | List of IDs of redshift public route tables |
+| redshift\_public\_subnet\_group | ID of redshift public subnet group |
+| redshift\_public\_subnets | List of IDs of redshift public subnets |
+| redshift\_public\_subnets\_cidr\_blocks | List of cidr_blocks of redshift public subnets |
 | vgw\_id | The ID of the VPN Gateway |
 | vpc\_cidr\_block | The CIDR block of the VPC |
 | vpc\_enable\_dns\_hostnames | Whether or not the VPC has DNS hostname support |

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ Sometimes it is handy to have public access to RDS instances (it is not recommen
 Sometimes it is handy to have public access to Redshift clusters (for example if you need to access it by Kinesis - VPC endpoint for Kinesis is not yet supported by Redshift) by specifying these arguments:
 
 ```hcl
-  create_redshift_public_subnet_group       = true
-  create_redshift_public_subnet_route_table = true  # <= Default it will be placed into public subnet route table
+  enable_public_redshift = true  # <= Default it will be placed into private subnet route table
 ```
 
 ## Terraform version
@@ -202,8 +201,6 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | create\_elasticache\_subnet\_route\_table | Controls if separate route table for elasticache should be created | string | `"false"` | no |
 | create\_redshift\_subnet\_group | Controls if redshift subnet group should be created | string | `"true"` | no |
 | create\_redshift\_subnet\_route\_table | Controls if separate route table for redshift should be created | string | `"false"` | no |
-| create\_redshift\_public\_subnet\_group | Controls if redshift public subnet group should be created | string | `"true"` | no |
-| create\_redshift\_public\_subnet\_route\_table | Controls if separate route table for public redshift should be created | string | `"false"` | no |
 | create\_vpc | Controls if VPC should be created (it affects almost all resources) | string | `"true"` | no |
 | database\_route\_table\_tags | Additional tags for the database route tables | map | `{}` | no |
 | database\_subnet\_group\_tags | Additional tags for the database subnet group | map | `{}` | no |
@@ -277,11 +274,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | redshift\_subnet\_suffix | Suffix to append to redshift subnets name | string | `"redshift"` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | map | `{}` | no |
 | redshift\_subnets | A list of redshift subnets | list | `[]` | no |
-| redshift\_public\_route\_table\_tags | Additional tags for the public redshift route tables | map | `{}` | no |
-| redshift\_public\_subnet\_group\_tags | Additional tags for the redshift public subnet group | map | `{}` | no |
-| redshift\_public\_subnet\_suffix | Suffix to append to redshift public subnets name | string | `"redshift_public"` | no |
-| redshift\_public\_subnet\_tags | Additional tags for the redshift public subnets | map | `{}` | no |
-| redshift\_public\_subnets | A list of redshift public subnets | list | `[]` | no |
+| enable\_public\_redshift | Should be true if you want Redshift cluster to be placed into public subnet route table | string | `"false"` | no |
 | reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable | string | `"false"` | no |
 | secondary\_cidr\_blocks | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | list | `[]` | no |
 | single\_nat\_gateway | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | string | `"false"` | no |
@@ -339,10 +332,6 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | redshift\_subnet\_group | ID of redshift subnet group |
 | redshift\_subnets | List of IDs of redshift subnets |
 | redshift\_subnets\_cidr\_blocks | List of cidr_blocks of redshift subnets |
-| redshift\_public\_route\_table\_ids | List of IDs of redshift public route tables |
-| redshift\_public\_subnet\_group | ID of redshift public subnet group |
-| redshift\_public\_subnets | List of IDs of redshift public subnets |
-| redshift\_public\_subnets\_cidr\_blocks | List of cidr_blocks of redshift public subnets |
 | vgw\_id | The ID of the VPN Gateway |
 | vpc\_cidr\_block | The CIDR block of the VPC |
 | vpc\_enable\_dns\_hostnames | Whether or not the VPC has DNS hostname support |

--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,7 @@ resource "aws_subnet" "redshift_public" {
 resource "aws_redshift_subnet_group" "redshift_public" {
   count = "${var.create_vpc && length(var.redshift_public_subnets) > 0 && var.create_redshift_public_subnet_group ? 1 : 0}"
 
-  name        = "${lower(var.name)}"
+  name        = "${lower(var.name)}-public"
   description = "Redshift public subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.redshift_public.*.id}"]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -178,6 +178,11 @@ output "redshift_route_table_ids" {
   value       = ["${coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id)}"]
 }
 
+output "redshift_public_route_table_ids" {
+  description = "List of IDs of redshift public route tables"
+  value       = ["${coalescelist(aws_route_table.redshift_public.*.id, aws_route_table.public.*.id)}"]
+}
+
 output "elasticache_route_table_ids" {
   description = "List of IDs of elasticache route tables"
   value       = ["${coalescelist(aws_route_table.elasticache.*.id, aws_route_table.private.*.id)}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,21 +113,6 @@ output "redshift_subnet_group" {
   value       = "${element(concat(aws_redshift_subnet_group.redshift.*.id, list("")), 0)}"
 }
 
-output "redshift_public_subnets" {
-  description = "List of IDs of redshift public subnets"
-  value       = ["${aws_subnet.redshift_public.*.id}"]
-}
-
-output "redshift_public_subnets_cidr_blocks" {
-  description = "List of cidr_blocks of redshift public subnets"
-  value       = ["${aws_subnet.redshift_public.*.cidr_block}"]
-}
-
-output "redshift_public_subnet_group" {
-  description = "ID of redshift public subnet group"
-  value       = "${element(concat(aws_redshift_subnet_group.redshift_public.*.id, list("")), 0)}"
-}
-
 output "elasticache_subnets" {
   description = "List of IDs of elasticache subnets"
   value       = ["${aws_subnet.elasticache.*.id}"]
@@ -176,11 +161,6 @@ output "database_route_table_ids" {
 output "redshift_route_table_ids" {
   description = "List of IDs of redshift route tables"
   value       = ["${coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id)}"]
-}
-
-output "redshift_public_route_table_ids" {
-  description = "List of IDs of redshift public route tables"
-  value       = ["${coalescelist(aws_route_table.redshift_public.*.id, aws_route_table.public.*.id)}"]
 }
 
 output "elasticache_route_table_ids" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,6 +113,21 @@ output "redshift_subnet_group" {
   value       = "${element(concat(aws_redshift_subnet_group.redshift.*.id, list("")), 0)}"
 }
 
+output "redshift_public_subnets" {
+  description = "List of IDs of redshift public subnets"
+  value       = ["${aws_subnet.redshift_public.*.id}"]
+}
+
+output "redshift_public_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of redshift public subnets"
+  value       = ["${aws_subnet.redshift_public.*.cidr_block}"]
+}
+
+output "redshift_public_subnet_group" {
+  description = "ID of redshift public subnet group"
+  value       = "${element(concat(aws_redshift_subnet_group.redshift_public.*.id, list("")), 0)}"
+}
+
 output "elasticache_subnets" {
   description = "List of IDs of elasticache subnets"
   value       = ["${aws_subnet.elasticache.*.id}"]

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,11 @@ variable "redshift_subnet_suffix" {
   default     = "redshift"
 }
 
+variable "redshift_public_subnet_suffix" {
+  description = "Suffix to append to redshift subnets name"
+  default     = "redshift_public"
+}
+
 variable "elasticache_subnet_suffix" {
   description = "Suffix to append to elasticache subnets name"
   default     = "elasticache"
@@ -70,6 +75,12 @@ variable "database_subnets" {
 }
 
 variable "redshift_subnets" {
+  type        = "list"
+  description = "A list of redshift subnets"
+  default     = []
+}
+
+variable "redshift_public_subnets" {
   type        = "list"
   description = "A list of redshift subnets"
   default     = []
@@ -114,6 +125,11 @@ variable "create_elasticache_subnet_group" {
 
 variable "create_redshift_subnet_group" {
   description = "Controls if redshift subnet group should be created"
+  default     = true
+}
+
+variable "create_redshift_public_subnet_group" {
+  description = "Controls if redshift public subnet group should be created"
   default     = true
 }
 
@@ -400,6 +416,16 @@ variable "redshift_subnet_tags" {
 
 variable "redshift_subnet_group_tags" {
   description = "Additional tags for the redshift subnet group"
+  default     = {}
+}
+
+variable "redshift_public_subnet_tags" {
+  description = "Additional tags for the redshift public subnets"
+  default     = {}
+}
+
+variable "redshift_public_subnet_group_tags" {
+  description = "Additional tags for the redshift public subnet group"
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -395,7 +395,7 @@ variable "redshift_route_table_tags" {
 }
 
 variable "redshift_public_route_table_tags" {
-  description = "Additional tags for the redshift route tables"
+  description = "Additional tags for the public redshift route tables"
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,11 +53,6 @@ variable "redshift_subnet_suffix" {
   default     = "redshift"
 }
 
-variable "redshift_public_subnet_suffix" {
-  description = "Suffix to append to redshift subnets name"
-  default     = "redshift_public"
-}
-
 variable "elasticache_subnet_suffix" {
   description = "Suffix to append to elasticache subnets name"
   default     = "elasticache"
@@ -85,12 +80,6 @@ variable "redshift_subnets" {
   default     = []
 }
 
-variable "redshift_public_subnets" {
-  type        = "list"
-  description = "A list of redshift subnets"
-  default     = []
-}
-
 variable "elasticache_subnets" {
   type        = "list"
   description = "A list of elasticache subnets"
@@ -113,8 +102,8 @@ variable "create_redshift_subnet_route_table" {
   default     = false
 }
 
-variable "create_redshift_public_subnet_route_table" {
-  description = "Controls if separate route table for redshift public should be created"
+variable "enable_public_redshift" {
+  description = "Controls if redshift should have public routing table"
   default     = false
 }
 
@@ -135,11 +124,6 @@ variable "create_elasticache_subnet_group" {
 
 variable "create_redshift_subnet_group" {
   description = "Controls if redshift subnet group should be created"
-  default     = true
-}
-
-variable "create_redshift_public_subnet_group" {
-  description = "Controls if redshift public subnet group should be created"
   default     = true
 }
 
@@ -399,11 +383,6 @@ variable "redshift_route_table_tags" {
   default     = {}
 }
 
-variable "redshift_public_route_table_tags" {
-  description = "Additional tags for the public redshift route tables"
-  default     = {}
-}
-
 variable "elasticache_route_table_tags" {
   description = "Additional tags for the elasticache route tables"
   default     = {}
@@ -431,16 +410,6 @@ variable "redshift_subnet_tags" {
 
 variable "redshift_subnet_group_tags" {
   description = "Additional tags for the redshift subnet group"
-  default     = {}
-}
-
-variable "redshift_public_subnet_tags" {
-  description = "Additional tags for the redshift public subnets"
-  default     = {}
-}
-
-variable "redshift_public_subnet_group_tags" {
-  description = "Additional tags for the redshift public subnet group"
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,11 @@ variable "create_redshift_subnet_route_table" {
   default     = false
 }
 
+variable "create_redshift_public_subnet_route_table" {
+  description = "Controls if separate route table for redshift public should be created"
+  default     = false
+}
+
 variable "create_elasticache_subnet_route_table" {
   description = "Controls if separate route table for elasticache should be created"
   default     = false
@@ -385,6 +390,11 @@ variable "database_route_table_tags" {
 }
 
 variable "redshift_route_table_tags" {
+  description = "Additional tags for the redshift route tables"
+  default     = {}
+}
+
+variable "redshift_public_route_table_tags" {
   description = "Additional tags for the redshift route tables"
   default     = {}
 }


### PR DESCRIPTION
I updated the VPC module by adding a public subnet for Redshift because in our use case we needed to access it from Kinesis. 
Because VPC endpoint for [Kinesis is not yet supported by Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-working-with-endpoints.html) , we had to add Redshift to a public subnet and made it publicly accessible. 