### PR TITLE
Add subnets and tagging for EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ Since AWS Lambda functions allocate Elastic Network Interfaces in proportion to 
 
 You can add additional tags with `intra_subnet_tags` as with other subnet types.
 
+## EKS (Kubernetes) Resource Tagging and Subnets
+
+When `enable_eks_resource_tags` is set to `true`, resources will be tagged according to the required structure for Amazon Elastic Kubernetes Service ([read more](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#vpc-tagging)).
+
+If `eks_cluster_name` is provided, cluster specific tags will also be applied.
+
+Tagging will be applied as follows:
+
+| Resource | Tag Name | Value |
+| :------- | :------ | ---: |
+| vpc | kubernetes.io/cluster/<cluster-name> | shared |
+| public_subnets | kubernetes.io/role/elb | 1 |
+| private_subnets | kubernetes.io/role/internal-elb | 1 |
+| eks_worker_subnets | kubernetes.io/cluster/<cluster-name> | shared |
+
+
+
 ## Conditional creation
 
 Sometimes you need to have a way to create VPC resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_vpc`.

--- a/outputs.tf
+++ b/outputs.tf
@@ -198,6 +198,26 @@ output "intra_subnets_ipv6_cidr_blocks" {
   value       = aws_subnet.intra.*.ipv6_cidr_block
 }
 
+output "eks_worker_subnets" {
+  description = "List of IDs of eks_worker subnets"
+  value       = aws_subnet.eks_worker.*.id
+}
+
+output "eks_worker_subnet_arns" {
+  description = "List of ARNs of eks_worker subnets"
+  value       = aws_subnet.eks_worker.*.arn
+}
+
+output "eks_worker_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of eks_worker subnets"
+  value       = aws_subnet.eks_worker.*.cidr_block
+}
+
+output "eks_worker_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of eks_worker subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.eks_worker.*.ipv6_cidr_block
+}
+
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
   value       = concat(aws_elasticache_subnet_group.elasticache.*.id, [""])[0]

--- a/variables.tf
+++ b/variables.tf
@@ -1746,3 +1746,44 @@ variable "elasticache_outbound_acl_rules" {
   ]
 }
 
+variable "eks_worker_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 EKS Worker Node subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list
+  default     = []
+}
+
+variable "eks_worker_subnet_assign_ipv6_address_on_creation" {
+  description = "Assign IPv6 address on EKS Worker Node subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
+  type        = bool
+  default     = null
+}
+
+variable "eks_worker_subnet_suffix" {
+  description = "Suffix to append to EKS Worker Node subnets name"
+  type        = string
+  default     = "eks-worker"
+}
+
+variable "eks_worker_subnets" {
+  description = "A list of EKS Worker Node subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_worker_subnet_tags" {
+  description = "Additional tags for the EKS Worker Node subnets"
+  type        = map(string)
+  default     = {}
+}
+
+variable "eks_cluster_name" {
+  description = "Name of EKS Cluster using worker subnets"
+  type        = string
+  default     = ""
+}
+
+variable "enable_eks_resource_tags" {
+  description = "Enables creating tags on vpc and subnets required for EKS to manage resources."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Adds functionality to make deploying EKS resources easier.

This change adds subnets for EKS worker nodes and configures tagging for vpc resources as per the aws requirements (https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#vpc-tagging)