### PR TITLE
feat: Add support for tagging egress only internet gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,14 @@ resource "aws_egress_only_internet_gateway" "this" {
   count = var.create_vpc && var.enable_ipv6 && local.max_subnet_length > 0 ? 1 : 0
 
   vpc_id = local.vpc_id
+
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.igw_tags,
+  )
 }
 
 ################

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.53"
+    aws = "~> 2.57"
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add support for tagging egress only internet gateway

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows tagging egress only internet gateway. tagging you resources is cool.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created VPC from IPV6 example to see if egress only internet gateway tags are created

Closes #433