### PR TITLE
Abstract simple-vpc module attributes into variables with defaults

### DIFF
--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -10,11 +10,11 @@ data "aws_security_group" "default" {
 module "vpc" {
   source = "../../"
 
-  name = "simple-example"
+  name = var.vpc_name
 
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = var.azs
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
@@ -23,17 +23,7 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
-  public_subnet_tags = {
-    Name = "overridden-name-public"
-  }
-
-  tags = {
-    Owner       = "user"
-    Environment = "dev"
-  }
-
-  vpc_tags = {
-    Name = "vpc-name"
-  }
+  public_subnet_tags = var.public_subnet_tags
+  vpc_tags           = var.vpc_tags
+  tags               = var.tags
 }
-

--- a/examples/simple-vpc/variables.tf
+++ b/examples/simple-vpc/variables.tf
@@ -1,0 +1,36 @@
+# VPC Name
+variable "vpc_name" {
+  type    = string
+  default = "simple-example"
+}
+
+# AZs
+variable "azs" {
+  type    = list(string)
+  default = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}
+
+# Public Subnet Tags
+variable "public_subnet_tags" {
+  type = map
+  default = {
+    Name = "overridden-name-public"
+  }
+}
+
+# VPC Tags
+variable "vpc_tags" {
+  type = map
+  default = {
+    Name = "vpc-name"
+  }
+}
+
+# Tags
+variable "tags" {
+  type = map
+  default = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}


### PR DESCRIPTION
# Description

The simple-vpc example is super useful! I know it's meant to be an example, but users may not want the default availability zones, or a couple of other variables so I abstracted them into variables.

There is no change to deployment if variables aren't specified.