### PR TITLE
Help users by specifying minimum versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:0.12.0
+    - image: hashicorp/terraform:0.12.6
   working_directory: /tmp/workspace/terraform
 
 jobs:
@@ -24,6 +24,13 @@ jobs:
       - run:
           name: Validate Terraform configurations
           command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && terraform validate && echo "√ $m") || exit 1 ; done
+      - run:
+          name: Validate minimum version check
+          command: |
+            sed -i.bak -e 's/>=/=/' -e 's/ \(\d\+\.\d\+\)"/ \1.0"/' versions.tf
+            terraform init
+            terraform validate
+            mv versions.tf.bak versions.tf
       - run:
           name: Check if Terraform configurations are properly formatted
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12.6"
+
+  required_providers {
+    aws = ">= 2.16"
+  }
+}


### PR DESCRIPTION
Couple of Issues raised lately caused by users using outdated versions of Terraform (#364 #361).

Use TF 0.12's minimum version hints to help. Also add a test to CircleCI to help ensure these are kept up to date. `terraform validate` isn't 100% accurate now with lazy `if` evaluation but better than nothing.

Based on similar work done in the [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks/) module.