### PR TITLE
Fix #433 - Add missing tags to EIGW

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,13 @@ resource "aws_egress_only_internet_gateway" "this" {
   count = var.create_vpc && var.enable_ipv6 && local.max_subnet_length > 0 ? 1 : 0
 
   vpc_id = local.vpc_id
+  tags   = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.igw_tags,
+  )
 }
 
 ################

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.53"
+    aws = "~> 2.57"
   }
 }


### PR DESCRIPTION
## Description
Fix missing tags for Egress only internet gateway (#433 )
Reuse tags_igw as custom tags

## Motivation and Context
Full empty tags on AWS console, no name, nothing...

## Breaking Changes
Nothing

## How Has This Been Tested?
Run an apply again to add tags