### PR TITLE
feat: Added external gateway for intra subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | intra\_subnet\_suffix | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | intra\_subnet\_tags | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | intra\_subnets | A list of intra subnets | `list(string)` | `[]` | no |
+| create\_intra\_external\_gateway\_route | Controls if an external gateway route for intra subnets should be created | `bool` | `false` | no |
+| intra\_external\_gateway | An external gateway for the intra subnets | `string` | `""` | no |
 | kinesis\_firehose\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Kinesis Firehose endpoint | `bool` | `false` | no |
 | kinesis\_firehose\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Kinesis Firehose endpoint | `list(string)` | `[]` | no |
 | kinesis\_firehose\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Kinesis Firehose endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -277,6 +277,18 @@ resource "aws_route_table" "intra" {
   )
 }
 
+resource "aws_route" "intra_external_gateway" {
+  count = var.create_vpc && length(var.intra_subnets) > 0 && var.intra_external_gateway != "" && var.create_intra_external_gateway_route ? 1 : 0
+
+  route_table_id         = aws_route_table.intra[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = var.intra_external_gateway
+
+  timeouts {
+    create = "5m"
+  }
+}
+
 ################
 # Public subnet
 ################

--- a/outputs.tf
+++ b/outputs.tf
@@ -198,6 +198,16 @@ output "intra_subnets_ipv6_cidr_blocks" {
   value       = aws_subnet.intra.*.ipv6_cidr_block
 }
 
+output "create_intra_external_gateway_route" {
+  description = "Controls if an external gateway route for intra subnets should be created"
+  value       = var.create_intra_external_gateway_route
+}
+
+output "intra_external_gateway" {
+  description = "An external gateway for the intra subnets"
+  value       = var.intra_external_gateway
+}
+
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
   value       = concat(aws_elasticache_subnet_group.elasticache.*.id, [""])[0]

--- a/variables.tf
+++ b/variables.tf
@@ -232,6 +232,18 @@ variable "create_database_internet_gateway_route" {
   default     = false
 }
 
+variable "create_intra_external_gateway_route" {
+  description = "Controls if an external gateway route for intra subnets should be created"
+  type        = bool
+  default     = false
+}
+
+variable "intra_external_gateway" {
+  description = "An external gateway for the intra subnets"
+  type        = string
+  default     = ""
+}
+
 variable "create_database_nat_gateway_route" {
   description = "Controls if a nat gateway route should be created to give internet access to the database subnets"
   type        = bool


### PR DESCRIPTION
## Description
Add create_intra_external_gateway_route and intra_external_gateway options


## Motivation and Context
We are using your vpc modules, and we need to be able to specify a default gateway for intra subnets. The (unfortunate) use case is that we are supporting an AWS Workspace setup where the traffic has to go through a Sophos gateway. Hence the need to be able to use that LB as the default gateway.



## Breaking Changes
No

## How Has This Been Tested?
This was test by using multiple input configurations with intra subnet relevance.
