### PR TITLE
Added support for default security group for sqs endpoint.

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -2,11 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-data "aws_security_group" "default" {
-  name   = "default"
-  vpc_id = module.vpc.vpc_id
-}
-
 module "vpc" {
   source = "../../"
 
@@ -104,7 +99,7 @@ module "vpc" {
   # VPC endpoint for SQS
   enable_sqs_endpoint              = true
   sqs_endpoint_private_dns_enabled = true
-  sqs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
+  sqs_endpoint_default_security_group  = true
 
   # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
   enable_flow_log                      = true

--- a/variables.tf
+++ b/variables.tf
@@ -395,6 +395,11 @@ variable "enable_sqs_endpoint" {
   default     = false
 }
 
+variable "sqs_endpoint_default_security_group" {
+  description = "Should be true if you want the SQS endpoint to use the default security group for the VPC"
+  default     = false
+}
+
 variable "sqs_endpoint_security_group_ids" {
   description = "The ID of one or more security groups to associate with the network interface for SQS endpoint"
   default     = []


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Added flag to use default security group for sqs endpoint.

2. Added support for only adding 1 subnet per availability zone. Endpoints are limited to 1 subnet per availability zone.

```tf
  azs = ["us-west-2a", "us-west-2b", "us-west-2c"]
  private_subnets = [
    cidrsubnet(local.cidr, 6, 0), cidrsubnet(local.cidr, 6, 4), cidrsubnet(local.cidr, 6, 8), 
    cidrsubnet(local.cidr, 8, 4), cidrsubnet(local.cidr, 8, 20), cidrsubnet(local.cidr, 8, 36), 
  ]

// Will use subents:
// cidrsubnet(local.cidr, 6, 0), cidrsubnet(local.cidr, 6, 4), cidrsubnet(local.cidr, 6, 8)
```

3. Limited availability zones to take only first 3. This is because SQS endpoint is only supported in a,b,c availability zones. Sadly d+ do not. (Tested in us-west-2)
 
NOTE: This requires that AZ-ZONES be in order.
```tf
Works in order:
azs = ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
 
Will not work
azs = ["us-west-2d", "us-west-2b", "us-west-2a", "us-west-2a"]
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We use terragrunt and it is not possible to reference an external security group because it causes a circular dependency. Based on the example and AWS documentation using the default security group is the norm.

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This was test by using multiple input configurations of AZ + subnets.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
