### PR TITLE
docs: Document create_database_subnet_group requiring database_subnets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -209,7 +209,7 @@ variable "create_elasticache_subnet_route_table" {
 }
 
 variable "create_database_subnet_group" {
-  description = "Controls if database subnet group should be created"
+  description = "Controls if database subnet group should be created (n.b. database_subnets must also be set)"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description

I ran into the same issue as https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/126 because there's nothing in the documentation making it clear that `create_database_subnet_group` only has an effect if you also specify `database_subnets`.