### PR TITLE
Add ability to define custom DB Subnet Group Name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_subnet" "database" {
 resource "aws_db_subnet_group" "database" {
   count = var.create_vpc && length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0
 
-  name        = lower(var.database_subnet_group_name)
+  name        = var.database_subnet_group_name != null ? lower(var.database_subnet_group_name) : lower(var.name)
   description = "Database subnet group for ${var.name}"
   subnet_ids  = aws_subnet.database.*.id
 

--- a/main.tf
+++ b/main.tf
@@ -443,7 +443,7 @@ resource "aws_subnet" "elasticache" {
 resource "aws_elasticache_subnet_group" "elasticache" {
   count = var.create_vpc && length(var.elasticache_subnets) > 0 && var.create_elasticache_subnet_group ? 1 : 0
 
-  name        = var.name
+  name        = var.elasticache_subnet_group_name != null ? lower(var.elasticache_subnet_group_name) : lower(var.name)
   description = "ElastiCache subnet group for ${var.name}"
   subnet_ids  = aws_subnet.elasticache.*.id
 }

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_subnet" "database" {
 resource "aws_db_subnet_group" "database" {
   count = var.create_vpc && length(var.database_subnets) > 0 && var.create_database_subnet_group ? 1 : 0
 
-  name        = lower(var.name)
+  name        = lower(var.database_subnet_group_name)
   description = "Database subnet group for ${var.name}"
   subnet_ids  = aws_subnet.database.*.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "database_subnet_group_name" {
   default     = null
 }
 
+variable "elasticache_subnet_group_name" {
+  description = "Name to be used on Elasticache Subnet Group resource as identifier"
+  type        = string
+  default     = null
+}
+
 variable "cidr" {
   description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "name" {
 variable "database_subnet_group_name" {
   description = "Name to be used on DB Subnet Group resource as identifier"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "cidr" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "name" {
   default     = ""
 }
 
+variable "database_subnet_group_name" {
+  description = "Name to be used on DB Subnet Group resource as identifier"
+  type        = string
+  default     = ""
+}
+
 variable "cidr" {
   description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
   type        = string


### PR DESCRIPTION
# Description

TF Will destroy and recreate any aws_db_subnet_group resource which has a name change. Allowing the module to specify a name allows users to import existing resources into the vpc managed by the module.
