### PR TITLE
Added basic support for an Ubuntu 18.04 NAT instance gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ This module supports three scenarios for creating NAT gateways. Each will be exp
 
 If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, then `single_nat_gateway` takes precedence.
 
+## NAT Instance Gateway
+
+This module also supports the use of an Ubuntu 18.04 NAT instance gateway. To use a NAT instance:
+
+* Create a keypair, and upload that to EC2. Note the name.
+* Configure the following settings:
+
+```
+nat_instance = true
+nat_instance_type = "t2.small"
+nat_instance_keypair = "NAME-OF-KEYPAIR-IN-EC2"
+enable_nat_gateway = false
+single_nat_gateway = false
+one_nat_gateway_per_az = false
+```
+
+Setting `nat_instance = false` will remove the NAT instance gateway.
+
 ### One NAT Gateway per subnet (default)
 
 By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway.  For example, if your configuration looks like the following:

--- a/variables.tf
+++ b/variables.tf
@@ -194,6 +194,24 @@ variable "one_nat_gateway_per_az" {
   default     = false
 }
 
+variable "nat_instance" {
+  description = "Should be true if you want to provision a single NAT instance."
+  type        = bool
+  default     = false
+}
+
+variable "nat_instance_type" {
+  description = "The instance type/size to use. Defaults to a t2.micro"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "nat_instance_keypair" {
+  description = "The AWS EC2 SSH keypair to use. Needs to be created first."
+  type        = string
+  default     = ""
+}
+
 variable "reuse_nat_ips" {
   description = "Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external_nat_ip_ids' variable"
   type        = bool


### PR DESCRIPTION
# Description

This PR attempts to address #250 .

It adds support for a NAT instance gateway, using Ubuntu 18.04 as the AMI. Note that it requires an AWS keypair to be created and named first. 

Hopefully the conditionals are sound, I did test back and forth going from an AWS managed NAT gateway to an instance, and it seemed to work well.