### PR TITLE
docs: Add endpoint example for Cloudwatch

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -106,6 +106,11 @@ module "vpc" {
   sqs_endpoint_private_dns_enabled = true
   sqs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
+  # VPC endpoint for Cloudwatch
+  enable_logs_endpoint              = true
+  logs_endpoint_private_dns_enabled = true
+  logs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
+  
   # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
   enable_flow_log                      = true
   create_flow_log_cloudwatch_log_group = true


### PR DESCRIPTION
## Description
Add endpoint example for Cloudwatch to `complete-vpc/main.tf`

## Motivation and Context
The complete VPC example does not include how to allow Cloudwatch endpoints

## Breaking Changes
None

## How Has This Been Tested?
- Vars used in the project to good success
- `terraform validate` passes
