### PR TITLE
IN-1830

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_vpc" "this" {
 
   lifecycle {
     ignore_changes = [
-      "tags.%",
+      tags,
     ]
   }
 
@@ -297,6 +297,12 @@ resource "aws_subnet" "public" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.public_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -322,6 +328,12 @@ resource "aws_subnet" "private" {
   assign_ipv6_address_on_creation = var.private_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.private_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 
   tags = merge(
     {
@@ -349,6 +361,12 @@ resource "aws_subnet" "database" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.database_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -368,6 +386,12 @@ resource "aws_db_subnet_group" "database" {
   name        = lower(var.name)
   description = "Database subnet group for ${var.name}"
   subnet_ids  = aws_subnet.database.*.id
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 
   tags = merge(
     {
@@ -390,6 +414,12 @@ resource "aws_subnet" "redshift" {
   assign_ipv6_address_on_creation = var.redshift_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.redshift_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.redshift_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.redshift_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 
   tags = merge(
     {
@@ -433,6 +463,12 @@ resource "aws_subnet" "elasticache" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.elasticache_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.elasticache_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -466,6 +502,12 @@ resource "aws_subnet" "intra" {
   assign_ipv6_address_on_creation = var.intra_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.intra_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,10 @@ resource "aws_vpc" "this" {
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
   assign_generated_ipv6_cidr_block = var.enable_ipv6
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
   tags = merge(
     {
       "Name" = format("%s", var.name)
@@ -291,6 +295,10 @@ resource "aws_subnet" "public" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.public_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -316,6 +324,10 @@ resource "aws_subnet" "private" {
   assign_ipv6_address_on_creation = var.private_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.private_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   tags = merge(
     {
@@ -343,6 +355,10 @@ resource "aws_subnet" "database" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.database_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -362,6 +378,10 @@ resource "aws_db_subnet_group" "database" {
   name        = lower(var.name)
   description = "Database subnet group for ${var.name}"
   subnet_ids  = aws_subnet.database.*.id
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   tags = merge(
     {
@@ -385,6 +405,10 @@ resource "aws_subnet" "redshift" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.redshift_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.redshift_subnet_ipv6_prefixes[count.index]) : null
 
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
   tags = merge(
     {
       "Name" = format(
@@ -404,6 +428,10 @@ resource "aws_redshift_subnet_group" "redshift" {
   name        = lower(var.name)
   description = "Redshift subnet group for ${var.name}"
   subnet_ids  = aws_subnet.redshift.*.id
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   tags = merge(
     {
@@ -426,6 +454,10 @@ resource "aws_subnet" "elasticache" {
   assign_ipv6_address_on_creation = var.elasticache_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.elasticache_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.elasticache_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.elasticache_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   tags = merge(
     {
@@ -460,6 +492,10 @@ resource "aws_subnet" "intra" {
   assign_ipv6_address_on_creation = var.intra_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.intra_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,7 @@ resource "aws_vpc" "this" {
 
   lifecycle {
     ignore_changes = [
-      "tags.%",
-      "tags.kubernetes.io/",
+      tags,
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,10 @@ resource "aws_vpc" "this" {
   assign_generated_ipv6_cidr_block = var.enable_ipv6
 
   lifecycle {
-    ignore_changes = [tags]
+    ignore_changes = [
+      "tags.%",
+      "tags.kubernetes.io/",
+    ]
   }
 
   tags = merge(
@@ -295,10 +298,6 @@ resource "aws_subnet" "public" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.public_subnet_ipv6_prefixes[count.index]) : null
 
-  lifecycle {
-    ignore_changes = [tags]
-  }
-
   tags = merge(
     {
       "Name" = format(
@@ -324,10 +323,6 @@ resource "aws_subnet" "private" {
   assign_ipv6_address_on_creation = var.private_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.private_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
 
   tags = merge(
     {
@@ -355,10 +350,6 @@ resource "aws_subnet" "database" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.database_subnet_ipv6_prefixes[count.index]) : null
 
-  lifecycle {
-    ignore_changes = [tags]
-  }
-
   tags = merge(
     {
       "Name" = format(
@@ -378,10 +369,6 @@ resource "aws_db_subnet_group" "database" {
   name        = lower(var.name)
   description = "Database subnet group for ${var.name}"
   subnet_ids  = aws_subnet.database.*.id
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
 
   tags = merge(
     {
@@ -405,10 +392,6 @@ resource "aws_subnet" "redshift" {
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.redshift_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.redshift_subnet_ipv6_prefixes[count.index]) : null
 
-  lifecycle {
-    ignore_changes = [tags]
-  }
-
   tags = merge(
     {
       "Name" = format(
@@ -428,10 +411,6 @@ resource "aws_redshift_subnet_group" "redshift" {
   name        = lower(var.name)
   description = "Redshift subnet group for ${var.name}"
   subnet_ids  = aws_subnet.redshift.*.id
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
 
   tags = merge(
     {
@@ -454,10 +433,6 @@ resource "aws_subnet" "elasticache" {
   assign_ipv6_address_on_creation = var.elasticache_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.elasticache_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.elasticache_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.elasticache_subnet_ipv6_prefixes[count.index]) : null
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
 
   tags = merge(
     {
@@ -492,10 +467,6 @@ resource "aws_subnet" "intra" {
   assign_ipv6_address_on_creation = var.intra_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.intra_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_vpc" "this" {
 
   lifecycle {
     ignore_changes = [
-      tags,
+      tags["kubernetes.io/"],
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_vpc" "this" {
 
   lifecycle {
     ignore_changes = [
-      tags["kubernetes.io/"],
+      "tags.%",
     ]
   }
 

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -12,7 +12,6 @@ resource "aws_vpc_endpoint" "s3" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.s3[0].service_name
-  tags         = local.vpce_tags
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
@@ -50,7 +49,6 @@ resource "aws_vpc_endpoint" "dynamodb" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.dynamodb[0].service_name
-  tags         = local.vpce_tags
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_dynamodb" {
@@ -977,8 +975,6 @@ resource "aws_vpc_endpoint" "efs" {
   security_group_ids  = var.efs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.efs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.efs_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
 }
 
 #######################
@@ -1000,6 +996,4 @@ resource "aws_vpc_endpoint" "cloud_directory" {
   security_group_ids  = var.cloud_directory_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloud_directory_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloud_directory_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
 }

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -94,7 +94,7 @@ resource "aws_vpc_endpoint" "codebuild" {
   security_group_ids  = var.codebuild_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codebuild_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###############################
@@ -116,7 +116,7 @@ resource "aws_vpc_endpoint" "codecommit" {
   security_group_ids  = var.codecommit_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###################################
@@ -138,7 +138,7 @@ resource "aws_vpc_endpoint" "git_codecommit" {
   security_group_ids  = var.git_codecommit_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.git_codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.git_codecommit_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ##########################
@@ -160,7 +160,7 @@ resource "aws_vpc_endpoint" "config" {
   security_group_ids  = var.config_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.config_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.config_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -182,7 +182,7 @@ resource "aws_vpc_endpoint" "sqs" {
   security_group_ids  = var.sqs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sqs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###################################
@@ -204,7 +204,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   security_group_ids  = var.secretsmanager_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.secretsmanager_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -226,7 +226,7 @@ resource "aws_vpc_endpoint" "ssm" {
   security_group_ids  = var.ssm_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ssm_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ssm_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###############################
@@ -248,7 +248,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   security_group_ids  = var.ssmmessages_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -270,7 +270,7 @@ resource "aws_vpc_endpoint" "ec2" {
   security_group_ids  = var.ec2_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###############################
@@ -292,7 +292,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   security_group_ids  = var.ec2messages_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###################################
@@ -314,7 +314,7 @@ resource "aws_vpc_endpoint" "transferserver" {
   security_group_ids  = var.transferserver_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.transferserver_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.transferserver_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###########################
@@ -336,7 +336,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   security_group_ids  = var.ecr_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ###########################
@@ -358,7 +358,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   security_group_ids  = var.ecr_dkr_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -380,7 +380,7 @@ resource "aws_vpc_endpoint" "apigw" {
   security_group_ids  = var.apigw_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.apigw_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -402,7 +402,7 @@ resource "aws_vpc_endpoint" "kms" {
   security_group_ids  = var.kms_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kms_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kms_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -424,7 +424,7 @@ resource "aws_vpc_endpoint" "ecs" {
   security_group_ids  = var.ecs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -447,7 +447,7 @@ resource "aws_vpc_endpoint" "ecs_agent" {
   security_group_ids  = var.ecs_agent_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_agent_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_agent_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -470,7 +470,7 @@ resource "aws_vpc_endpoint" "ecs_telemetry" {
   security_group_ids  = var.ecs_telemetry_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_telemetry_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_telemetry_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -493,7 +493,7 @@ resource "aws_vpc_endpoint" "sns" {
   security_group_ids  = var.sns_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sns_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sns_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -516,7 +516,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   security_group_ids  = var.monitoring_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.monitoring_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -539,7 +539,7 @@ resource "aws_vpc_endpoint" "logs" {
   security_group_ids  = var.logs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.logs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.logs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -562,7 +562,7 @@ resource "aws_vpc_endpoint" "events" {
   security_group_ids  = var.events_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.events_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.events_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -585,7 +585,7 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
   security_group_ids  = var.elasticloadbalancing_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticloadbalancing_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -608,7 +608,7 @@ resource "aws_vpc_endpoint" "cloudtrail" {
   security_group_ids  = var.cloudtrail_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloudtrail_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloudtrail_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -631,7 +631,7 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
   security_group_ids  = var.kinesis_streams_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_streams_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 
@@ -654,7 +654,7 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
   security_group_ids  = var.kinesis_firehose_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_firehose_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -676,7 +676,7 @@ resource "aws_vpc_endpoint" "glue" {
   security_group_ids  = var.glue_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.glue_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.glue_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 ######################################
@@ -698,7 +698,7 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
   security_group_ids  = var.sagemaker_notebook_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_notebook_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################
@@ -720,7 +720,7 @@ resource "aws_vpc_endpoint" "sts" {
   security_group_ids  = var.sts_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sts_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sts_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #############################
@@ -742,7 +742,7 @@ resource "aws_vpc_endpoint" "cloudformation" {
   security_group_ids  = var.cloudformation_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloudformation_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloudformation_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for CodePipeline
@@ -763,7 +763,7 @@ resource "aws_vpc_endpoint" "codepipeline" {
   security_group_ids  = var.codepipeline_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codepipeline_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codepipeline_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for AppMesh
@@ -784,7 +784,7 @@ resource "aws_vpc_endpoint" "appmesh_envoy_management" {
   security_group_ids  = var.appmesh_envoy_management_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.appmesh_envoy_management_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.appmesh_envoy_management_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for Service Catalog
@@ -805,7 +805,7 @@ resource "aws_vpc_endpoint" "servicecatalog" {
   security_group_ids  = var.servicecatalog_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.servicecatalog_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.servicecatalog_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for Storage Gateway
@@ -826,7 +826,7 @@ resource "aws_vpc_endpoint" "storagegateway" {
   security_group_ids  = var.storagegateway_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.storagegateway_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.storagegateway_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for Transfer
@@ -847,7 +847,7 @@ resource "aws_vpc_endpoint" "transfer" {
   security_group_ids  = var.transfer_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.transfer_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.transfer_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for SageMaker API
@@ -868,7 +868,7 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
   security_group_ids  = var.sagemaker_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 #############################
 # VPC Endpoint for SageMaker Runtime
@@ -889,7 +889,7 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
   security_group_ids  = var.sagemaker_runtime_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_runtime_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #############################
@@ -911,7 +911,7 @@ resource "aws_vpc_endpoint" "appstream" {
   security_group_ids  = var.appstream_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.appstream_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.appstream_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #############################
@@ -933,7 +933,7 @@ resource "aws_vpc_endpoint" "athena" {
   security_group_ids  = var.athena_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.athena_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.athena_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #############################
@@ -955,7 +955,7 @@ resource "aws_vpc_endpoint" "rekognition" {
   security_group_ids  = var.rekognition_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.rekognition_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+
 }
 
 #######################


### PR DESCRIPTION
- Removed VPC endpoint tags that were added to the module, causing failure. Endpoint tags are unsupported, not sure why they were in to begin with. 

- Added lifecycle directive to ignore all tag changes to VPC and subnets. Pattern matching for something like "kubernetes.io/%" looks to be unsupported, throwing an error in Terraform. And "kubernetes.io/*" still results in a change.
