### PR TITLE
Default value for booleans should be false so they do not show up as required in Terraform Registry

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,37 +67,37 @@ variable "assign_ipv6_address_on_creation" {
 variable "private_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on private subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "public_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on public subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "database_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on database subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "redshift_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on redshift subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "elasticache_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on elasticache subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "intra_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "secondary_cidr_blocks" {
@@ -1878,4 +1878,3 @@ variable "elasticache_outbound_acl_rules" {
     },
   ]
 }
-


### PR DESCRIPTION
…required in Terraform registry

# Description

Before this change, several values show up as "required" that probably should not be:

![Screenshot_2019-12-05 terraform-aws-modules vpc aws Terraform Registry](https://user-images.githubusercontent.com/416849/70248699-e9700580-1740-11ea-87fc-b933c41f0568.png)

