### PR TITLE
Improving DHCP options docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `"true"` | no |
 | default\_vpc\_name | Name to be used on the Default VPC | string | `""` | no |
 | default\_vpc\_tags | Additional tags for the Default VPC | map | `{}` | no |
-| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set (requires `enable_dhcp_options` set to `true`) | string | `""` | no |
-| dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires `enable_dhcp_options` set to `true`) | list | `[ "AmazonProvidedDNS" ]` | no |
-| dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set (requires `enable_dhcp_options` set to `true`) | list | `[]` | no |
-| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set (requires `enable_dhcp_options` set to `true`) | string | `""` | no |
-| dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set (requires `enable_dhcp_options` set to `true`) | list | `[]` | no |
-| dhcp\_options\_tags | Additional tags for the DHCP option set (requires `enable_dhcp_options` set to `true`) | map | `{}` | no |
+| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set (requires enable_dhcp_options set to true) | string | `""` | no |
+| dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true) | list | `[ "AmazonProvidedDNS" ]` | no |
+| dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set (requires enable_dhcp_options set to true) | list | `[]` | no |
+| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set (requires enable_dhcp_options set to true) | string | `""` | no |
+| dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set (requires enable_dhcp_options set to true) | list | `[]` | no |
+| dhcp\_options\_tags | Additional tags for the DHCP option set (requires enable_dhcp_options set to true) | map | `{}` | no |
 | ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `"false"` | no |
 | ec2\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 endpoint | list | `[]` | no |
 | ec2\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Terraform version 0.10.3 or newer is required for this module to work.
 | default\_vpc\_enable\_dns\_support | Should be true to enable DNS support in the Default VPC | string | `"true"` | no |
 | default\_vpc\_name | Name to be used on the Default VPC | string | `""` | no |
 | default\_vpc\_tags | Additional tags for the Default VPC | map | `{}` | no |
-| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set | string | `""` | no |
-| dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided | list | `[ "AmazonProvidedDNS" ]` | no |
-| dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set | list | `[]` | no |
-| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set | string | `""` | no |
-| dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set | list | `[]` | no |
-| dhcp\_options\_tags | Additional tags for the DHCP option set | map | `{}` | no |
+| dhcp\_options\_domain\_name | Specifies DNS name for DHCP options set (requires `enable_dhcp_options` set to `true`) | string | `""` | no |
+| dhcp\_options\_domain\_name\_servers | Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires `enable_dhcp_options` set to `true`) | list | `[ "AmazonProvidedDNS" ]` | no |
+| dhcp\_options\_netbios\_name\_servers | Specify a list of netbios servers for DHCP options set (requires `enable_dhcp_options` set to `true`) | list | `[]` | no |
+| dhcp\_options\_netbios\_node\_type | Specify netbios node_type for DHCP options set (requires `enable_dhcp_options` set to `true`) | string | `""` | no |
+| dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set (requires `enable_dhcp_options` set to `true`) | list | `[]` | no |
+| dhcp\_options\_tags | Additional tags for the DHCP option set (requires `enable_dhcp_options` set to `true`) | map | `{}` | no |
 | ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | string | `"false"` | no |
 | ec2\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 endpoint | list | `[]` | no |
 | ec2\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -490,7 +490,7 @@ variable "elasticache_acl_tags" {
 }
 
 variable "dhcp_options_tags" {
-  description = "Additional tags for the DHCP option set"
+  description = "Additional tags for the DHCP option set (requires enable_dhcp_options set to true)"
   default     = {}
 }
 
@@ -515,30 +515,30 @@ variable "enable_dhcp_options" {
 }
 
 variable "dhcp_options_domain_name" {
-  description = "Specifies DNS name for DHCP options set"
+  description = "Specifies DNS name for DHCP options set (requires enable_dhcp_options set to true)"
   default     = ""
 }
 
 variable "dhcp_options_domain_name_servers" {
-  description = "Specify a list of DNS server addresses for DHCP options set, default to AWS provided"
+  description = "Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
 
   default = ["AmazonProvidedDNS"]
 }
 
 variable "dhcp_options_ntp_servers" {
-  description = "Specify a list of NTP servers for DHCP options set"
+  description = "Specify a list of NTP servers for DHCP options set (requires enable_dhcp_options set to true)"
 
   default = []
 }
 
 variable "dhcp_options_netbios_name_servers" {
-  description = "Specify a list of netbios servers for DHCP options set"
+  description = "Specify a list of netbios servers for DHCP options set (requires enable_dhcp_options set to true)"
 
   default = []
 }
 
 variable "dhcp_options_netbios_node_type" {
-  description = "Specify netbios node_type for DHCP options set"
+  description = "Specify netbios node_type for DHCP options set (requires enable_dhcp_options set to true)"
   default     = ""
 }
 


### PR DESCRIPTION
Clarifying that `enable_dhcp_options` is required when specifying `dhcp_options_*` variables.