### PR TITLE
Added param to use availability zone ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Sometimes it is handy to have public access to Redshift clusters (for example if
 | transferserver\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Transfer Server endpoint | bool | `"false"` | no |
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | list(string) | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | list(string) | `[]` | no |
+| use\_az\_ids | Whether to use availability zone ids | bool | `"false"` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | map(string) | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | map(string) | `{}` | no |
 | vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -285,7 +285,8 @@ resource "aws_subnet" "public" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = element(concat(var.public_subnets, [""]), count.index)
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   assign_ipv6_address_on_creation = var.public_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.public_subnet_assign_ipv6_address_on_creation
 
@@ -312,7 +313,8 @@ resource "aws_subnet" "private" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = var.private_subnets[count.index]
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   assign_ipv6_address_on_creation = var.private_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.private_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
@@ -338,7 +340,8 @@ resource "aws_subnet" "database" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = var.database_subnets[count.index]
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   assign_ipv6_address_on_creation = var.database_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.database_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.database_subnet_ipv6_prefixes[count.index]) : null
@@ -380,7 +383,8 @@ resource "aws_subnet" "redshift" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = var.redshift_subnets[count.index]
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   assign_ipv6_address_on_creation = var.redshift_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.redshift_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.redshift_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.redshift_subnet_ipv6_prefixes[count.index]) : null
@@ -422,7 +426,8 @@ resource "aws_subnet" "elasticache" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = var.elasticache_subnets[count.index]
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   assign_ipv6_address_on_creation = var.elasticache_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.elasticache_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.elasticache_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.elasticache_subnet_ipv6_prefixes[count.index]) : null
@@ -456,7 +461,8 @@ resource "aws_subnet" "intra" {
 
   vpc_id                          = local.vpc_id
   cidr_block                      = var.intra_subnets[count.index]
-  availability_zone               = element(var.azs, count.index)
+  availability_zone               = var.use_az_ids == false ? element(var.azs, count.index) : null
+  availability_zone_id            = var.use_az_ids ? element(var.azs, count.index) : null
   assign_ipv6_address_on_creation = var.intra_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.intra_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null

--- a/variables.tf
+++ b/variables.tf
@@ -244,6 +244,12 @@ variable "azs" {
   default     = []
 }
 
+variable "use_az_ids" {
+  description = "Whether to use availability zone ids"
+  type        = bool
+  default     = false
+}
+
 variable "enable_dns_hostnames" {
   description = "Should be true to enable DNS hostnames in the VPC"
   type        = bool


### PR DESCRIPTION
# Description

Added a param that will allow you to specify the availability zone IDs instead of the availability zone names.

This is especially important to be able to do when desiring to deploy AWS workspaces, as these types of resources can only be in certain AZs.  Unfortunately AWS changes the name of the AZs with each account, making specifying the correct AZs to use very difficult to do across different accounts.  However, the AZ IDs stay the same, and these can be used as a reliable way to ensure the correct AZs are used for deploying AWS AD and Workspaces.

To use the new parameter, simply specify `true` for `use_az_ids` and then use the availability zone ids in the `azs` variable instead of the availability zone names.
