### PR TITLE
Add IPv6 support (Terraform 0.12 edition)

### DIFF
--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source             = "../.."
+  name               = "ipv6"
+  cidr               = "10.0.0.0/16"
+  azs                = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
+  private_subnets    = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
+  enable_nat_gateway = false
+
+  enable_ipv6                      = true
+  assign_generated_ipv6_cidr_block = true
+  assign_ipv6_address_on_creation  = true
+  public_subnet_ipv6_prefixes      = [0, 1]
+  private_subnet_ipv6_prefixes     = [2, 3]
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -14,7 +14,6 @@ module "vpc" {
   enable_nat_gateway = false
 
   enable_ipv6                      = true
-  assign_generated_ipv6_cidr_block = true
   assign_ipv6_address_on_creation  = true
   public_subnet_ipv6_prefixes      = [0, 1]
   private_subnet_ipv6_prefixes     = [2, 3]

--- a/examples/ipv6/outputs.tf
+++ b/examples/ipv6/outputs.tf
@@ -1,0 +1,15 @@
+# VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = "${module.vpc.vpc_id}"
+}
+
+output "ipv6_association_id" {
+  description = "The IPv6 CIDR block"
+  value       = ["${module.vpc.vpc_ipv6_cidr_block}"]
+}
+
+output "ipv6_cidr_block" {
+  description = "The association ID for the IPv6 CIDR block"
+  value       = ["${module.vpc.vpc_ipv6_association_id}"]
+}

--- a/examples/ipv6/variables.tf
+++ b/examples/ipv6/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+  default = "eu-west-1"
+}

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_vpc" "this" {
 resource "aws_vpc_ipv4_cidr_block_association" "this" {
   count = var.create_vpc && length(var.secondary_cidr_blocks) > 0 ? length(var.secondary_cidr_blocks) : 0
 
-  vpc_id = aws_vpc.this[0].id
+  vpc_id = element(concat(aws_vpc.this.*.id, [""]), 0)
 
   cidr_block = element(var.secondary_cidr_blocks, count.index)
 }
@@ -95,6 +95,12 @@ resource "aws_internet_gateway" "this" {
   )
 }
 
+resource "aws_egress_only_internet_gateway" "this" {
+  count = var.enable_ipv6 && length(var.database_subnets) + length(var.private_subnets) > 0 ? 1 : 0
+
+  vpc_id = element(concat(aws_vpc.this.*.id, [""]), 0)
+}
+
 ################
 # Publiс routes
 ################
@@ -122,6 +128,14 @@ resource "aws_route" "public_internet_gateway" {
   timeouts {
     create = "5m"
   }
+}
+
+resource "aws_route" "public_internet_gateway_ipv6" {
+  count = var.create_vpc && var.enable_ipv6 && length(var.public_subnets) > 0 ? 1 : 0
+
+  route_table_id              = aws_route_table.public[0].id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.this[0].id
 }
 
 #################
@@ -193,6 +207,14 @@ resource "aws_route" "database_nat_gateway" {
   }
 }
 
+resource "aws_route" "database_ipv6_egress" {
+  count = var.enable_ipv6 ? length(var.database_subnets) : 0
+
+  route_table_id              = element(aws_route_table.database.*.id, count.index)
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this.*.id, 0)
+}
+
 #################
 # Redshift routes
 #################
@@ -250,10 +272,14 @@ resource "aws_route_table" "intra" {
 resource "aws_subnet" "public" {
   count = var.create_vpc && length(var.public_subnets) > 0 && (false == var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0
 
-  vpc_id                  = local.vpc_id
-  cidr_block              = element(concat(var.public_subnets, [""]), count.index)
-  availability_zone       = element(var.azs, count.index)
-  map_public_ip_on_launch = var.map_public_ip_on_launch
+  vpc_id                          = local.vpc_id
+  cidr_block                      = element(concat(var.public_subnets, [""]), count.index)
+  availability_zone               = element(var.azs, count.index)
+  map_public_ip_on_launch         = var.map_public_ip_on_launch
+  assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
+
+  # TODO: Does not unset, need null support or the like see: Terraform 0.12
+  ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.public_subnet_ipv6_prefixes, list("0")), count.index)) : ""
 
   tags = merge(
     {
@@ -274,9 +300,13 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   count = var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.private_subnets[count.index]
-  availability_zone = element(var.azs, count.index)
+  vpc_id                          = local.vpc_id
+  cidr_block                      = var.private_subnets[count.index]
+  availability_zone               = element(var.azs, count.index)
+  assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
+
+  # TODO: Does not unset, need null support or the like see: Terraform 0.12
+  ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0  ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(coalescelist(var.private_subnet_ipv6_prefixes, list("0")), count.index)) : ""
 
   tags = merge(
     {
@@ -297,9 +327,13 @@ resource "aws_subnet" "private" {
 resource "aws_subnet" "database" {
   count = var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.database_subnets[count.index]
-  availability_zone = element(var.azs, count.index)
+  vpc_id                          = local.vpc_id
+  cidr_block                      = var.database_subnets[count.index]
+  availability_zone               = element(var.azs, count.index)
+  assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
+
+  # TODO: Does not unset, need null support or the like see: Terraform 0.12
+  ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.database_subnet_ipv6_prefixes, list("0")), count.index)) : ""
 
   tags = merge(
     {
@@ -409,6 +443,9 @@ resource "aws_subnet" "intra" {
   vpc_id            = local.vpc_id
   cidr_block        = var.intra_subnets[count.index]
   availability_zone = element(var.azs, count.index)
+
+  # TODO: Does not unset, need null support or the like see: Terraform 0.12
+  ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.intra_subnet_ipv6_prefixes, list("0")), count.index)) : ""
 
   tags = merge(
     {
@@ -822,6 +859,14 @@ resource "aws_route" "private_nat_gateway" {
   timeouts {
     create = "5m"
   }
+}
+
+resource "aws_route" "private_ipv6_egress" {
+  count = var.enable_ipv6 ? length(var.private_subnets) : 0
+
+  route_table_id              = element(aws_route_table.private.*.id, count.index)
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this.*.id, 0)
 }
 
 ######################

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_vpc" "this" {
   instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames
   enable_dns_support               = var.enable_dns_support
-  assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
+  assign_generated_ipv6_cidr_block = var.enable_ipv6
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_vpc" "this" {
 resource "aws_vpc_ipv4_cidr_block_association" "this" {
   count = var.create_vpc && length(var.secondary_cidr_blocks) > 0 ? length(var.secondary_cidr_blocks) : 0
 
-  vpc_id = element(concat(aws_vpc.this.*.id, [""]), 0)
+  vpc_id = aws_vpc.this[0].id
 
   cidr_block = element(var.secondary_cidr_blocks, count.index)
 }

--- a/main.tf
+++ b/main.tf
@@ -278,8 +278,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
 
-  # TODO: Does not unset, need null support or the like see: Terraform 0.12
-  ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.public_subnet_ipv6_prefixes, list("0")), count.index)) : ""
+  ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.public_subnet_ipv6_prefixes, list("0")), count.index)) : null
 
   tags = merge(
     {
@@ -305,8 +304,7 @@ resource "aws_subnet" "private" {
   availability_zone               = element(var.azs, count.index)
   assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
 
-  # TODO: Does not unset, need null support or the like see: Terraform 0.12
-  ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0  ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(coalescelist(var.private_subnet_ipv6_prefixes, list("0")), count.index)) : ""
+  ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0  ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(coalescelist(var.private_subnet_ipv6_prefixes, list("0")), count.index)) : null
 
   tags = merge(
     {
@@ -332,8 +330,7 @@ resource "aws_subnet" "database" {
   availability_zone               = element(var.azs, count.index)
   assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
 
-  # TODO: Does not unset, need null support or the like see: Terraform 0.12
-  ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.database_subnet_ipv6_prefixes, list("0")), count.index)) : ""
+  ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.database_subnet_ipv6_prefixes, list("0")), count.index)) : null
 
   tags = merge(
     {
@@ -444,8 +441,7 @@ resource "aws_subnet" "intra" {
   cidr_block        = var.intra_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
-  # TODO: Does not unset, need null support or the like see: Terraform 0.12
-  ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.intra_subnet_ipv6_prefixes, list("0")), count.index)) : ""
+  ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, element(concat(var.intra_subnet_ipv6_prefixes, list("0")), count.index)) : null
 
   tags = merge(
     {

--- a/outputs.tf
+++ b/outputs.tf
@@ -630,21 +630,21 @@ output "ipv6_egress_only_igw_id" {
 }
 
 output "public_subnets_ipv6_cidr_blocks" {
-  description = "List of ipv6 cidr_blocks of public subnets in an ipv6 enabled VPC"
+  description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
   value       = aws_subnet.public.*.ipv6_cidr_block
 }
 
 output "private_subnets_ipv6_cidr_blocks" {
-  description = "List of ipv6 cidr_blocks of private subnets in an ipv6 enabled VPC"
+  description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
   value       = aws_subnet.private.*.ipv6_cidr_block
 }
 
 output "database_subnets_ipv6_cidr_blocks" {
-  description = "List of ipv6 cidr_blocks of database subnets in an ipv6 enabled VPC"
+  description = "List of IPv6 cidr_blocks of database subnets in an IPv6 enabled VPC"
   value       = aws_subnet.database.*.ipv6_cidr_block
 }
 
 output "intra_subnets_ipv6_cidr_blocks" {
-  description = "List of ipv6 cidr_blocks of intra subnets in an ipv6 enabled VPC"
+  description = "List of IPv6 cidr_blocks of intra subnets in an IPv6 enabled VPC"
   value       = aws_subnet.intra.*.ipv6_cidr_block
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,15 +53,15 @@ output "vpc_main_route_table_id" {
   value       = concat(aws_vpc.this.*.main_route_table_id, [""])[0]
 }
 
-//output "vpc_ipv6_association_id" {
-//  description = "The association ID for the IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)}"
-//}
-//
-//output "vpc_ipv6_cidr_block" {
-//  description = "The IPv6 CIDR block"
-//  value       = "${element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)}"
-//}
+output "vpc_ipv6_association_id" {
+  description = "The association ID for the IPv6 CIDR block"
+  value       = element(concat(aws_vpc.this.*.ipv6_association_id, list("")), 0)
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = element(concat(aws_vpc.this.*.ipv6_cidr_block, list("")), 0)
+}
 
 output "vpc_secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks of the VPC"
@@ -624,3 +624,27 @@ output "azs" {
   value       = var.azs
 }
 
+output "ipv6_egress_only_igw_id" {
+  description = "The ID of the egress only Internet Gateway"
+  value       = element(concat(aws_egress_only_internet_gateway.this.*.id, list("")), 0)
+}
+
+output "public_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of public subnets in an ipv6 enabled VPC"
+  value       = aws_subnet.public.*.ipv6_cidr_block
+}
+
+output "private_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of private subnets in an ipv6 enabled VPC"
+  value       = aws_subnet.private.*.ipv6_cidr_block
+}
+
+output "database_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of database subnets in an ipv6 enabled VPC"
+  value       = aws_subnet.database.*.ipv6_cidr_block
+}
+
+output "intra_subnets_ipv6_cidr_blocks" {
+  description = "List of ipv6 cidr_blocks of intra subnets in an ipv6 enabled VPC"
+  value       = aws_subnet.intra.*.ipv6_cidr_block
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,36 +21,36 @@ variable "assign_generated_ipv6_cidr_block" {
 }
 
 variable "enable_ipv6" {
-  description = "Assigns ipv6 subnets and routes"
+  description = "Assigns IPv6 subnets and routes"
   default     = false
 }
 
 variable "private_subnet_ipv6_prefixes" {
-  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  description = "Assigns IPv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   default     = []
   type        = "list"
 }
 
 variable "public_subnet_ipv6_prefixes" {
-  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  description = "Assigns IPv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   default     = []
   type        = "list"
 }
 
 variable "database_subnet_ipv6_prefixes" {
-  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  description = "Assigns IPv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   default     = []
   type        = "list"
 }
 
 variable "intra_subnet_ipv6_prefixes" {
-  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  description = "Assigns IPv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   default     = []
   type        = "list"
 }
 
 variable "assign_ipv6_address_on_creation" {
-  description = "Assign ipv6 address on subnet, must be disabled to change ipv6 cidrs. This is the ipv6 equivalent of map_public_ip_on_launch"
+  description = "Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   default     = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,40 @@ variable "assign_generated_ipv6_cidr_block" {
   default     = false
 }
 
+variable "enable_ipv6" {
+  description = "Assigns ipv6 subnets and routes"
+  default     = false
+}
+
+variable "private_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "public_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "database_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "intra_subnet_ipv6_prefixes" {
+  description = "Assigns ipv6 subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding ipv4 subnet list"
+  default     = []
+  type        = "list"
+}
+
+variable "assign_ipv6_address_on_creation" {
+  description = "Assign ipv6 address on subnet, must be disabled to change ipv6 cidrs. This is the ipv6 equivalent of map_public_ip_on_launch"
+  default     = false
+}
+
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)


### PR DESCRIPTION
Add variable `enable_ipv6` to allow enabling IPv6 support (resulting in passing `assign_generated_ipv6_cidr_block` to `aws_vpc`).

Enabling IPv6 support further results in an egress-only internet gateway being provisioned and routing tables of subnets being adjusted.

Additional variables allow to choose the indices out of the /64 subnet based on the assigned /56 range.

This is based on @bcenker's work in #16 as well as @dekimsey's on #218, but based on a clean master branch (after the Terraform 0.12 upgrade).