### PR TITLE
Terraform 0.12 support

### DIFF
--- a/examples/simple-vpc/outputs.tf
+++ b/examples/simple-vpc/outputs.tf
@@ -1,13 +1,13 @@
 # VPC
 output "vpc_id" {
   description = "The ID of the VPC"
-  value       = "${module.vpc.vpc_id}"
+  value       = module.vpc.vpc_id
 }
 
 # CIDR blocks
 output "vpc_cidr_block" {
   description = "The CIDR block of the VPC"
-  value       = ["${module.vpc.vpc_cidr_block}"]
+  value       = [module.vpc.vpc_cidr_block]
 }
 
 //output "vpc_ipv6_cidr_block" {
@@ -18,22 +18,28 @@ output "vpc_cidr_block" {
 # Subnets
 output "private_subnets" {
   description = "List of IDs of private subnets"
-  value       = ["${module.vpc.private_subnets}"]
+  value       = [module.vpc.private_subnets]
 }
 
 output "public_subnets" {
   description = "List of IDs of public subnets"
-  value       = ["${module.vpc.public_subnets}"]
+  value       = [module.vpc.public_subnets]
 }
 
 # NAT gateways
 output "nat_public_ips" {
   description = "List of public Elastic IPs created for AWS NAT Gateway"
-  value       = ["${module.vpc.nat_public_ips}"]
+  value       = [module.vpc.nat_public_ips]
 }
 
 # AZs
 output "azs" {
   description = "A list of availability zones spefified as argument to this module"
-  value       = ["${module.vpc.azs}"]
+  value       = [module.vpc.azs]
 }
+
+5000
++200 (social) vs 31%
+
+house: 234m2 - 1200 eur
+

--- a/examples/simple-vpc/outputs.tf
+++ b/examples/simple-vpc/outputs.tf
@@ -37,9 +37,3 @@ output "azs" {
   description = "A list of availability zones spefified as argument to this module"
   value       = [module.vpc.azs]
 }
-
-5000
-+200 (social) vs 31%
-
-house: 234m2 - 1200 eur
-

--- a/examples/simple-vpc/versions.tf
+++ b/examples/simple-vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/main.tf
+++ b/main.tf
@@ -3,89 +3,125 @@ terraform {
 }
 
 locals {
-  max_subnet_length = "${max(length(var.private_subnets), length(var.elasticache_subnets), length(var.database_subnets), length(var.redshift_subnets))}"
-  nat_gateway_count = "${var.single_nat_gateway ? 1 : (var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length)}"
+  max_subnet_length = max(
+    length(var.private_subnets),
+    length(var.elasticache_subnets),
+    length(var.database_subnets),
+    length(var.redshift_subnets),
+  )
+  nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
-  vpc_id = "${element(concat(aws_vpc_ipv4_cidr_block_association.this.*.vpc_id, aws_vpc.this.*.id, list("")), 0)}"
+  vpc_id = element(
+    concat(
+      aws_vpc_ipv4_cidr_block_association.this.*.vpc_id,
+      aws_vpc.this.*.id,
+      [""],
+    ),
+    0,
+  )
 }
 
 ######
 # VPC
 ######
 resource "aws_vpc" "this" {
-  count = "${var.create_vpc ? 1 : 0}"
+  count = var.create_vpc ? 1 : 0
 
-  cidr_block                       = "${var.cidr}"
-  instance_tenancy                 = "${var.instance_tenancy}"
-  enable_dns_hostnames             = "${var.enable_dns_hostnames}"
-  enable_dns_support               = "${var.enable_dns_support}"
-  assign_generated_ipv6_cidr_block = "${var.assign_generated_ipv6_cidr_block}"
+  cidr_block                       = var.cidr
+  instance_tenancy                 = var.instance_tenancy
+  enable_dns_hostnames             = var.enable_dns_hostnames
+  enable_dns_support               = var.enable_dns_support
+  assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.vpc_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.vpc_tags,
+  )
 }
 
 resource "aws_vpc_ipv4_cidr_block_association" "this" {
-  count = "${var.create_vpc && length(var.secondary_cidr_blocks) > 0 ? length(var.secondary_cidr_blocks) : 0}"
+  count = var.create_vpc && length(var.secondary_cidr_blocks) > 0 ? length(var.secondary_cidr_blocks) : 0
 
-  vpc_id = "${aws_vpc.this.id}"
+  vpc_id = aws_vpc.this[0].id
 
-  cidr_block = "${element(var.secondary_cidr_blocks, count.index)}"
+  cidr_block = element(var.secondary_cidr_blocks, count.index)
 }
 
 ###################
 # DHCP Options Set
 ###################
 resource "aws_vpc_dhcp_options" "this" {
-  count = "${var.create_vpc && var.enable_dhcp_options ? 1 : 0}"
+  count = var.create_vpc && var.enable_dhcp_options ? 1 : 0
 
-  domain_name          = "${var.dhcp_options_domain_name}"
-  domain_name_servers  = ["${var.dhcp_options_domain_name_servers}"]
-  ntp_servers          = ["${var.dhcp_options_ntp_servers}"]
-  netbios_name_servers = ["${var.dhcp_options_netbios_name_servers}"]
-  netbios_node_type    = "${var.dhcp_options_netbios_node_type}"
+  domain_name          = var.dhcp_options_domain_name
+  domain_name_servers  = var.dhcp_options_domain_name_servers
+  ntp_servers          = var.dhcp_options_ntp_servers
+  netbios_name_servers = var.dhcp_options_netbios_name_servers
+  netbios_node_type    = var.dhcp_options_netbios_node_type
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.dhcp_options_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.dhcp_options_tags,
+  )
 }
 
 ###############################
 # DHCP Options Set Association
 ###############################
 resource "aws_vpc_dhcp_options_association" "this" {
-  count = "${var.create_vpc && var.enable_dhcp_options ? 1 : 0}"
+  count = var.create_vpc && var.enable_dhcp_options ? 1 : 0
 
-  vpc_id          = "${local.vpc_id}"
-  dhcp_options_id = "${aws_vpc_dhcp_options.this.id}"
+  vpc_id          = local.vpc_id
+  dhcp_options_id = aws_vpc_dhcp_options.this[0].id
 }
 
 ###################
 # Internet Gateway
 ###################
 resource "aws_internet_gateway" "this" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.igw_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.igw_tags,
+  )
 }
 
 ################
 # Publiс routes
 ################
 resource "aws_route_table" "public" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(map("Name", format("%s-${var.public_subnet_suffix}", var.name)), var.tags, var.public_route_table_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s-${var.public_subnet_suffix}", var.name)
+    },
+    var.tags,
+    var.public_route_table_tags,
+  )
 }
 
 resource "aws_route" "public_internet_gateway" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && length(var.public_subnets) > 0 ? 1 : 0
 
-  route_table_id         = "${aws_route_table.public.id}"
+  route_table_id         = aws_route_table.public[0].id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.this.id}"
+  gateway_id             = aws_internet_gateway.this[0].id
 
   timeouts {
     create = "5m"
@@ -97,16 +133,26 @@ resource "aws_route" "public_internet_gateway" {
 # There are so many routing tables as the largest amount of subnets of each type (really?)
 #################
 resource "aws_route_table" "private" {
-  count = "${var.create_vpc && local.max_subnet_length > 0 ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(map("Name", (var.single_nat_gateway ? "${var.name}-${var.private_subnet_suffix}" : format("%s-${var.private_subnet_suffix}-%s", var.name, element(var.azs, count.index)))), var.tags, var.private_route_table_tags)}"
+  tags = merge(
+    {
+      "Name" = var.single_nat_gateway ? "${var.name}-${var.private_subnet_suffix}" : format(
+        "%s-${var.private_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.private_route_table_tags,
+  )
 
   lifecycle {
     # When attaching VPN gateways it is common to define aws_vpn_gateway_route_propagation
     # resources that manipulate the attributes of the routing table (typically for the private subnets)
-    ignore_changes = ["propagating_vgws"]
+    ignore_changes = [propagating_vgws]
   }
 }
 
@@ -114,19 +160,25 @@ resource "aws_route_table" "private" {
 # Database routes
 #################
 resource "aws_route_table" "database" {
-  count = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(var.tags, var.database_route_table_tags, map("Name", "${var.name}-${var.database_subnet_suffix}"))}"
+  tags = merge(
+    var.tags,
+    var.database_route_table_tags,
+    {
+      "Name" = "${var.name}-${var.database_subnet_suffix}"
+    },
+  )
 }
 
 resource "aws_route" "database_internet_gateway" {
-  count = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && var.create_database_internet_gateway_route && !var.create_database_nat_gateway_route ? 1 : 0}"
+  count = var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && var.create_database_internet_gateway_route && false == var.create_database_nat_gateway_route ? 1 : 0
 
-  route_table_id         = "${aws_route_table.database.id}"
+  route_table_id         = aws_route_table.database[0].id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.this.id}"
+  gateway_id             = aws_internet_gateway.this[0].id
 
   timeouts {
     create = "5m"
@@ -134,10 +186,10 @@ resource "aws_route" "database_internet_gateway" {
 }
 
 resource "aws_route" "database_nat_gateway" {
-  count                  = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && !var.create_database_internet_gateway_route && var.create_database_nat_gateway_route && var.enable_nat_gateway ? local.nat_gateway_count : 0}"
-  route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  count                  = var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && false == var.create_database_internet_gateway_route && var.create_database_nat_gateway_route && var.enable_nat_gateway ? local.nat_gateway_count : 0
+  route_table_id         = element(aws_route_table.private.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.this.*.id, count.index)}"
+  nat_gateway_id         = element(aws_nat_gateway.this.*.id, count.index)
 
   timeouts {
     create = "5m"
@@ -148,140 +200,230 @@ resource "aws_route" "database_nat_gateway" {
 # Redshift routes
 #################
 resource "aws_route_table" "redshift" {
-  count = "${var.create_vpc && var.create_redshift_subnet_route_table && length(var.redshift_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.create_redshift_subnet_route_table && length(var.redshift_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(var.tags, var.redshift_route_table_tags, map("Name", "${var.name}-${var.redshift_subnet_suffix}"))}"
+  tags = merge(
+    var.tags,
+    var.redshift_route_table_tags,
+    {
+      "Name" = "${var.name}-${var.redshift_subnet_suffix}"
+    },
+  )
 }
 
 #################
 # Elasticache routes
 #################
 resource "aws_route_table" "elasticache" {
-  count = "${var.create_vpc && var.create_elasticache_subnet_route_table && length(var.elasticache_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.create_elasticache_subnet_route_table && length(var.elasticache_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(var.tags, var.elasticache_route_table_tags, map("Name", "${var.name}-${var.elasticache_subnet_suffix}"))}"
+  tags = merge(
+    var.tags,
+    var.elasticache_route_table_tags,
+    {
+      "Name" = "${var.name}-${var.elasticache_subnet_suffix}"
+    },
+  )
 }
 
 #################
 # Intra routes
 #################
 resource "aws_route_table" "intra" {
-  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && length(var.intra_subnets) > 0 ? 1 : 0
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags = "${merge(map("Name", "${var.name}-${var.intra_subnet_suffix}"), var.tags, var.intra_route_table_tags)}"
+  tags = merge(
+    {
+      "Name" = "${var.name}-${var.intra_subnet_suffix}"
+    },
+    var.tags,
+    var.intra_route_table_tags,
+  )
 }
 
 ################
 # Public subnet
 ################
 resource "aws_subnet" "public" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 && (!var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0}"
+  count = var.create_vpc && length(var.public_subnets) > 0 && false == var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs) ? length(var.public_subnets) : 0
 
-  vpc_id                  = "${local.vpc_id}"
-  cidr_block              = "${element(concat(var.public_subnets, list("")), count.index)}"
-  availability_zone       = "${element(var.azs, count.index)}"
-  map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
+  vpc_id                  = local.vpc_id
+  cidr_block              = element(concat(var.public_subnets, [""]), count.index)
+  availability_zone       = element(var.azs, count.index)
+  map_public_ip_on_launch = var.map_public_ip_on_launch
 
-  tags = "${merge(map("Name", format("%s-${var.public_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.public_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.public_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.public_subnet_tags,
+  )
 }
 
 #################
 # Private subnet
 #################
 resource "aws_subnet" "private" {
-  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0}"
+  count = var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${var.private_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
 
-  tags = "${merge(map("Name", format("%s-${var.private_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.private_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.private_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.private_subnet_tags,
+  )
 }
 
 ##################
 # Database subnet
 ##################
 resource "aws_subnet" "database" {
-  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0}"
+  count = var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${var.database_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = var.database_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
 
-  tags = "${merge(map("Name", format("%s-${var.database_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.database_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.database_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.database_subnet_tags,
+  )
 }
 
 resource "aws_db_subnet_group" "database" {
-  count = "${var.create_vpc && length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0}"
+  count = var.create_vpc && length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0
 
-  name        = "${lower(var.name)}"
+  name        = lower(var.name)
   description = "Database subnet group for ${var.name}"
-  subnet_ids  = ["${aws_subnet.database.*.id}"]
+  subnet_ids  = aws_subnet.database.*.id
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.database_subnet_group_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.database_subnet_group_tags,
+  )
 }
 
 ##################
 # Redshift subnet
 ##################
 resource "aws_subnet" "redshift" {
-  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0}"
+  count = var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${var.redshift_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = var.redshift_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
 
-  tags = "${merge(map("Name", format("%s-${var.redshift_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.redshift_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.redshift_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.redshift_subnet_tags,
+  )
 }
 
 resource "aws_redshift_subnet_group" "redshift" {
-  count = "${var.create_vpc && length(var.redshift_subnets) > 0 && var.create_redshift_subnet_group ? 1 : 0}"
+  count = var.create_vpc && length(var.redshift_subnets) > 0 && var.create_redshift_subnet_group ? 1 : 0
 
-  name        = "${lower(var.name)}"
+  name        = lower(var.name)
   description = "Redshift subnet group for ${var.name}"
-  subnet_ids  = ["${aws_subnet.redshift.*.id}"]
+  subnet_ids  = aws_subnet.redshift.*.id
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.redshift_subnet_group_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.redshift_subnet_group_tags,
+  )
 }
 
 #####################
 # ElastiCache subnet
 #####################
 resource "aws_subnet" "elasticache" {
-  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0}"
+  count = var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${var.elasticache_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = var.elasticache_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
 
-  tags = "${merge(map("Name", format("%s-${var.elasticache_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.elasticache_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.elasticache_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.elasticache_subnet_tags,
+  )
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
-  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 && var.create_elasticache_subnet_group ? 1 : 0}"
+  count = var.create_vpc && length(var.elasticache_subnets) > 0 && var.create_elasticache_subnet_group ? 1 : 0
 
-  name        = "${var.name}"
+  name        = var.name
   description = "ElastiCache subnet group for ${var.name}"
-  subnet_ids  = ["${aws_subnet.elasticache.*.id}"]
+  subnet_ids  = aws_subnet.elasticache.*.id
 }
 
 #####################################################
 # intra subnets - private subnet without NAT gateway
 #####################################################
 resource "aws_subnet" "intra" {
-  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0}"
+  count = var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${var.intra_subnets[count.index]}"
-  availability_zone = "${element(var.azs, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = var.intra_subnets[count.index]
+  availability_zone = element(var.azs, count.index)
 
-  tags = "${merge(map("Name", format("%s-${var.intra_subnet_suffix}-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.intra_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.intra_subnet_tags,
+  )
 }
 
 ##############
@@ -296,34 +438,63 @@ resource "aws_subnet" "intra" {
 #
 # but then when count of aws_eip.nat.*.id is zero, this would throw a resource not found error on aws_eip.nat.*.id.
 locals {
-  nat_gateway_ips = "${split(",", (var.reuse_nat_ips ? join(",", var.external_nat_ip_ids) : join(",", aws_eip.nat.*.id)))}"
+  nat_gateway_ips = split(
+    ",",
+    var.reuse_nat_ips ? join(",", var.external_nat_ip_ids) : join(",", aws_eip.nat.*.id),
+  )
 }
 
 resource "aws_eip" "nat" {
-  count = "${var.create_vpc && (var.enable_nat_gateway && !var.reuse_nat_ips) ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && var.enable_nat_gateway && false == var.reuse_nat_ips ? local.nat_gateway_count : 0
 
   vpc = true
 
-  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.tags, var.nat_eip_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-%s",
+        var.name,
+        element(var.azs, var.single_nat_gateway ? 0 : count.index),
+      )
+    },
+    var.tags,
+    var.nat_eip_tags,
+  )
 }
 
 resource "aws_nat_gateway" "this" {
-  count = "${var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
 
-  allocation_id = "${element(local.nat_gateway_ips, (var.single_nat_gateway ? 0 : count.index))}"
-  subnet_id     = "${element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  allocation_id = element(
+    local.nat_gateway_ips,
+    var.single_nat_gateway ? 0 : count.index,
+  )
+  subnet_id = element(
+    aws_subnet.public.*.id,
+    var.single_nat_gateway ? 0 : count.index,
+  )
 
-  tags = "${merge(map("Name", format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))), var.tags, var.nat_gateway_tags)}"
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-%s",
+        var.name,
+        element(var.azs, var.single_nat_gateway ? 0 : count.index),
+      )
+    },
+    var.tags,
+    var.nat_gateway_tags,
+  )
 
-  depends_on = ["aws_internet_gateway.this"]
+  depends_on = [aws_internet_gateway.this]
 }
 
 resource "aws_route" "private_nat_gateway" {
-  count = "${var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
 
-  route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  route_table_id         = element(aws_route_table.private.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.this.*.id, count.index)}"
+  nat_gateway_id         = element(aws_nat_gateway.this.*.id, count.index)
 
   timeouts {
     create = "5m"
@@ -334,310 +505,350 @@ resource "aws_route" "private_nat_gateway" {
 # VPC Endpoint for S3
 ######################
 data "aws_vpc_endpoint_service" "s3" {
-  count = "${var.create_vpc && var.enable_s3_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
   service = "s3"
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  count = "${var.create_vpc && var.enable_s3_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
-  vpc_id       = "${local.vpc_id}"
-  service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
+  vpc_id       = local.vpc_id
+  service_name = data.aws_vpc_endpoint_service.s3[0].service_name
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count = "${var.create_vpc && var.enable_s3_endpoint ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && var.enable_s3_endpoint ? local.nat_gateway_count : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
-  route_table_id  = "${element(aws_route_table.private.*.id, count.index)}"
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = element(aws_route_table.private.*.id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "intra_s3" {
-  count = "${var.create_vpc && var.enable_s3_endpoint && length(var.intra_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.enable_s3_endpoint && length(var.intra_subnets) > 0 ? 1 : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
-  route_table_id  = "${element(aws_route_table.intra.*.id, 0)}"
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = element(aws_route_table.intra.*.id, 0)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  count = "${var.create_vpc && var.enable_s3_endpoint && length(var.public_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.enable_s3_endpoint && length(var.public_subnets) > 0 ? 1 : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
-  route_table_id  = "${aws_route_table.public.id}"
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.public[0].id
 }
 
 ############################
 # VPC Endpoint for DynamoDB
 ############################
 data "aws_vpc_endpoint_service" "dynamodb" {
-  count = "${var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0
 
   service = "dynamodb"
 }
 
 resource "aws_vpc_endpoint" "dynamodb" {
-  count = "${var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0
 
-  vpc_id       = "${local.vpc_id}"
-  service_name = "${data.aws_vpc_endpoint_service.dynamodb.service_name}"
+  vpc_id       = local.vpc_id
+  service_name = data.aws_vpc_endpoint_service.dynamodb[0].service_name
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_dynamodb" {
-  count = "${var.create_vpc && var.enable_dynamodb_endpoint ? local.nat_gateway_count : 0}"
+  count = var.create_vpc && var.enable_dynamodb_endpoint ? local.nat_gateway_count : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.dynamodb.id}"
-  route_table_id  = "${element(aws_route_table.private.*.id, count.index)}"
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = element(aws_route_table.private.*.id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "intra_dynamodb" {
-  count = "${var.create_vpc && var.enable_dynamodb_endpoint && length(var.intra_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.enable_dynamodb_endpoint && length(var.intra_subnets) > 0 ? 1 : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.dynamodb.id}"
-  route_table_id  = "${element(aws_route_table.intra.*.id, 0)}"
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = element(aws_route_table.intra.*.id, 0)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_dynamodb" {
-  count = "${var.create_vpc && var.enable_dynamodb_endpoint && length(var.public_subnets) > 0 ? 1 : 0}"
+  count = var.create_vpc && var.enable_dynamodb_endpoint && length(var.public_subnets) > 0 ? 1 : 0
 
-  vpc_endpoint_id = "${aws_vpc_endpoint.dynamodb.id}"
-  route_table_id  = "${aws_route_table.public.id}"
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = aws_route_table.public[0].id
 }
 
 #######################
 # VPC Endpoint for SSM
 #######################
 data "aws_vpc_endpoint_service" "ssm" {
-  count = "${var.create_vpc && var.enable_ssm_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ssm_endpoint ? 1 : 0
 
   service = "ssm"
 }
 
 resource "aws_vpc_endpoint" "ssm" {
-  count = "${var.create_vpc && var.enable_ssm_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ssm_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ssm.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ssm[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ssm_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ssm_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ssm_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ssm_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ssm_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ssm_endpoint_private_dns_enabled
 }
 
 ###############################
 # VPC Endpoint for SSMMESSAGES
 ###############################
 data "aws_vpc_endpoint_service" "ssmmessages" {
-  count = "${var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0
 
   service = "ssmmessages"
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
-  count = "${var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ssmmessages.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ssmmessages[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ssmmessages_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ssmmessages_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ssmmessages_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
 }
 
 #######################
 # VPC Endpoint for EC2
 #######################
 data "aws_vpc_endpoint_service" "ec2" {
-  count = "${var.create_vpc && var.enable_ec2_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ec2_endpoint ? 1 : 0
 
   service = "ec2"
 }
 
 resource "aws_vpc_endpoint" "ec2" {
-  count = "${var.create_vpc && var.enable_ec2_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ec2_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ec2.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ec2[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ec2_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ec2_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ec2_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ec2_endpoint_private_dns_enabled
 }
 
 ###############################
 # VPC Endpoint for EC2MESSAGES
 ###############################
 data "aws_vpc_endpoint_service" "ec2messages" {
-  count = "${var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0
 
   service = "ec2messages"
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
-  count = "${var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ec2messages.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ec2messages[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ec2messages_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ec2messages_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ec2messages_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
 }
 
 ###########################
 # VPC Endpoint for ECR API
 ###########################
 data "aws_vpc_endpoint_service" "ecr_api" {
-  count = "${var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0
 
   service = "ecr.api"
 }
 
 resource "aws_vpc_endpoint" "ecr_api" {
-  count = "${var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ecr_api.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ecr_api[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ecr_api_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ecr_api_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ecr_api_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
 }
 
 ###########################
 # VPC Endpoint for ECR DKR
 ###########################
 data "aws_vpc_endpoint_service" "ecr_dkr" {
-  count = "${var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0
 
   service = "ecr.dkr"
 }
 
 resource "aws_vpc_endpoint" "ecr_dkr" {
-  count = "${var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.ecr_dkr.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.ecr_dkr[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.ecr_dkr_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.ecr_dkr_endpoint_private_dns_enabled}"
+  security_group_ids  = var.ecr_dkr_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
 }
 
 #######################
 # VPC Endpoint for API Gateway
 #######################
 data "aws_vpc_endpoint_service" "apigw" {
-  count = "${var.create_vpc && var.enable_apigw_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_apigw_endpoint ? 1 : 0
 
   service = "execute-api"
 }
 
 resource "aws_vpc_endpoint" "apigw" {
-  count = "${var.create_vpc && var.enable_apigw_endpoint ? 1 : 0}"
+  count = var.create_vpc && var.enable_apigw_endpoint ? 1 : 0
 
-  vpc_id            = "${local.vpc_id}"
-  service_name      = "${data.aws_vpc_endpoint_service.apigw.service_name}"
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.apigw[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = ["${var.apigw_endpoint_security_group_ids}"]
-  subnet_ids          = ["${coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)}"]
-  private_dns_enabled = "${var.apigw_endpoint_private_dns_enabled}"
+  security_group_ids  = var.apigw_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.apigw_endpoint_private_dns_enabled
 }
 
 ##########################
 # Route table association
 ##########################
 resource "aws_route_table_association" "private" {
-  count = "${var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0}"
+  count = var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  subnet_id = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(
+    aws_route_table.private.*.id,
+    var.single_nat_gateway ? 0 : count.index,
+  )
 }
 
 resource "aws_route_table_association" "database" {
-  count = "${var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0}"
+  count = var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.database.*.id, count.index)}"
-  route_table_id = "${element(coalescelist(aws_route_table.database.*.id, aws_route_table.private.*.id), (var.single_nat_gateway || var.create_database_subnet_route_table ? 0 : count.index))}"
+  subnet_id = element(aws_subnet.database.*.id, count.index)
+  route_table_id = element(
+    coalescelist(aws_route_table.database.*.id, aws_route_table.private.*.id),
+    var.single_nat_gateway || var.create_database_subnet_route_table ? 0 : count.index,
+  )
 }
 
 resource "aws_route_table_association" "redshift" {
-  count = "${var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0}"
+  count = var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.redshift.*.id, count.index)}"
-  route_table_id = "${element(coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id), (var.single_nat_gateway || var.create_redshift_subnet_route_table ? 0 : count.index))}"
+  subnet_id = element(aws_subnet.redshift.*.id, count.index)
+  route_table_id = element(
+    coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id),
+    var.single_nat_gateway || var.create_redshift_subnet_route_table ? 0 : count.index,
+  )
 }
 
 resource "aws_route_table_association" "elasticache" {
-  count = "${var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0}"
+  count = var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.elasticache.*.id, count.index)}"
-  route_table_id = "${element(coalescelist(aws_route_table.elasticache.*.id, aws_route_table.private.*.id), (var.single_nat_gateway || var.create_elasticache_subnet_route_table ? 0 : count.index))}"
+  subnet_id = element(aws_subnet.elasticache.*.id, count.index)
+  route_table_id = element(
+    coalescelist(
+      aws_route_table.elasticache.*.id,
+      aws_route_table.private.*.id,
+    ),
+    var.single_nat_gateway || var.create_elasticache_subnet_route_table ? 0 : count.index,
+  )
 }
 
 resource "aws_route_table_association" "intra" {
-  count = "${var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0}"
+  count = var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.intra.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.intra.*.id, 0)}"
+  subnet_id      = element(aws_subnet.intra.*.id, count.index)
+  route_table_id = element(aws_route_table.intra.*.id, 0)
 }
 
 resource "aws_route_table_association" "public" {
-  count = "${var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_subnets) : 0}"
+  count = var.create_vpc && length(var.public_subnets) > 0 ? length(var.public_subnets) : 0
 
-  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
-  route_table_id = "${aws_route_table.public.id}"
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public[0].id
 }
 
 ##############
 # VPN Gateway
 ##############
 resource "aws_vpn_gateway" "this" {
-  count = "${var.create_vpc && var.enable_vpn_gateway ? 1 : 0}"
+  count = var.create_vpc && var.enable_vpn_gateway ? 1 : 0
 
-  vpc_id          = "${local.vpc_id}"
-  amazon_side_asn = "${var.amazon_side_asn}"
+  vpc_id          = local.vpc_id
+  amazon_side_asn = var.amazon_side_asn
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.vpn_gateway_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.vpn_gateway_tags,
+  )
 }
 
 resource "aws_vpn_gateway_attachment" "this" {
-  count = "${var.vpn_gateway_id != "" ? 1 : 0}"
+  count = var.vpn_gateway_id != "" ? 1 : 0
 
-  vpc_id         = "${local.vpc_id}"
-  vpn_gateway_id = "${var.vpn_gateway_id}"
+  vpc_id         = local.vpc_id
+  vpn_gateway_id = var.vpn_gateway_id
 }
 
 resource "aws_vpn_gateway_route_propagation" "public" {
-  count = "${var.create_vpc && var.propagate_public_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? 1 : 0}"
+  count = var.create_vpc && var.propagate_public_route_tables_vgw && var.enable_vpn_gateway || var.vpn_gateway_id != "" ? 1 : 0
 
-  route_table_id = "${element(aws_route_table.public.*.id, count.index)}"
-  vpn_gateway_id = "${element(concat(aws_vpn_gateway.this.*.id, aws_vpn_gateway_attachment.this.*.vpn_gateway_id), count.index)}"
+  route_table_id = element(aws_route_table.public.*.id, count.index)
+  vpn_gateway_id = element(
+    concat(
+      aws_vpn_gateway.this.*.id,
+      aws_vpn_gateway_attachment.this.*.vpn_gateway_id,
+    ),
+    count.index,
+  )
 }
 
 resource "aws_vpn_gateway_route_propagation" "private" {
-  count = "${var.create_vpc && var.propagate_private_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? length(var.private_subnets) : 0}"
+  count = var.create_vpc && var.propagate_private_route_tables_vgw && var.enable_vpn_gateway || var.vpn_gateway_id != "" ? length(var.private_subnets) : 0
 
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
-  vpn_gateway_id = "${element(concat(aws_vpn_gateway.this.*.id, aws_vpn_gateway_attachment.this.*.vpn_gateway_id), count.index)}"
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+  vpn_gateway_id = element(
+    concat(
+      aws_vpn_gateway.this.*.id,
+      aws_vpn_gateway_attachment.this.*.vpn_gateway_id,
+    ),
+    count.index,
+  )
 }
 
 ###########
 # Defaults
 ###########
 resource "aws_default_vpc" "this" {
-  count = "${var.manage_default_vpc ? 1 : 0}"
+  count = var.manage_default_vpc ? 1 : 0
 
-  enable_dns_support   = "${var.default_vpc_enable_dns_support}"
-  enable_dns_hostnames = "${var.default_vpc_enable_dns_hostnames}"
-  enable_classiclink   = "${var.default_vpc_enable_classiclink}"
+  enable_dns_support   = var.default_vpc_enable_dns_support
+  enable_dns_hostnames = var.default_vpc_enable_dns_hostnames
+  enable_classiclink   = var.default_vpc_enable_classiclink
 
-  tags = "${merge(map("Name", format("%s", var.default_vpc_name)), var.tags, var.default_vpc_tags)}"
+  tags = merge(
+    {
+      "Name" = format("%s", var.default_vpc_name)
+    },
+    var.tags,
+    var.default_vpc_tags,
+  )
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,41 +1,41 @@
 output "vpc_id" {
   description = "The ID of the VPC"
-  value       = "${element(concat(aws_vpc.this.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.id, [""]), 0)
 }
 
 output "vpc_cidr_block" {
   description = "The CIDR block of the VPC"
-  value       = "${element(concat(aws_vpc.this.*.cidr_block, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.cidr_block, [""]), 0)
 }
 
 output "default_security_group_id" {
   description = "The ID of the security group created by default on VPC creation"
-  value       = "${element(concat(aws_vpc.this.*.default_security_group_id, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.default_security_group_id, [""]), 0)
 }
 
 output "default_network_acl_id" {
   description = "The ID of the default network ACL"
-  value       = "${element(concat(aws_vpc.this.*.default_network_acl_id, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.default_network_acl_id, [""]), 0)
 }
 
 output "default_route_table_id" {
   description = "The ID of the default route table"
-  value       = "${element(concat(aws_vpc.this.*.default_route_table_id, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.default_route_table_id, [""]), 0)
 }
 
 output "vpc_instance_tenancy" {
   description = "Tenancy of instances spin up within VPC"
-  value       = "${element(concat(aws_vpc.this.*.instance_tenancy, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.instance_tenancy, [""]), 0)
 }
 
 output "vpc_enable_dns_support" {
   description = "Whether or not the VPC has DNS support"
-  value       = "${element(concat(aws_vpc.this.*.enable_dns_support, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.enable_dns_support, [""]), 0)
 }
 
 output "vpc_enable_dns_hostnames" {
   description = "Whether or not the VPC has DNS hostname support"
-  value       = "${element(concat(aws_vpc.this.*.enable_dns_hostnames, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.enable_dns_hostnames, [""]), 0)
 }
 
 //output "vpc_enable_classiclink" {
@@ -45,7 +45,7 @@ output "vpc_enable_dns_hostnames" {
 
 output "vpc_main_route_table_id" {
   description = "The ID of the main route table associated with this VPC"
-  value       = "${element(concat(aws_vpc.this.*.main_route_table_id, list("")), 0)}"
+  value       = element(concat(aws_vpc.this.*.main_route_table_id, [""]), 0)
 }
 
 //output "vpc_ipv6_association_id" {
@@ -60,182 +60,207 @@ output "vpc_main_route_table_id" {
 
 output "vpc_secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks of the VPC"
-  value       = ["${aws_vpc_ipv4_cidr_block_association.this.*.cidr_block}"]
+  value       = [aws_vpc_ipv4_cidr_block_association.this.*.cidr_block]
 }
 
 output "private_subnets" {
   description = "List of IDs of private subnets"
-  value       = ["${aws_subnet.private.*.id}"]
+  value       = [aws_subnet.private.*.id]
 }
 
 output "private_subnets_cidr_blocks" {
   description = "List of cidr_blocks of private subnets"
-  value       = ["${aws_subnet.private.*.cidr_block}"]
+  value       = [aws_subnet.private.*.cidr_block]
 }
 
 output "public_subnets" {
   description = "List of IDs of public subnets"
-  value       = ["${aws_subnet.public.*.id}"]
+  value       = [aws_subnet.public.*.id]
 }
 
 output "public_subnets_cidr_blocks" {
   description = "List of cidr_blocks of public subnets"
-  value       = ["${aws_subnet.public.*.cidr_block}"]
+  value       = [aws_subnet.public.*.cidr_block]
 }
 
 output "database_subnets" {
   description = "List of IDs of database subnets"
-  value       = ["${aws_subnet.database.*.id}"]
+  value       = [aws_subnet.database.*.id]
 }
 
 output "database_subnets_cidr_blocks" {
   description = "List of cidr_blocks of database subnets"
-  value       = ["${aws_subnet.database.*.cidr_block}"]
+  value       = [aws_subnet.database.*.cidr_block]
 }
 
 output "database_subnet_group" {
   description = "ID of database subnet group"
-  value       = "${element(concat(aws_db_subnet_group.database.*.id, list("")), 0)}"
+  value       = element(concat(aws_db_subnet_group.database.*.id, [""]), 0)
 }
 
 output "redshift_subnets" {
   description = "List of IDs of redshift subnets"
-  value       = ["${aws_subnet.redshift.*.id}"]
+  value       = [aws_subnet.redshift.*.id]
 }
 
 output "redshift_subnets_cidr_blocks" {
   description = "List of cidr_blocks of redshift subnets"
-  value       = ["${aws_subnet.redshift.*.cidr_block}"]
+  value       = [aws_subnet.redshift.*.cidr_block]
 }
 
 output "redshift_subnet_group" {
   description = "ID of redshift subnet group"
-  value       = "${element(concat(aws_redshift_subnet_group.redshift.*.id, list("")), 0)}"
+  value       = element(concat(aws_redshift_subnet_group.redshift.*.id, [""]), 0)
 }
 
 output "elasticache_subnets" {
   description = "List of IDs of elasticache subnets"
-  value       = ["${aws_subnet.elasticache.*.id}"]
+  value       = [aws_subnet.elasticache.*.id]
 }
 
 output "elasticache_subnets_cidr_blocks" {
   description = "List of cidr_blocks of elasticache subnets"
-  value       = ["${aws_subnet.elasticache.*.cidr_block}"]
+  value       = [aws_subnet.elasticache.*.cidr_block]
 }
 
 output "intra_subnets" {
   description = "List of IDs of intra subnets"
-  value       = ["${aws_subnet.intra.*.id}"]
+  value       = [aws_subnet.intra.*.id]
 }
 
 output "intra_subnets_cidr_blocks" {
   description = "List of cidr_blocks of intra subnets"
-  value       = ["${aws_subnet.intra.*.cidr_block}"]
+  value       = [aws_subnet.intra.*.cidr_block]
 }
 
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
-  value       = "${element(concat(aws_elasticache_subnet_group.elasticache.*.id, list("")), 0)}"
+  value = element(
+    concat(aws_elasticache_subnet_group.elasticache.*.id, [""]),
+    0,
+  )
 }
 
 output "elasticache_subnet_group_name" {
   description = "Name of elasticache subnet group"
-  value       = "${element(concat(aws_elasticache_subnet_group.elasticache.*.name, list("")), 0)}"
+  value = element(
+    concat(aws_elasticache_subnet_group.elasticache.*.name, [""]),
+    0,
+  )
 }
 
 output "public_route_table_ids" {
   description = "List of IDs of public route tables"
-  value       = ["${aws_route_table.public.*.id}"]
+  value       = [aws_route_table.public.*.id]
 }
 
 output "private_route_table_ids" {
   description = "List of IDs of private route tables"
-  value       = ["${aws_route_table.private.*.id}"]
+  value       = [aws_route_table.private.*.id]
 }
 
 output "database_route_table_ids" {
   description = "List of IDs of database route tables"
-  value       = ["${coalescelist(aws_route_table.database.*.id, aws_route_table.private.*.id)}"]
+  value       = [coalescelist(aws_route_table.database.*.id, aws_route_table.private.*.id)]
 }
 
 output "redshift_route_table_ids" {
   description = "List of IDs of redshift route tables"
-  value       = ["${coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id)}"]
+  value       = [coalescelist(aws_route_table.redshift.*.id, aws_route_table.private.*.id)]
 }
 
 output "elasticache_route_table_ids" {
   description = "List of IDs of elasticache route tables"
-  value       = ["${coalescelist(aws_route_table.elasticache.*.id, aws_route_table.private.*.id)}"]
+  value = [coalescelist(
+    aws_route_table.elasticache.*.id,
+    aws_route_table.private.*.id,
+  )]
 }
 
 output "intra_route_table_ids" {
   description = "List of IDs of intra route tables"
-  value       = ["${aws_route_table.intra.*.id}"]
+  value       = [aws_route_table.intra.*.id]
 }
 
 output "nat_ids" {
   description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
-  value       = ["${aws_eip.nat.*.id}"]
+  value       = [aws_eip.nat.*.id]
 }
 
 output "nat_public_ips" {
   description = "List of public Elastic IPs created for AWS NAT Gateway"
-  value       = ["${aws_eip.nat.*.public_ip}"]
+  value       = [aws_eip.nat.*.public_ip]
 }
 
 output "natgw_ids" {
   description = "List of NAT Gateway IDs"
-  value       = ["${aws_nat_gateway.this.*.id}"]
+  value       = [aws_nat_gateway.this.*.id]
 }
 
 output "igw_id" {
   description = "The ID of the Internet Gateway"
-  value       = "${element(concat(aws_internet_gateway.this.*.id, list("")), 0)}"
+  value       = element(concat(aws_internet_gateway.this.*.id, [""]), 0)
 }
 
 output "vgw_id" {
   description = "The ID of the VPN Gateway"
-  value       = "${element(concat(aws_vpn_gateway.this.*.id, aws_vpn_gateway_attachment.this.*.vpn_gateway_id, list("")), 0)}"
+  value = element(
+    concat(
+      aws_vpn_gateway.this.*.id,
+      aws_vpn_gateway_attachment.this.*.vpn_gateway_id,
+      [""],
+    ),
+    0,
+  )
 }
 
 output "default_vpc_id" {
   description = "The ID of the VPC"
-  value       = "${element(concat(aws_default_vpc.this.*.id, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.id, [""]), 0)
 }
 
 output "default_vpc_cidr_block" {
   description = "The CIDR block of the VPC"
-  value       = "${element(concat(aws_default_vpc.this.*.cidr_block, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.cidr_block, [""]), 0)
 }
 
 output "default_vpc_default_security_group_id" {
   description = "The ID of the security group created by default on VPC creation"
-  value       = "${element(concat(aws_default_vpc.this.*.default_security_group_id, list("")), 0)}"
+  value = element(
+    concat(aws_default_vpc.this.*.default_security_group_id, [""]),
+    0,
+  )
 }
 
 output "default_vpc_default_network_acl_id" {
   description = "The ID of the default network ACL"
-  value       = "${element(concat(aws_default_vpc.this.*.default_network_acl_id, list("")), 0)}"
+  value = element(
+    concat(aws_default_vpc.this.*.default_network_acl_id, [""]),
+    0,
+  )
 }
 
 output "default_vpc_default_route_table_id" {
   description = "The ID of the default route table"
-  value       = "${element(concat(aws_default_vpc.this.*.default_route_table_id, list("")), 0)}"
+  value = element(
+    concat(aws_default_vpc.this.*.default_route_table_id, [""]),
+    0,
+  )
 }
 
 output "default_vpc_instance_tenancy" {
   description = "Tenancy of instances spin up within VPC"
-  value       = "${element(concat(aws_default_vpc.this.*.instance_tenancy, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.instance_tenancy, [""]), 0)
 }
 
 output "default_vpc_enable_dns_support" {
   description = "Whether or not the VPC has DNS support"
-  value       = "${element(concat(aws_default_vpc.this.*.enable_dns_support, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.enable_dns_support, [""]), 0)
 }
 
 output "default_vpc_enable_dns_hostnames" {
   description = "Whether or not the VPC has DNS hostname support"
-  value       = "${element(concat(aws_default_vpc.this.*.enable_dns_hostnames, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.enable_dns_hostnames, [""]), 0)
 }
 
 //output "default_vpc_enable_classiclink" {
@@ -245,7 +270,7 @@ output "default_vpc_enable_dns_hostnames" {
 
 output "default_vpc_main_route_table_id" {
   description = "The ID of the main route table associated with this VPC"
-  value       = "${element(concat(aws_default_vpc.this.*.main_route_table_id, list("")), 0)}"
+  value       = element(concat(aws_default_vpc.this.*.main_route_table_id, [""]), 0)
 }
 
 //output "default_vpc_ipv6_association_id" {
@@ -261,86 +286,87 @@ output "default_vpc_main_route_table_id" {
 # VPC Endpoints
 output "vpc_endpoint_s3_id" {
   description = "The ID of VPC endpoint for S3"
-  value       = "${element(concat(aws_vpc_endpoint.s3.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.s3.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_s3_pl_id" {
   description = "The prefix list for the S3 VPC endpoint."
-  value       = "${element(concat(aws_vpc_endpoint.s3.*.prefix_list_id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.s3.*.prefix_list_id, [""]), 0)
 }
 
 output "vpc_endpoint_dynamodb_id" {
   description = "The ID of VPC endpoint for DynamoDB"
-  value       = "${element(concat(aws_vpc_endpoint.dynamodb.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.dynamodb.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_dynamodb_pl_id" {
   description = "The prefix list for the DynamoDB VPC endpoint."
-  value       = "${element(concat(aws_vpc_endpoint.dynamodb.*.prefix_list_id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.dynamodb.*.prefix_list_id, [""]), 0)
 }
 
 output "vpc_endpoint_ssm_id" {
   description = "The ID of VPC endpoint for SSM"
-  value       = "${element(concat(aws_vpc_endpoint.ssm.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.ssm.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_ssm_network_interface_ids" {
   description = "One or more network interfaces for the VPC Endpoint for SSM."
-  value       = "${flatten(aws_vpc_endpoint.ssm.*.network_interface_ids)}"
+  value       = flatten(aws_vpc_endpoint.ssm.*.network_interface_ids)
 }
 
 output "vpc_endpoint_ssm_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for SSM."
-  value       = "${flatten(aws_vpc_endpoint.ssm.*.dns_entry)}"
+  value       = flatten(aws_vpc_endpoint.ssm.*.dns_entry)
 }
 
 output "vpc_endpoint_ssmmessages_id" {
   description = "The ID of VPC endpoint for SSMMESSAGES"
-  value       = "${element(concat(aws_vpc_endpoint.ssmmessages.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.ssmmessages.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_ssmmessages_network_interface_ids" {
   description = "One or more network interfaces for the VPC Endpoint for SSMMESSAGES."
-  value       = "${flatten(aws_vpc_endpoint.ssmmessages.*.network_interface_ids)}"
+  value       = flatten(aws_vpc_endpoint.ssmmessages.*.network_interface_ids)
 }
 
 output "vpc_endpoint_ssmmessages_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for SSMMESSAGES."
-  value       = "${flatten(aws_vpc_endpoint.ssmmessages.*.dns_entry)}"
+  value       = flatten(aws_vpc_endpoint.ssmmessages.*.dns_entry)
 }
 
 output "vpc_endpoint_ec2_id" {
   description = "The ID of VPC endpoint for EC2"
-  value       = "${element(concat(aws_vpc_endpoint.ec2.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.ec2.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_ec2_network_interface_ids" {
   description = "One or more network interfaces for the VPC Endpoint for EC2"
-  value       = "${flatten(aws_vpc_endpoint.ec2.*.network_interface_ids)}"
+  value       = flatten(aws_vpc_endpoint.ec2.*.network_interface_ids)
 }
 
 output "vpc_endpoint_ec2_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for EC2."
-  value       = "${flatten(aws_vpc_endpoint.ec2.*.dns_entry)}"
+  value       = flatten(aws_vpc_endpoint.ec2.*.dns_entry)
 }
 
 output "vpc_endpoint_ec2messages_id" {
   description = "The ID of VPC endpoint for EC2MESSAGES"
-  value       = "${element(concat(aws_vpc_endpoint.ec2messages.*.id, list("")), 0)}"
+  value       = element(concat(aws_vpc_endpoint.ec2messages.*.id, [""]), 0)
 }
 
 output "vpc_endpoint_ec2messages_network_interface_ids" {
   description = "One or more network interfaces for the VPC Endpoint for EC2MESSAGES"
-  value       = "${flatten(aws_vpc_endpoint.ec2messages.*.network_interface_ids)}"
+  value       = flatten(aws_vpc_endpoint.ec2messages.*.network_interface_ids)
 }
 
 output "vpc_endpoint_ec2messages_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for EC2MESSAGES."
-  value       = "${flatten(aws_vpc_endpoint.ec2messages.*.dns_entry)}"
+  value       = flatten(aws_vpc_endpoint.ec2messages.*.dns_entry)
 }
 
 # Static values (arguments)
 output "azs" {
   description = "A list of availability zones specified as argument to this module"
-  value       = "${var.azs}"
+  value       = var.azs
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -69,25 +69,25 @@ variable "private_subnets" {
 }
 
 variable "database_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "A list of database subnets"
   default     = []
 }
 
 variable "redshift_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "A list of redshift subnets"
   default     = []
 }
 
 variable "elasticache_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "A list of elasticache subnets"
   default     = []
 }
 
 variable "intra_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "A list of intra subnets"
   default     = []
 }
@@ -169,7 +169,7 @@ variable "reuse_nat_ips" {
 
 variable "external_nat_ip_ids" {
   description = "List of EIP IDs to be assigned to the NAT Gateways (used in combination with reuse_nat_ips)"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
@@ -355,107 +355,128 @@ variable "propagate_public_route_tables_vgw" {
 
 variable "tags" {
   description = "A map of tags to add to all resources"
-  default     = {}
+  default = {
+  }
 }
 
 variable "vpc_tags" {
   description = "Additional tags for the VPC"
-  default     = {}
+  default = {
+  }
 }
 
 variable "igw_tags" {
   description = "Additional tags for the internet gateway"
-  default     = {}
+  default = {
+  }
 }
 
 variable "public_subnet_tags" {
   description = "Additional tags for the public subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "private_subnet_tags" {
   description = "Additional tags for the private subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "public_route_table_tags" {
   description = "Additional tags for the public route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "private_route_table_tags" {
   description = "Additional tags for the private route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "database_route_table_tags" {
   description = "Additional tags for the database route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "redshift_route_table_tags" {
   description = "Additional tags for the redshift route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "elasticache_route_table_tags" {
   description = "Additional tags for the elasticache route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "intra_route_table_tags" {
   description = "Additional tags for the intra route tables"
-  default     = {}
+  default = {
+  }
 }
 
 variable "database_subnet_tags" {
   description = "Additional tags for the database subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "database_subnet_group_tags" {
   description = "Additional tags for the database subnet group"
-  default     = {}
+  default = {
+  }
 }
 
 variable "redshift_subnet_tags" {
   description = "Additional tags for the redshift subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "redshift_subnet_group_tags" {
   description = "Additional tags for the redshift subnet group"
-  default     = {}
+  default = {
+  }
 }
 
 variable "elasticache_subnet_tags" {
   description = "Additional tags for the elasticache subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "intra_subnet_tags" {
   description = "Additional tags for the intra subnets"
-  default     = {}
+  default = {
+  }
 }
 
 variable "dhcp_options_tags" {
   description = "Additional tags for the DHCP option set"
-  default     = {}
+  default = {
+  }
 }
 
 variable "nat_gateway_tags" {
   description = "Additional tags for the NAT gateways"
-  default     = {}
+  default = {
+  }
 }
 
 variable "nat_eip_tags" {
   description = "Additional tags for the NAT EIP"
-  default     = {}
+  default = {
+  }
 }
 
 variable "vpn_gateway_tags" {
   description = "Additional tags for the VPN gateway"
-  default     = {}
+  default = {
+  }
 }
 
 variable "enable_dhcp_options" {
@@ -470,19 +491,19 @@ variable "dhcp_options_domain_name" {
 
 variable "dhcp_options_domain_name_servers" {
   description = "Specify a list of DNS server addresses for DHCP options set, default to AWS provided"
-  type        = "list"
+  type        = list(string)
   default     = ["AmazonProvidedDNS"]
 }
 
 variable "dhcp_options_ntp_servers" {
   description = "Specify a list of NTP servers for DHCP options set"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "dhcp_options_netbios_name_servers" {
   description = "Specify a list of netbios servers for DHCP options set"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
@@ -518,5 +539,7 @@ variable "default_vpc_enable_classiclink" {
 
 variable "default_vpc_tags" {
   description = "Additional tags for the Default VPC"
-  default     = {}
+  default = {
+  }
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This issue is going to be marked as work in progress for a week or so to gather feedback from early adopters of Terraform 0.12.

If you are reading this and you don't want to gamble with your infrastructure, please lock the module version to be `~> 1.59.0` or `< 2.0.0`. Like this:
```
module "vpc" {
  source  = "terraform-aws-modules/vpc/aws"
  version = "~> 1.59.0"
}
```

This module as well as the majority of other [terraform-aws-modules](https://github.com/terraform-aws-modules) will support latest stable version of Terraform once it is available. You will always be able to use previous/current versions of this module if you don't want to upgrade to Terraform 0.12.

This module will be working in Terraform 0.11 and will be supported also for some time, while there is no guarantee that all new features will be available in both versions of this module.