### PR TITLE
Added Resources to support multiple public/private subnets and route tables

### DIFF
--- a/examples/generic-vpc/main.tf
+++ b/examples/generic-vpc/main.tf
@@ -2,7 +2,7 @@
 provider "aws" {
     region = "ap-south-1"
     version = "~> 2.0"
-    allowed_account_ids = ["44444444444"]
+#    allowed_account_ids = ["44444444444"]
     profile = "testuser"
 }
 
@@ -27,7 +27,7 @@ module "vpc" {
 
     azs = ["ap-south-1a", "ap-south-1b", "ap-south-1c"]
 
-    generic_public_subnets = [
+    multi_public_subnets = [
         {
             cidr_block = "172.35.240.0/24",
             avlzone = "ap-south-1a",
@@ -48,7 +48,7 @@ module "vpc" {
         },
     ]
 
-    generic_private_subnets = [
+    multi_private_subnets = [
         {
             cidr_block = "172.35.230.0/24",
             avlzone = "ap-south-1a",

--- a/examples/generic-vpc/main.tf
+++ b/examples/generic-vpc/main.tf
@@ -1,0 +1,96 @@
+#####################################
+provider "aws" {
+    region = "ap-south-1"
+    version = "~> 2.0"
+    allowed_account_ids = ["461115619209"]
+    profile = "crashtest"
+}
+
+#terraform {
+#  backend "s3" {}
+#  required_version = "= 0.11.11"
+#}
+
+module "vpc" {
+    source = "../../"
+
+    name = "rabbani-terraform"
+    cidr = "172.35.0.0/16"
+
+    tags = {
+        Owner       = "devops"
+        Environment = "production"
+        Terraform   = "true"
+        User        = "rabbani-test"
+    }
+
+
+    azs = ["ap-south-1a", "ap-south-1b", "ap-south-1c"]
+
+    generic_public_subnets = [
+        {
+            cidr_block = "172.35.240.0/24",
+            avlzone = "ap-south-1a",
+            tag_suffix = "public_prd"
+            route_table_name = "public"
+        },
+        {
+            cidr_block = "172.35.241.0/24",
+            avlzone = "ap-south-1b",
+            tag_suffix = "public_prd"
+            route_table_name = "public"
+        },
+        {
+            cidr_block = "172.35.242.0/24",
+            avlzone = "ap-south-1c",
+            tag_suffix = "public_prd"
+            route_table_name = "public"
+        },
+    ]
+
+    generic_private_subnets = [
+        {
+            cidr_block = "172.35.230.0/24",
+            avlzone = "ap-south-1a",
+            subnets_suffix = "database"
+            route_table_name = "private_1a"
+        },
+        {
+            cidr_block = "172.35.231.0/24",
+            avlzone = "ap-south-1b",
+            subnets_suffix = "database"
+            route_table_name = "private_1b"
+        },
+        {
+            cidr_block = "172.35.232.0/24",
+            avlzone = "ap-south-1c",
+            subnets_suffix = "database"
+            route_table_name = "private_1c"
+        },
+        {
+            cidr_block = "172.35.220.0/24",
+            avlzone = "ap-south-1a",
+            subnets_suffix = "elk"
+            route_table_name = "private_1a"
+        },
+        {
+            cidr_block = "172.35.221.0/24",
+            avlzone = "ap-south-1b",
+            subnets_suffix = "elk"
+            route_table_name = "private_1b"
+        },
+        {
+            cidr_block = "172.35.222.0/24",
+            avlzone = "ap-south-1c",
+            subnets_suffix = "elk"
+            route_table_name = "private_1c"
+        },
+    ]
+
+    enable_nat_gateway = true
+    single_nat_gateway = false
+
+    reuse_nat_ips = false
+#    external_nat_ip_ids = ["2.34.5.612", "56.34.12.89", "90.12.1.3"]
+
+}

--- a/examples/generic-vpc/main.tf
+++ b/examples/generic-vpc/main.tf
@@ -2,8 +2,8 @@
 provider "aws" {
     region = "ap-south-1"
     version = "~> 2.0"
-    allowed_account_ids = ["461115619209"]
-    profile = "crashtest"
+    allowed_account_ids = ["44444444444"]
+    profile = "testuser"
 }
 
 #terraform {

--- a/examples/generic-vpc/outputs.tf
+++ b/examples/generic-vpc/outputs.tf
@@ -1,0 +1,33 @@
+
+variable "route_tables" {
+  description = "A list of public subnets inside the VPC"
+  type        = list(map(string))
+  default     = []
+}
+
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_arn" {
+  description = "The ARN of the VPC"
+  value       = module.vpc.vpc_arn
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc.public_subnets
+}
+
+
+output "public_route_table_ids" {
+  description = "List of IDs of public route tables"
+  value       = module.vpc.public_route_table_ids
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = module.vpc.private_route_table_ids
+}
+

--- a/main.tf
+++ b/main.tf
@@ -1218,7 +1218,7 @@ resource "aws_subnet" "generic_private" {
 }
 
 locals {
-  generic_nat_gateway_count = var.single_nat_gateway ? 1 : length(local.avlzones)
+  generic_nat_gateway_count = length(var.generic_public_subnets) > 0 ? var.single_nat_gateway ? 1 : length(local.avlzones) : 0
   generic_nat_gateway_ips = split(
     ",",
     var.reuse_nat_ips ? join(",", var.external_nat_ip_ids) : join(",", aws_eip.generic_eip.*.id),

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
     length(var.database_subnets),
     length(var.redshift_subnets),
   )
-  nat_gateway_count = length(var.generic_public_subnets) == 0 ? var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length : 0
+  nat_gateway_count = length(var.multi_public_subnets) == 0 ? var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length : 0
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
   vpc_id = element(
@@ -1080,14 +1080,14 @@ resource "aws_default_vpc" "this" {
 
 locals {
 # Get number of route tables to created by uniquely get the names.
-    public_route_table_names = distinct(var.generic_public_subnets.*.route_table_name)
-    private_route_table_names = distinct(var.generic_private_subnets.*.route_table_name)
+    public_route_table_names = distinct(var.multi_public_subnets.*.route_table_name)
+    private_route_table_names = distinct(var.multi_private_subnets.*.route_table_name)
 }
 
 ##############################
-# Generic Publiс Routes tables
+# multi Publiс Routes tables
 ##############################
-resource "aws_route_table" "generic_public" {
+resource "aws_route_table" "multi_public" {
 count = length(local.public_route_table_names) > 0 ? length(local.public_route_table_names) : 0
 
   vpc_id                          = aws_vpc.this[0].id
@@ -1105,15 +1105,15 @@ locals {
 # This is map of route table name versus route table id.
 # Later this can be used wherever we need route table d for given route table name.
 # One example is route tablee association to subnets. We can extend it to route creation also.
-    public_route_table_ids = zipmap(local.public_route_table_names, aws_route_table.generic_public.*.id)
-    avlzones_public_subnets_ids = zipmap(var.generic_public_subnets.*.avlzone, aws_subnet.generic_public.*.id)
+    public_route_table_ids = zipmap(local.public_route_table_names, aws_route_table.multi_public.*.id)
+    avlzones_public_subnets_ids = zipmap(var.multi_public_subnets.*.avlzone, aws_subnet.multi_public.*.id)
 }
 
 ###################
 # Internet Gateway
 ###################
 resource "aws_internet_gateway" "int_gw" {
-  count = var.create_vpc && length(var.generic_public_subnets) > 0 ? 1 : 0
+  count = var.create_vpc && length(var.multi_public_subnets) > 0 ? 1 : 0
 
   vpc_id = aws_vpc.this[0].id
 
@@ -1126,10 +1126,10 @@ resource "aws_internet_gateway" "int_gw" {
   )
 }
 
-resource "aws_route" "generic_public_internet_gateway" {
+resource "aws_route" "multi_public_internet_gateway" {
   count = var.create_vpc && length(local.public_route_table_names) > 0 ? length(local.public_route_table_names) : 0
 
-  route_table_id         = aws_route_table.generic_public[count.index].id
+  route_table_id         = aws_route_table.multi_public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.int_gw[0].id
 
@@ -1139,21 +1139,21 @@ resource "aws_route" "generic_public_internet_gateway" {
 }
 
 ########################
-# Generic Public subnets
+# multi Public subnets
 ########################
-resource "aws_subnet" "generic_public" {
-  count = var.create_vpc && length(var.generic_public_subnets) > 0 ? length(var.generic_public_subnets) : 0
+resource "aws_subnet" "multi_public" {
+  count = var.create_vpc && length(var.multi_public_subnets) > 0 ? length(var.multi_public_subnets) : 0
 
   vpc_id                          = aws_vpc.this[0].id
-  cidr_block                      = var.generic_public_subnets[count.index].cidr_block
-  availability_zone               = var.generic_public_subnets[count.index].avlzone
+  cidr_block                      = var.multi_public_subnets[count.index].cidr_block
+  availability_zone               = var.multi_public_subnets[count.index].avlzone
 
   tags = merge(
     {
       "Name" = format(
         "subnet_%s_%s",
-        var.generic_public_subnets[count.index].tag_suffix,
-        substr(var.generic_public_subnets[count.index].avlzone, length(var.generic_public_subnets[count.index].avlzone)-1, 1)
+        var.multi_public_subnets[count.index].tag_suffix,
+        substr(var.multi_public_subnets[count.index].avlzone, length(var.multi_public_subnets[count.index].avlzone)-1, 1)
       )
     },
     var.tags,
@@ -1161,19 +1161,19 @@ resource "aws_subnet" "generic_public" {
 }
 
 #################################
-#Generic  Route table association
+#multi  Route table association
 #################################
 resource "aws_route_table_association" "public_route_table_subnets" {
-  count = length(var.generic_public_subnets) > 0 ? length(var.generic_public_subnets) : 0
+  count = length(var.multi_public_subnets) > 0 ? length(var.multi_public_subnets) : 0
 
-  subnet_id = element(aws_subnet.generic_public.*.id, count.index)
-  route_table_id = local.public_route_table_ids[var.generic_public_subnets[count.index].route_table_name]
+  subnet_id = element(aws_subnet.multi_public.*.id, count.index)
+  route_table_id = local.public_route_table_ids[var.multi_public_subnets[count.index].route_table_name]
 }
 
 ################
-# Generic Private routes
+# multi Private routes
 ################
-resource "aws_route_table" "generic_private" {
+resource "aws_route_table" "multi_private" {
 count = length(local.private_route_table_names) > 0 ? length(local.private_route_table_names) : 0
 
   vpc_id = aws_vpc.this[0].id
@@ -1190,27 +1190,27 @@ locals {
 # This is map of route table name versus route table id.
 # Later this can be used wherever we need route table d for given route table name.
 # One example is route tablee association to subnets. We can extend it to route creation also.
-    private_route_table_ids = zipmap(local.private_route_table_names, aws_route_table.generic_private.*.id)
-    avlzones_private_subnets_ids = zipmap(var.generic_private_subnets.*.avlzone, aws_subnet.generic_private.*.id)
-    avlzones = distinct(var.generic_public_subnets.*.avlzone)
+    private_route_table_ids = zipmap(local.private_route_table_names, aws_route_table.multi_private.*.id)
+    avlzones_private_subnets_ids = zipmap(var.multi_private_subnets.*.avlzone, aws_subnet.multi_private.*.id)
+    avlzones = distinct(var.multi_public_subnets.*.avlzone)
 }
 
 ################
-# Generic Private subnet
+# multi Private subnet
 ################
-resource "aws_subnet" "generic_private" {
-  count = var.create_vpc && length(var.generic_private_subnets) > 0 ? length(var.generic_private_subnets) : 0
+resource "aws_subnet" "multi_private" {
+  count = var.create_vpc && length(var.multi_private_subnets) > 0 ? length(var.multi_private_subnets) : 0
 
   vpc_id                          = aws_vpc.this[0].id
-  cidr_block                      = var.generic_private_subnets[count.index].cidr_block
-  availability_zone               = var.generic_private_subnets[count.index].avlzone
+  cidr_block                      = var.multi_private_subnets[count.index].cidr_block
+  availability_zone               = var.multi_private_subnets[count.index].avlzone
 
   tags = merge(
     {
       "Name" = format(
         "subnet_%s_%s",
-        var.generic_private_subnets[count.index].subnets_suffix,
-        substr(var.generic_private_subnets[count.index].avlzone, length(var.generic_private_subnets[count.index].avlzone)-1, 1)
+        var.multi_private_subnets[count.index].subnets_suffix,
+        substr(var.multi_private_subnets[count.index].avlzone, length(var.multi_private_subnets[count.index].avlzone)-1, 1)
       )
     },
     var.tags,
@@ -1218,10 +1218,10 @@ resource "aws_subnet" "generic_private" {
 }
 
 locals {
-  generic_nat_gateway_count = length(var.public_subnets) > 0 ? 0 : ( length(var.generic_public_subnets) > 0 ? var.single_nat_gateway ? 1 : length(local.avlzones) : 0)
-  generic_nat_gateway_ips = split(
+  multi_nat_gateway_count = length(var.public_subnets) > 0 ? 0 : ( length(var.multi_public_subnets) > 0 ? var.single_nat_gateway ? 1 : length(local.avlzones) : 0)
+  multi_nat_gateway_ips = split(
     ",",
-    var.reuse_nat_ips ? join(",", var.external_nat_ip_ids) : join(",", aws_eip.generic_eip.*.id),
+    var.reuse_nat_ips ? join(",", var.external_nat_ip_ids) : join(",", aws_eip.multi_eip.*.id),
   )
 }
 
@@ -1229,14 +1229,14 @@ locals {
 # Private  Route table association
 ##########################
 resource "aws_route_table_association" "private_route_table_subnets" {
-  count = length(var.generic_private_subnets) > 0 ? length(var.generic_private_subnets) : 0
+  count = length(var.multi_private_subnets) > 0 ? length(var.multi_private_subnets) : 0
 
-  subnet_id = element(aws_subnet.generic_private.*.id, count.index)
-  route_table_id = local.private_route_table_ids[var.generic_private_subnets[count.index].route_table_name]
+  subnet_id = element(aws_subnet.multi_private.*.id, count.index)
+  route_table_id = local.private_route_table_ids[var.multi_private_subnets[count.index].route_table_name]
 }
 
-resource "aws_eip" "generic_eip" {
-  count = var.create_vpc && var.enable_nat_gateway && false == var.reuse_nat_ips ? local.generic_nat_gateway_count : 0
+resource "aws_eip" "multi_eip" {
+  count = var.create_vpc && var.enable_nat_gateway && false == var.reuse_nat_ips ? local.multi_nat_gateway_count : 0
 
   vpc = true
 
@@ -1253,11 +1253,11 @@ resource "aws_eip" "generic_eip" {
   )
 }
 
-resource "aws_nat_gateway" "generic_natgw" {
-  count = var.create_vpc && var.enable_nat_gateway ? local.generic_nat_gateway_count : 0
+resource "aws_nat_gateway" "multi_natgw" {
+  count = var.create_vpc && var.enable_nat_gateway ? local.multi_nat_gateway_count : 0
 
   allocation_id = element(
-    local.generic_nat_gateway_ips,
+    local.multi_nat_gateway_ips,
     var.single_nat_gateway ? 0 : count.index,
   )
   subnet_id = local.avlzones_public_subnets_ids[local.avlzones[count.index]]
@@ -1277,12 +1277,12 @@ resource "aws_nat_gateway" "generic_natgw" {
   depends_on = [aws_internet_gateway.int_gw]
 }
 
-resource "aws_route" "generic_private_nat_gateway" {
-  count = var.create_vpc && var.enable_nat_gateway && (local.generic_nat_gateway_count > 0) ? length(local.private_route_table_names) : 0
+resource "aws_route" "multi_private_nat_gateway" {
+  count = var.create_vpc && var.enable_nat_gateway && (local.multi_nat_gateway_count > 0) ? length(local.private_route_table_names) : 0
 
-  route_table_id         = element(aws_route_table.generic_private.*.id, count.index)
+  route_table_id         = element(aws_route_table.multi_private.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = element(aws_nat_gateway.generic_natgw.*.id, var.single_nat_gateway ? 0 : count.index)
+  nat_gateway_id         = element(aws_nat_gateway.multi_natgw.*.id, var.single_nat_gateway ? 0 : count.index)
 
   timeouts {
     create = "5m"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1013,3 +1013,36 @@ output "name" {
   description = "The name of the VPC specified as argument to this module"
   value       = var.name
 }
+
+output "generic_public_subnets" {
+  description = "List of IDs of generic public subnets"
+  value       = aws_subnet.generic_public.*.id
+}
+
+output "generic_public_route_table_ids" {
+  description = "List of IDs of generic public route tables"
+  value       = aws_route_table.generic_public.*.id
+}
+
+output "public_route_table_map" {
+    value = local.public_route_table_ids
+}
+
+output "generic_private_subnets" {
+  description = "List of IDs of generic private subnets"
+  value       = aws_subnet.generic_private.*.id
+}
+
+output "generic_private_route_table_ids" {
+  description = "List of IDs of generic private route tables"
+  value       = aws_route_table.generic_private.*.id
+}
+
+output "private_route_table_map" {
+    value = local.private_route_table_ids
+}
+
+output "avlzones_map" {
+    value = local.avlzones_public_subnets_ids
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1014,28 +1014,28 @@ output "name" {
   value       = var.name
 }
 
-output "generic_public_subnets" {
-  description = "List of IDs of generic public subnets"
-  value       = aws_subnet.generic_public.*.id
+output "multi_public_subnets" {
+  description = "List of IDs of multi public subnets"
+  value       = aws_subnet.multi_public.*.id
 }
 
-output "generic_public_route_table_ids" {
-  description = "List of IDs of generic public route tables"
-  value       = aws_route_table.generic_public.*.id
+output "multi_public_route_table_ids" {
+  description = "List of IDs of multi public route tables"
+  value       = aws_route_table.multi_public.*.id
 }
 
 output "public_route_table_map" {
     value = local.public_route_table_ids
 }
 
-output "generic_private_subnets" {
-  description = "List of IDs of generic private subnets"
-  value       = aws_subnet.generic_private.*.id
+output "multi_private_subnets" {
+  description = "List of IDs of multi private subnets"
+  value       = aws_subnet.multi_private.*.id
 }
 
-output "generic_private_route_table_ids" {
-  description = "List of IDs of generic private route tables"
-  value       = aws_route_table.generic_private.*.id
+output "multi_private_route_table_ids" {
+  description = "List of IDs of multi private route tables"
+  value       = aws_route_table.multi_private.*.id
 }
 
 output "private_route_table_map" {

--- a/variables.tf
+++ b/variables.tf
@@ -1879,13 +1879,13 @@ variable "elasticache_outbound_acl_rules" {
   ]
 }
 
-variable "generic_public_subnets" {
+variable "multi_public_subnets" {
   description = "A list of public subnets inside the VPC"
   type        = list(map(string))
   default     = []
 }
 
-variable "generic_private_subnets" {
+variable "multi_private_subnets" {
   description = "A list of private subnets inside the VPC"
   type        = list(map(string))
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -1879,3 +1879,15 @@ variable "elasticache_outbound_acl_rules" {
   ]
 }
 
+variable "generic_public_subnets" {
+  description = "A list of public subnets inside the VPC"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "generic_private_subnets" {
+  description = "A list of private subnets inside the VPC"
+  type        = list(map(string))
+  default     = []
+}
+


### PR DESCRIPTION
Current terraform modules give good understanding of creating VPC, Subnets, Route tables and its Routes. If we want to add multiple subnets, route tables etc. new resources need to be added. We added generic resource to avoid adding multiple resources. This just needs two extra variables multi_public_subnets and multi_private_subnets. Both variables are of same structure. 

**Implementation:**
Structure is list of map and map has four attributes. tag_suffix is name of the subnets and route_table_name is route table. 

Route tables are created by making list of unique route_table_name. For public route table an internet gate way is created and same is added to all the public route tables as route entry. Similarly for private route tables NAT gate way is created. 

Example code is provided in examples/generic-vpc/
Variables multi_public_subnets and multi_private_subnets looks like:

```
multi_public_subnets = [
    {
        cidr_block = "172.35.240.0/24",
        avlzone = "ap-south-1a",
        tag_suffix = "public_prd"
        route_table_name = "public"
    },
    {
        cidr_block = "172.35.241.0/24",
        avlzone = "ap-south-1b",
        tag_suffix = "public_prd"
        route_table_name = "public"
    },
]

multi_private_subnets = [
    {
        cidr_block = "172.35.230.0/24",
        avlzone = "ap-south-1a",
        subnets_suffix = "database"
        route_table_name = "private_1a"
    },
    {
        cidr_block = "172.35.231.0/24",
        avlzone = "ap-south-1b",
        subnets_suffix = "database"
        route_table_name = "private_1b"
    },
    {
        cidr_block = "172.35.220.0/24",
        avlzone = "ap-south-1a",
        subnets_suffix = "elk"
        route_table_name = "private_1a"
    },
    {
        cidr_block = "172.35.221.0/24",
        avlzone = "ap-south-1b",
        subnets_suffix = "elk"
        route_table_name = "private_1b"
    },
]
```