### PR TITLE
[WIP] Ignore tag changes for vpc and subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,10 @@ resource "aws_vpc_dhcp_options" "this" {
     var.tags,
     var.dhcp_options_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 ###############################
@@ -266,6 +270,10 @@ resource "aws_subnet" "public" {
     var.tags,
     var.public_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 #################
@@ -289,6 +297,10 @@ resource "aws_subnet" "private" {
     var.tags,
     var.private_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 ##################
@@ -312,6 +324,10 @@ resource "aws_subnet" "database" {
     var.tags,
     var.database_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_db_subnet_group" "database" {
@@ -351,6 +367,10 @@ resource "aws_subnet" "redshift" {
     var.tags,
     var.redshift_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_redshift_subnet_group" "redshift" {
@@ -390,6 +410,10 @@ resource "aws_subnet" "elasticache" {
     var.tags,
     var.elasticache_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
@@ -421,6 +445,10 @@ resource "aws_subnet" "intra" {
     var.tags,
     var.intra_subnet_tags,
   )
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 #######################


### PR DESCRIPTION
More and more services in aws (for example EKS) create tags on existing resources for proper working. Upon Terraform run, those tags are removed as they where not in the original template.
This patch is a tradeoff between usability and user friendliness.

After applying this patch it will create the tags who are defined in the landscape.tf but who are not yet in the state file. If the tag is not defined in the landscape file it wont remove it nor will it try to change tags if it is changed in aws but not in the landscape file. Once set they are now unmanaged.
