### PR TITLE
Terraform 0.11 - Add NAT Gateway to Database route table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,10 +135,10 @@ resource "aws_route" "database_internet_gateway" {
 }
 
 resource "aws_route" "database_nat_gateway" {
-  count                  = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && ! var.create_database_internet_gateway_route && var.create_database_nat_gateway_route && var.enable_nat_gateway ? local.nat_gateway_count : 0}"
-  route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  count                  = "${var.create_vpc && var.create_database_subnet_route_table && length(var.database_subnets) > 0 && ! var.create_database_internet_gateway_route && var.create_database_nat_gateway_route && var.enable_nat_gateway ? 1 : 0}"
+  route_table_id         = "${aws_route_table.database.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.this.*.id, count.index)}"
+  nat_gateway_id         = "${aws_nat_gateway.this.0.id}"
 
   timeouts {
     create = "5m"


### PR DESCRIPTION
This commit corrects the configuration of the create_database_nat_gateway_route feature where it adds a route to allow the databse subnets access to the internet.

Previously this feature would add the NAT gateway to the private subnet route table and not the database route table causing a conlict in configuration as both `aws_route.private_nat_gateway` and `aws_route.database_nat_gateway` would both want to add a route for `destination_cidr_block = "0.0.0.0/0"` which will cause the following error

```
Error: Error applying plan:

3 errors occurred:
        * module.vpc.aws_route.database_nat_gateway[0]: 1 error occurred:
        * aws_route.database_nat_gateway.0: Error creating route: RouteAlreadyExists: The route identified by 0.0.0.0/0 already exists.
        status code: 400, request id: f64ae1fb-e56d-4eed-9117-97d392f0e8c4

        * module.vpc.aws_route.database_nat_gateway[1]: 1 error occurred:
        * aws_route.database_nat_gateway.1: Error creating route: RouteAlreadyExists: The route identified by 0.0.0.0/0 already exists.
        status code: 400, request id: f5ac8726-ea1c-46b1-9a76-794efc95542b

        * module.vpc.aws_route.database_nat_gateway[2]: 1 error occurred:
        * aws_route.database_nat_gateway.2: Error creating route: RouteAlreadyExists: The route identified by 0.0.0.0/0 already exists.
        status code: 400, request id: 9edbe494-2407-4552-88bd-498379da7dc8
```

Because there is only a single route table for the Database subnets even if they are multi AZ enabled I have selected to follow the standard that is in the `aws_route.database_internet_gateway` resource where the association is done for the first route table and NAT gateway.
