### PR TITLE
fix ipv6 enable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -912,7 +912,7 @@ resource "aws_route" "private_nat_gateway" {
 }
 
 resource "aws_route" "private_ipv6_egress" {
-  count = var.enable_ipv6 ? length(var.private_subnets) : 0
+  count = var.create_vpc && var.enable_ipv6 ? length(var.private_subnets) : 0
 
   route_table_id              = element(aws_route_table.private.*.id, count.index)
   destination_ipv6_cidr_block = "::/0"


### PR DESCRIPTION
fixes the following current issue:

```
Error: Error in function call

  on .terraform_stage/modules/main_vpc/terraform-aws-modules-terraform-aws-vpc-5358041/main.tf line 917, in resource "aws_route" "private_ipv6_egress":
 917:   route_table_id              = element(aws_route_table.private.*.id, count.index)
    |----------------
    | aws_route_table.private is empty tuple
    | count.index is 0

Call to function "element" failed: cannot use element function with an empty
list.
```