### PR TITLE
Adding IPv6 assign on creation for public subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Sometimes it is handy to have public access to Redshift clusters (for example if
 | apigw\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for API GW  endpoint | list(string) | `[]` | no |
 | apigw\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for API GW endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list(string) | `[]` | no |
 | assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | bool | `"false"` | no |
+| assign\_ipv6\_address\_on\_creation | (Optional) Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`. | bool | `"false"` | no |
 | azs | A list of availability zones in the region | list(string) | `[]` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `"0.0.0.0/0"` | no |
 | cloudtrail\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudTrail endpoint | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Sometimes it is handy to have public access to Redshift clusters (for example if
 | apigw\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for API GW  endpoint | list(string) | `[]` | no |
 | apigw\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for API GW endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list(string) | `[]` | no |
 | assign\_generated\_ipv6\_cidr\_block | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block | bool | `"false"` | no |
-| assign\_ipv6\_address\_on\_creation | (Optional) Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`. | bool | `"false"` | no |
+| assign\_ipv6\_address\_on\_creation | Specify `true` to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`. | bool | `"false"` | no |
 | azs | A list of availability zones in the region | list(string) | `[]` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | string | `"0.0.0.0/0"` | no |
 | cloudtrail\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudTrail endpoint | bool | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,4 @@
 locals {
-  # Check if IPv6 was enabled for this VPC. Only allow if `assign_generated_ipv6_cidr_block` was true as well.
-  assign_ipv6_address_on_creation = var.assign_generated_ipv6_cidr_block && var.assign_ipv6_address_on_creation ? true : false
-
   max_subnet_length = max(
     length(var.private_subnets),
     length(var.elasticache_subnets),
@@ -258,7 +255,7 @@ resource "aws_subnet" "public" {
   cidr_block                      = element(concat(var.public_subnets, [""]), count.index)
   availability_zone               = element(var.azs, count.index)
   map_public_ip_on_launch         = var.map_public_ip_on_launch
-  assign_ipv6_address_on_creation = local.assign_ipv6_address_on_creation
+  assign_ipv6_address_on_creation = var.assign_ipv6_address_on_creation
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "assign_generated_ipv6_cidr_block" {
   default     = false
 }
 
+variable "assign_ipv6_address_on_creation" {
+  description = "(Optional) Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`."
+  default     = false
+  type        = bool
+}
+
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)
@@ -1384,4 +1390,3 @@ variable "elasticache_outbound_acl_rules" {
     },
   ]
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "assign_generated_ipv6_cidr_block" {
 }
 
 variable "assign_ipv6_address_on_creation" {
-  description = "(Optional) Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`."
+  description = "Specify `true` to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`."
   default     = false
   type        = bool
 }


### PR DESCRIPTION
Allows the user to toggle automatic assignment of IPv6 addresses to public subnets.

## Description
Solves issue https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/185. Basically, this is a mini-feature until https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/300 is fully approved and merged.

Currently, creation of IPv6 blocks on subnets is a manual process. This makes sure that any of those manual assignments done via the AWS console are **not** overridden upon running `terraform apply`.

## Motivation and Context
Currently I have public subnets that are assigning IPv6 addresses to instances already, and would like if I could apply Terraform updates without this setting being set to `false` each time.

Also, I understand that https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/300 is also using this `assign_ipv6_address_on_creation` on private / database subnets as well, but as I understand it, this module creates those subnets with the intention to be private-only (i.e. IPv4). Since all IPv6 are publicly routable, I figured it made sense to only put them on public subnets in this PR.

## How Has This Been Tested?
- Ran locally against current VPC with public IPv6-enabled subnets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.