### PR TITLE
feat: add vpc_owner_id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | vpc\_ipv6\_association\_id | The association ID for the IPv6 CIDR block |
 | vpc\_ipv6\_cidr\_block | The IPv6 CIDR block |
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
+| vpc\_owner\_id | The ID of the AWS account that owns the VPC |
 | vpc\_secondary\_cidr\_blocks | List of secondary CIDR blocks of the VPC |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "owner_id" {
+  description = "The owner of the VPC/Account number"
+  value       = concat(aws_vpc.this.*.owner_id, [""])[0]
+}
+
 output "vpc_id" {
   description = "The ID of the VPC"
   value       = concat(aws_vpc.this.*.id, [""])[0]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "owner_id" {
-  description = "The owner of the VPC/Account number"
-  value       = concat(aws_vpc.this.*.owner_id, [""])[0]
-}
-
 output "vpc_id" {
   description = "The ID of the VPC"
   value       = concat(aws_vpc.this.*.id, [""])[0]
@@ -71,6 +66,11 @@ output "vpc_ipv6_cidr_block" {
 output "vpc_secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks of the VPC"
   value       = aws_vpc_ipv4_cidr_block_association.this.*.cidr_block
+}
+
+output "vpc_owner_id" {
+  description = "The ID of the AWS account that owns the VPC"
+  value       = concat(aws_vpc.this.*.owner_id, [""])[0]
 }
 
 output "private_subnets" {


### PR DESCRIPTION
## Description
this will just add owner_id output to module

## Motivation and Context
I use owner_id/Account ID in different policies and building dynamic variables, for example

codebuild
```
  buildspec = templatefile("files/buildspec.yml", {
    aws_region   = var.region,
    ecr_registry = "${module.vpc.owner_id}.dkr.ecr.${var.region}.amazonaws.com/${module.label.id}-ecr"
  })
```
or iam policy
```
"Resource": [
                "arn:aws:ecr:${var.region}:${module.vpc.owner_id}:repository/ecr-${var.plat}/influxdb",
```

## Breaking Changes
none

## How Has This Been Tested?
tested calling from other resources and modules as in example above
