### PR TITLE
Allow ICMP Network ACL rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.8.1
+  rev: v1.19.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.1.0
+  rev: v2.3.0
   hooks:
     - id: check-merge-conflict

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -96,6 +96,14 @@ locals {
         protocol    = "tcp"
         cidr_block  = "0.0.0.0/0"
       },
+      {
+        rule_number = 140
+        rule_action = "allow"
+        icmp_code   = -1
+        icmp_type   = 0
+        protocol    = "icmp"
+        cidr_block  = "10.0.1.0/22"
+      },
     ]
 
     public_outbound = [
@@ -130,6 +138,14 @@ locals {
         to_port     = 22
         protocol    = "tcp"
         cidr_block  = "10.0.100.0/22"
+      },
+      {
+        rule_number = 140
+        rule_action = "allow"
+        icmp_code   = -1
+        icmp_type   = 8
+        protocol    = "icmp"
+        cidr_block  = "10.0.1.0/22"
       },
     ]
   }

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -14,11 +14,13 @@ module "vpc" {
   public_subnets      = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
   elasticache_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
 
-  public_dedicated_network_acl = true
-  public_inbound_acl_rules     = "${concat(local.network_acls["default_inbound"], local.network_acls["public_inbound"])}"
-  public_outbound_acl_rules    = "${concat(local.network_acls["default_outbound"], local.network_acls["public_outbound"])}"
+  public_dedicated_network_acl   = true
+  public_inbound_acl_rules       = "${concat(local.network_acls["default_inbound"], local.network_acls["public_inbound"])}"
+  public_outbound_acl_rules      = "${concat(local.network_acls["default_outbound"], local.network_acls["public_outbound"])}"
+  elasticache_outbound_acl_rules = "${concat(local.network_acls["default_outbound"], local.network_acls["elasticache_outbound"])}"
 
-  private_dedicated_network_acl = true
+  private_dedicated_network_acl     = true
+  elasticache_dedicated_network_acl = true
 
   assign_generated_ipv6_cidr_block = true
 
@@ -102,7 +104,7 @@ locals {
         icmp_code   = -1
         icmp_type   = 0
         protocol    = "icmp"
-        cidr_block  = "10.0.1.0/22"
+        cidr_block  = "10.0.0.0/22"
       },
     ]
 
@@ -145,7 +147,34 @@ locals {
         icmp_code   = -1
         icmp_type   = 8
         protocol    = "icmp"
-        cidr_block  = "10.0.1.0/22"
+        cidr_block  = "10.0.0.0/22"
+      },
+    ]
+
+    elasticache_outbound = [
+      {
+        rule_number = 100
+        rule_action = "allow"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+      },
+      {
+        rule_number = 110
+        rule_action = "allow"
+        from_port   = 443
+        to_port     = 443
+        protocol    = "tcp"
+        cidr_block  = "0.0.0.0/0"
+      },
+      {
+        rule_number = 140
+        rule_action = "allow"
+        icmp_code   = -1
+        icmp_type   = 12
+        protocol    = "icmp"
+        cidr_block  = "10.0.0.0/22"
       },
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -322,10 +322,12 @@ resource "aws_network_acl_rule" "public_inbound" {
   egress      = false
   rule_number = "${lookup(var.public_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.public_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.public_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.public_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.public_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.public_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.public_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.public_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.public_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.public_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "public_outbound" {
@@ -336,10 +338,12 @@ resource "aws_network_acl_rule" "public_outbound" {
   egress      = true
   rule_number = "${lookup(var.public_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.public_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.public_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.public_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.public_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.public_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.public_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.public_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.public_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.public_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 #######################
@@ -362,10 +366,12 @@ resource "aws_network_acl_rule" "private_inbound" {
   egress      = false
   rule_number = "${lookup(var.private_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.private_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.private_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.private_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.private_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.private_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.private_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.private_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.private_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.private_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "private_outbound" {
@@ -376,10 +382,12 @@ resource "aws_network_acl_rule" "private_outbound" {
   egress      = true
   rule_number = "${lookup(var.private_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.private_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.private_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.private_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.private_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.private_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.private_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.private_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.private_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.private_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 ########################
@@ -402,10 +410,12 @@ resource "aws_network_acl_rule" "intra_inbound" {
   egress      = false
   rule_number = "${lookup(var.intra_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.intra_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.intra_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.intra_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.intra_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.intra_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.intra_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.intra_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.intra_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.intra_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "intra_outbound" {
@@ -416,10 +426,12 @@ resource "aws_network_acl_rule" "intra_outbound" {
   egress      = true
   rule_number = "${lookup(var.intra_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.intra_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.intra_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.intra_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.intra_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.intra_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.intra_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.intra_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.intra_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.intra_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 ########################

--- a/main.tf
+++ b/main.tf
@@ -454,10 +454,12 @@ resource "aws_network_acl_rule" "database_inbound" {
   egress      = false
   rule_number = "${lookup(var.database_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.database_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.database_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.database_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.database_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.database_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.database_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.database_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.database_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.database_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "database_outbound" {
@@ -468,10 +470,12 @@ resource "aws_network_acl_rule" "database_outbound" {
   egress      = true
   rule_number = "${lookup(var.database_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.database_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.database_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.database_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.database_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.database_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.database_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.database_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.database_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.database_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 ########################
@@ -494,10 +498,12 @@ resource "aws_network_acl_rule" "redshift_inbound" {
   egress      = false
   rule_number = "${lookup(var.redshift_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.redshift_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.redshift_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.redshift_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.redshift_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.redshift_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.redshift_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.redshift_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.redshift_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.redshift_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "redshift_outbound" {
@@ -508,10 +514,12 @@ resource "aws_network_acl_rule" "redshift_outbound" {
   egress      = true
   rule_number = "${lookup(var.redshift_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.redshift_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.redshift_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.redshift_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.redshift_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.redshift_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.redshift_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.redshift_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.redshift_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.redshift_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 ###########################
@@ -534,10 +542,12 @@ resource "aws_network_acl_rule" "elasticache_inbound" {
   egress      = false
   rule_number = "${lookup(var.elasticache_inbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.elasticache_inbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.elasticache_inbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.elasticache_inbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.elasticache_inbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.elasticache_inbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.elasticache_inbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.elasticache_inbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.elasticache_inbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.elasticache_inbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 resource "aws_network_acl_rule" "elasticache_outbound" {
@@ -548,10 +558,12 @@ resource "aws_network_acl_rule" "elasticache_outbound" {
   egress      = true
   rule_number = "${lookup(var.elasticache_outbound_acl_rules[count.index], "rule_number")}"
   rule_action = "${lookup(var.elasticache_outbound_acl_rules[count.index], "rule_action")}"
-  from_port   = "${lookup(var.elasticache_outbound_acl_rules[count.index], "from_port")}"
-  to_port     = "${lookup(var.elasticache_outbound_acl_rules[count.index], "to_port")}"
+  from_port   = "${lookup(var.elasticache_outbound_acl_rules[count.index], "from_port", "-1")}"
+  to_port     = "${lookup(var.elasticache_outbound_acl_rules[count.index], "to_port", "-1")}"
   protocol    = "${lookup(var.elasticache_outbound_acl_rules[count.index], "protocol")}"
   cidr_block  = "${lookup(var.elasticache_outbound_acl_rules[count.index], "cidr_block")}"
+  icmp_type   = "${lookup(var.elasticache_outbound_acl_rules[count.index], "icmp_type", "-1")}"
+  icmp_code   = "${lookup(var.elasticache_outbound_acl_rules[count.index], "icmp_code", "-1")}"
 }
 
 ##############


### PR DESCRIPTION
Updating VPC module to allow ICMP Network ACL rules.  Since from_port and to_port are ignored for ICMP rules, allowing user to leave these fields off makes sense.  We could make this more complicated and require from_port and to_port if protocol is not ICMP but that would make the module less readable.