### PR TITLE
Set minimum terraform version to 0.12.6 (fixes circleci)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,14 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:0.12.0
+    - image: hashicorp/terraform:0.12.6
   working_directory: /tmp/workspace/terraform
 
 jobs:
   validate:
     <<: *terraform
-    environment:
-        AWS_DEFAULT_REGION: us-east-1
     steps:
       - checkout
-      - run:
-          name: Install curl
-          command: apk add --update curl
 #      - run:
 #          name: Add github.com to ~/.ssh/known_hosts
 #          command: mkdir ~/.ssh && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
@@ -24,12 +19,14 @@ jobs:
       - run:
           name: Validate Terraform configurations
           command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && terraform validate && echo "√ $m") || exit 1 ; done
+          environment:
+              AWS_DEFAULT_REGION: us-east-1
       - run:
           name: Check if Terraform configurations are properly formatted
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: Install tflint
-          command: curl -L -o /tmp/tflint.zip https://github.com/wata727/tflint/releases/download/v0.12.1/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
+          command: wget -O /tmp/tflint.zip https://github.com/wata727/tflint/releases/download/v0.12.1/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
           command: tflint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.23.0
+  rev: v1.24.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.23 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.23"
+  }
+}


### PR DESCRIPTION
# Description

The `for_each` loop was released with Terraform `0.12.6` and, due to its usage in `main.tf`, is required for this module to work. This commit sets that minimum version and updates `.circleci/config` accordingly.

As a result this also fixes the currently failing CircleCI tests.