### PR TITLE
Adding default security group as a fallback for the AWS VPC Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Sometimes it is handy to have public access to Redshift clusters (for example if
 | enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | bool | `"false"` | no |
 | enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | bool | `"false"` | no |
 | enable\_dns\_support | Should be true to enable DNS support in the VPC | bool | `"true"` | no |
+| enable\_default\_security\_group\_for\_endpoints | Should be true if you want to use the default security group for VPC Endpoints of type Interface | bool | `"false"` | no |
 | enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | bool | `"false"` | no |
 | enable\_ec2\_endpoint | Should be true if you want to provision an EC2 endpoint to the VPC | bool | `"false"` | no |
 | enable\_ec2messages\_endpoint | Should be true if you want to provision an EC2MESSAGES endpoint to the VPC | bool | `"false"` | no |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -2,11 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-data "aws_security_group" "default" {
-  name   = "default"
-  vpc_id = module.vpc.vpc_id
-}
-
 module "vpc" {
   source = "../../"
 
@@ -21,6 +16,8 @@ module "vpc" {
   elasticache_subnets = ["20.10.31.0/24", "20.10.32.0/24", "20.10.33.0/24"]
   redshift_subnets    = ["20.10.41.0/24", "20.10.42.0/24", "20.10.43.0/24"]
   intra_subnets       = ["20.10.51.0/24", "20.10.52.0/24", "20.10.53.0/24"]
+
+  enable_default_security_group_for_endpoints = true
 
   create_database_subnet_group = false
 
@@ -48,52 +45,42 @@ module "vpc" {
   # VPC endpoint for SSM
   enable_ssm_endpoint              = true
   ssm_endpoint_private_dns_enabled = true
-  ssm_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for SSMMESSAGES
   enable_ssmmessages_endpoint              = true
   ssmmessages_endpoint_private_dns_enabled = true
-  ssmmessages_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC Endpoint for EC2
   enable_ec2_endpoint              = true
   ec2_endpoint_private_dns_enabled = true
-  ec2_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC Endpoint for EC2MESSAGES
   enable_ec2messages_endpoint              = true
   ec2messages_endpoint_private_dns_enabled = true
-  ec2messages_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC Endpoint for ECR API
   enable_ecr_api_endpoint              = true
   ecr_api_endpoint_private_dns_enabled = true
-  ecr_api_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC Endpoint for ECR DKR
   enable_ecr_dkr_endpoint              = true
   ecr_dkr_endpoint_private_dns_enabled = true
-  ecr_dkr_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for KMS
   enable_kms_endpoint              = true
   kms_endpoint_private_dns_enabled = true
-  kms_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for ECS
   enable_ecs_endpoint              = true
   ecs_endpoint_private_dns_enabled = true
-  ecs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for ECS telemetry
   enable_ecs_telemetry_endpoint              = true
   ecs_telemetry_endpoint_private_dns_enabled = true
-  ecs_telemetry_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for SQS
   enable_sqs_endpoint              = true
   sqs_endpoint_private_dns_enabled = true
-  sqs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   tags = {
     Owner       = "user"

--- a/variables.tf
+++ b/variables.tf
@@ -298,6 +298,12 @@ variable "external_nat_ip_ids" {
   default     = []
 }
 
+variable "enable_default_security_group_for_endpoints" {
+  description = "Whether or not to use the default security group as a fallback"
+  type        = bool
+  default     = false
+}
+
 variable "enable_dynamodb_endpoint" {
   description = "Should be true if you want to provision a DynamoDB endpoint to the VPC"
   type        = bool

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,3 +1,10 @@
+data "aws_security_group" "default" {
+  count = var.enable_default_security_group_for_endpoints ? 1 : 0
+
+  name   = "default"
+  vpc_id = local.vpc_id
+}
+
 ######################
 # VPC Endpoint for S3
 ######################
@@ -91,8 +98,16 @@ resource "aws_vpc_endpoint" "codebuild" {
   service_name      = data.aws_vpc_endpoint_service.codebuild[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.codebuild_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.codebuild_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.codebuild_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.codebuild_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -113,8 +128,16 @@ resource "aws_vpc_endpoint" "codecommit" {
   service_name      = data.aws_vpc_endpoint_service.codecommit[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.codecommit_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.codecommit_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.codecommit_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -135,8 +158,16 @@ resource "aws_vpc_endpoint" "git_codecommit" {
   service_name      = data.aws_vpc_endpoint_service.git_codecommit[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.git_codecommit_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.git_codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.git_codecommit_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.git_codecommit_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.git_codecommit_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -157,8 +188,16 @@ resource "aws_vpc_endpoint" "config" {
   service_name      = data.aws_vpc_endpoint_service.config[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.config_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.config_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.config_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.config_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.config_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -179,8 +218,16 @@ resource "aws_vpc_endpoint" "sqs" {
   service_name      = data.aws_vpc_endpoint_service.sqs[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sqs_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sqs_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sqs_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sqs_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -201,8 +248,16 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   service_name      = data.aws_vpc_endpoint_service.secretsmanager[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.secretsmanager_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.secretsmanager_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.secretsmanager_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.secretsmanager_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -223,8 +278,16 @@ resource "aws_vpc_endpoint" "ssm" {
   service_name      = data.aws_vpc_endpoint_service.ssm[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ssm_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ssm_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ssm_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ssm_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ssm_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -245,8 +308,16 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   service_name      = data.aws_vpc_endpoint_service.ssmmessages[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ssmmessages_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ssmmessages_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ssmmessages_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -267,8 +338,16 @@ resource "aws_vpc_endpoint" "ec2" {
   service_name      = data.aws_vpc_endpoint_service.ec2[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ec2_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ec2_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ec2_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ec2_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -289,8 +368,16 @@ resource "aws_vpc_endpoint" "ec2messages" {
   service_name      = data.aws_vpc_endpoint_service.ec2messages[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ec2messages_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ec2messages_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ec2messages_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -311,8 +398,16 @@ resource "aws_vpc_endpoint" "transferserver" {
   service_name      = data.aws_vpc_endpoint_service.transferserver[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.transferserver_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.transferserver_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.transferserver_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.transferserver_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.transferserver_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -333,8 +428,16 @@ resource "aws_vpc_endpoint" "ecr_api" {
   service_name      = data.aws_vpc_endpoint_service.ecr_api[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ecr_api_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ecr_api_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ecr_api_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -355,8 +458,16 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   service_name      = data.aws_vpc_endpoint_service.ecr_dkr[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ecr_dkr_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ecr_dkr_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ecr_dkr_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -377,8 +488,16 @@ resource "aws_vpc_endpoint" "apigw" {
   service_name      = data.aws_vpc_endpoint_service.apigw[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.apigw_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.apigw_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.apigw_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.apigw_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -399,8 +518,16 @@ resource "aws_vpc_endpoint" "kms" {
   service_name      = data.aws_vpc_endpoint_service.kms[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.kms_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.kms_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.kms_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.kms_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.kms_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -421,8 +548,16 @@ resource "aws_vpc_endpoint" "ecs" {
   service_name      = data.aws_vpc_endpoint_service.ecs[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ecs_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ecs_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ecs_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ecs_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ecs_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -444,8 +579,16 @@ resource "aws_vpc_endpoint" "ecs_agent" {
   service_name      = data.aws_vpc_endpoint_service.ecs_agent[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ecs_agent_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ecs_agent_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ecs_agent_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ecs_agent_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ecs_agent_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -467,8 +610,16 @@ resource "aws_vpc_endpoint" "ecs_telemetry" {
   service_name      = data.aws_vpc_endpoint_service.ecs_telemetry[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.ecs_telemetry_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.ecs_telemetry_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.ecs_telemetry_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.ecs_telemetry_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.ecs_telemetry_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -490,8 +641,16 @@ resource "aws_vpc_endpoint" "sns" {
   service_name      = data.aws_vpc_endpoint_service.sns[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sns_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sns_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sns_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sns_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sns_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -513,8 +672,16 @@ resource "aws_vpc_endpoint" "monitoring" {
   service_name      = data.aws_vpc_endpoint_service.monitoring[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.monitoring_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.monitoring_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.monitoring_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.monitoring_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -536,8 +703,16 @@ resource "aws_vpc_endpoint" "logs" {
   service_name      = data.aws_vpc_endpoint_service.logs[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.logs_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.logs_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.logs_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.logs_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.logs_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -559,8 +734,16 @@ resource "aws_vpc_endpoint" "events" {
   service_name      = data.aws_vpc_endpoint_service.events[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.events_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.events_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.events_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.events_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.events_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -582,8 +765,16 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
   service_name      = data.aws_vpc_endpoint_service.elasticloadbalancing[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.elasticloadbalancing_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.elasticloadbalancing_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.elasticloadbalancing_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.elasticloadbalancing_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -605,8 +796,16 @@ resource "aws_vpc_endpoint" "cloudtrail" {
   service_name      = data.aws_vpc_endpoint_service.cloudtrail[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.cloudtrail_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.cloudtrail_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.cloudtrail_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.cloudtrail_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.cloudtrail_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -628,8 +827,16 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
   service_name      = data.aws_vpc_endpoint_service.kinesis_streams[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.kinesis_streams_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.kinesis_streams_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.kinesis_streams_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.kinesis_streams_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -651,8 +858,16 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
   service_name      = data.aws_vpc_endpoint_service.kinesis_firehose[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.kinesis_firehose_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.kinesis_firehose_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.kinesis_firehose_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.kinesis_firehose_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -673,8 +888,16 @@ resource "aws_vpc_endpoint" "glue" {
   service_name      = data.aws_vpc_endpoint_service.glue[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.glue_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.glue_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.glue_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.glue_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.glue_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -695,8 +918,16 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
   service_name      = data.aws_vpc_endpoint_service.sagemaker_notebook[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sagemaker_notebook_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sagemaker_notebook_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sagemaker_notebook_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sagemaker_notebook_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -717,8 +948,16 @@ resource "aws_vpc_endpoint" "sts" {
   service_name      = data.aws_vpc_endpoint_service.sts[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sts_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sts_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sts_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sts_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sts_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -739,8 +978,16 @@ resource "aws_vpc_endpoint" "cloudformation" {
   service_name      = data.aws_vpc_endpoint_service.cloudformation[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.cloudformation_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.cloudformation_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.cloudformation_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.cloudformation_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.cloudformation_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -760,8 +1007,16 @@ resource "aws_vpc_endpoint" "codepipeline" {
   service_name      = data.aws_vpc_endpoint_service.codepipeline[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.codepipeline_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.codepipeline_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.codepipeline_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.codepipeline_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.codepipeline_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -781,8 +1036,16 @@ resource "aws_vpc_endpoint" "appmesh_envoy_management" {
   service_name      = data.aws_vpc_endpoint_service.appmesh_envoy_management[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.appmesh_envoy_management_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.appmesh_envoy_management_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.appmesh_envoy_management_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.appmesh_envoy_management_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.appmesh_envoy_management_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -802,8 +1065,16 @@ resource "aws_vpc_endpoint" "servicecatalog" {
   service_name      = data.aws_vpc_endpoint_service.servicecatalog[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.servicecatalog_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.servicecatalog_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.servicecatalog_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.servicecatalog_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.servicecatalog_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -823,8 +1094,16 @@ resource "aws_vpc_endpoint" "storagegateway" {
   service_name      = data.aws_vpc_endpoint_service.storagegateway[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.storagegateway_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.storagegateway_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.storagegateway_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.storagegateway_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.storagegateway_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -844,8 +1123,16 @@ resource "aws_vpc_endpoint" "transfer" {
   service_name      = data.aws_vpc_endpoint_service.transfer[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.transfer_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.transfer_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.transfer_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.transfer_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.transfer_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -865,8 +1152,16 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
   service_name      = data.aws_vpc_endpoint_service.sagemaker_api[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sagemaker_api_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sagemaker_api_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sagemaker_api_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sagemaker_api_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -886,8 +1181,16 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
   service_name      = data.aws_vpc_endpoint_service.sagemaker_runtime[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.sagemaker_runtime_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.sagemaker_runtime_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.sagemaker_runtime_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.sagemaker_runtime_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -908,8 +1211,16 @@ resource "aws_vpc_endpoint" "appstream" {
   service_name      = data.aws_vpc_endpoint_service.appstream[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.appstream_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.appstream_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.appstream_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.appstream_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.appstream_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -930,8 +1241,16 @@ resource "aws_vpc_endpoint" "athena" {
   service_name      = data.aws_vpc_endpoint_service.athena[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.athena_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.athena_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.athena_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.athena_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.athena_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
@@ -952,8 +1271,16 @@ resource "aws_vpc_endpoint" "rekognition" {
   service_name      = data.aws_vpc_endpoint_service.rekognition[0].service_name
   vpc_endpoint_type = "Interface"
 
-  security_group_ids  = var.rekognition_endpoint_security_group_ids
-  subnet_ids          = coalescelist(var.rekognition_endpoint_subnet_ids, aws_subnet.private.*.id)
+  security_group_ids = coalescelist(
+    var.rekognition_endpoint_security_group_ids,
+    data.aws_security_group.default.*.id,
+  )
+
+  subnet_ids = coalescelist(
+    var.rekognition_endpoint_subnet_ids,
+    aws_subnet.private.*.id
+  )
+
   private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }


### PR DESCRIPTION
# Description

Related issue: https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/332.

The current example for a [complete-vpc](examples/complete-vpc/main.tf) is suggesting the usage of a circular reference with the security group of a VPC that will only be created within the module, creating a chicken-and-egg problem.

Considering https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/332#issuecomment-534018355 a feature toggle was implemented and disabled by default.