### PR TITLE
feat: Add ability to supply vpc_id along with endpoint creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | use\_existing\_vpc\_id\_for\_endpoints | Whether or not to associate endpoint with an existing vpc. Used with vpc_id. | `bool` | `false` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
-| vpc\_id | The VPC id used to create endpoints when used in conjuction with use_existing_vpc_id_for_endpoints. | `string` | `` | no |
+| vpc\_id | The VPC id used to create endpoints when used in conjuction with use_existing_vpc_id_for_endpoints. | `string` | `""` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |
 | vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -594,8 +594,10 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | transferserver\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Transfer Server endpoint | `bool` | `false` | no |
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | `list(string)` | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| use\_existing\_vpc\_id\_for\_endpoints | Whether or not to associate endpoint with an existing vpc. Used with vpc_id. | `bool` | `false` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
+| vpc\_id | The VPC id used to create endpoints when used in conjuction with use_existing_vpc_id_for_endpoints. | `string` | `` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |
 | vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | intra\_dedicated\_network\_acl | Whether to use dedicated network ACL (not default) and custom rules for intra subnets | `bool` | `false` | no |
 | intra\_inbound\_acl\_rules | Intra subnets inbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | intra\_outbound\_acl\_rules | Intra subnets outbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| intra\_route\_table\_id | Used when specifying vpc\_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with a intra route | `string` | `""` | no |
 | intra\_route\_table\_tags | Additional tags for the intra route tables | `map(string)` | `{}` | no |
 | intra\_subnet\_assign\_ipv6\_address\_on\_creation | Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | intra\_subnet\_ipv6\_prefixes | Assigns IPv6 intra subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list` | `[]` | no |
@@ -505,6 +506,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | private\_dedicated\_network\_acl | Whether to use dedicated network ACL (not default) and custom rules for private subnets | `bool` | `false` | no |
 | private\_inbound\_acl\_rules | Private subnets inbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | private\_outbound\_acl\_rules | Private subnets outbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| private\_route\_table\_ids | Used when specifying vpc\_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with one or more private routes | `list(string)` | `[]` | no |
 | private\_route\_table\_tags | Additional tags for the private route tables | `map(string)` | `{}` | no |
 | private\_subnet\_assign\_ipv6\_address\_on\_creation | Assign IPv6 address on private subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | private\_subnet\_ipv6\_prefixes | Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list` | `[]` | no |
@@ -518,6 +520,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | public\_dedicated\_network\_acl | Whether to use dedicated network ACL (not default) and custom rules for public subnets | `bool` | `false` | no |
 | public\_inbound\_acl\_rules | Public subnets inbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | public\_outbound\_acl\_rules | Public subnets outbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| public\_route\_table\_id | Used when specifying vpc\_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with a public route | `string` | `""` | no |
 | public\_route\_table\_tags | Additional tags for the public route tables | `map(string)` | `{}` | no |
 | public\_subnet\_assign\_ipv6\_address\_on\_creation | Assign IPv6 address on public subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | public\_subnet\_ipv6\_prefixes | Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list` | `[]` | no |
@@ -594,10 +597,10 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | transferserver\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Transfer Server endpoint | `bool` | `false` | no |
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | `list(string)` | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
-| use\_existing\_vpc\_id\_for\_endpoints | Whether or not to associate endpoint with an existing vpc. Used with vpc_id. | `bool` | `false` | no |
+| use\_existing\_vpc\_id\_for\_endpoints | Should be set to true if you want to create endpoints with passed varible vpc\_id. Variable create\_vpc must be set to false for this to take effect. | `bool` | `false` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
-| vpc\_id | The VPC id used to create endpoints when used in conjuction with use_existing_vpc_id_for_endpoints. | `string` | `""` | no |
+| vpc\_id | The VPC id used to create endpoints when used in conjuction with use\_existing\_vpc\_id\_for\_endpoints and create\_vpc. | `string` | `""` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |
 | vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | `string` | `""` | no |

--- a/examples/endpoint-existing-vpc/README.md
+++ b/examples/endpoint-existing-vpc/README.md
@@ -1,0 +1,43 @@
+# Existing VPC and Security Group - create ONLY endpoint
+
+Configuration in this directory creates set of VPC resources which may be sufficient for creating endpoints inside an existing VPC.
+
+This configuration uses a VPC ID and Security Group ID for demonstration purposes.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| vpc_id | n/a | `string` | `""` | no |
+| sg_id | n/a | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc\_endpoint\_ec2\_id | The ID of VPC endpoint for EC2 |
+| vpc\_endpoint\_ec2\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for EC2 |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/endpoint-existing-vpc/main.tf
+++ b/examples/endpoint-existing-vpc/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = "ap-southeast-2"
+}
+
+data "aws_vpc" "existing_vpc" {
+  id = "${var.vpc_id}"
+}
+
+data "aws_security_group" "endpoint_sg" {
+  id = "${var.securitygoup_id}"
+}
+
+data "aws_subnet_ids" "subnets" {
+  vpc_id = data.aws_vpc.existing_vpc.id
+}
+
+module "vpc_endpoints" {
+  source = "../../"
+
+  create_vpc                        = false
+  use_existing_vpc_id_for_endpoints = true 
+  vpc_id                            = data.aws_vpc.existing_vpc.id
+
+  enable_ec2_endpoint               = true
+  ec2_endpoint_security_group_ids   = [data.aws_security_group.endpoint_sg.id]
+  ec2_endpoint_subnet_ids           = data.aws_subnet_ids.subnets.ids
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}

--- a/examples/endpoint-existing-vpc/outputs.tf
+++ b/examples/endpoint-existing-vpc/outputs.tf
@@ -1,0 +1,10 @@
+# Endpoints
+output "vpc_endpoint_ec2_id" {
+  description = "The ID of VPC endpoint for EC2"
+  value       = module.vpc_endpoints.vpc_endpoint_ec2_id
+}
+
+output "vpc_endpoint_ec2_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for EC2"
+  value       = module.vpc_endpoints.vpc_endpoint_ec2_network_interface_ids
+}

--- a/examples/endpoint-existing-vpc/variables.tf
+++ b/examples/endpoint-existing-vpc/variables.tf
@@ -1,0 +1,7 @@
+variable "vpc_id" {
+  default = ""
+}
+
+variable "securitygoup_id" {
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1662,7 +1662,7 @@ variable "acm_pca_endpoint_private_dns_enabled" {
 }
 
 variable "use_existing_vpc_id_for_endpoints" {
-  description = "Should be set to true if you want to create endpoints with passed varible vpc_id. Variable create_vpc must be set to false for this to take affect."
+  description = "Should be set to true if you want to create endpoints with passed varible vpc_id. Variable create_vpc must be set to false for this to take effect."
   default     = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "name" {
   default     = ""
 }
 
+variable "vpc_id" {
+  description = "The VPC id used to create endpoints when used in conjuction with use_existing_vpc_id_for_endpoints and create_vpc."
+  type        = string
+  default     = ""
+}
+
 variable "cidr" {
   description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
   type        = string
@@ -1654,6 +1660,12 @@ variable "acm_pca_endpoint_private_dns_enabled" {
   description = "Whether or not to associate a private hosted zone with the specified VPC for ACM PCA endpoint"
   default     = false
 }
+
+variable "use_existing_vpc_id_for_endpoints" {
+  description = "Should be set to true if you want to create endpoints with passed varible vpc_id. Variable create_vpc must be set to false for this to take affect."
+  default     = false
+}
+
 
 variable "map_public_ip_on_launch" {
   description = "Should be false if you do not want to auto-assign public IP on launch"

--- a/variables.tf
+++ b/variables.tf
@@ -304,6 +304,24 @@ variable "external_nat_ip_ids" {
   default     = []
 }
 
+variable "public_route_table_id" {
+  description = "Used when specifying vpc_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with a public route"
+  type        = string
+  default     = ""
+}
+
+variable "intra_route_table_id" {
+  description = "Used when specifying vpc_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with a intra route"
+  type        = string
+  default     = ""
+}
+
+variable "private_route_table_ids" {
+  description = "Used when specifying vpc_id as a variable to provision a DynamoDB or S3 endpoint to the VPC with one or more private routes"
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_dynamodb_endpoint" {
   description = "Should be true if you want to provision a DynamoDB endpoint to the VPC"
   type        = bool

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -79,15 +79,15 @@ resource "aws_vpc_endpoint_route_table_association" "public_dynamodb" {
 # VPC Endpoint for Codebuild
 #############################
 data "aws_vpc_endpoint_service" "codebuild" {
-  count = var.create_vpc && var.enable_codebuild_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codebuild_endpoint ? 1 : 0
 
   service = "codebuild"
 }
 
 resource "aws_vpc_endpoint" "codebuild" {
-  count = var.create_vpc && var.enable_codebuild_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codebuild_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.codebuild[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -101,15 +101,15 @@ resource "aws_vpc_endpoint" "codebuild" {
 # VPC Endpoint for Code Commit
 ###############################
 data "aws_vpc_endpoint_service" "codecommit" {
-  count = var.create_vpc && var.enable_codecommit_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codecommit_endpoint ? 1 : 0
 
   service = "codecommit"
 }
 
 resource "aws_vpc_endpoint" "codecommit" {
-  count = var.create_vpc && var.enable_codecommit_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codecommit_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.codecommit[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -123,15 +123,15 @@ resource "aws_vpc_endpoint" "codecommit" {
 # VPC Endpoint for Git Code Commit
 ###################################
 data "aws_vpc_endpoint_service" "git_codecommit" {
-  count = var.create_vpc && var.enable_git_codecommit_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_git_codecommit_endpoint ? 1 : 0
 
   service = "git-codecommit"
 }
 
 resource "aws_vpc_endpoint" "git_codecommit" {
-  count = var.create_vpc && var.enable_git_codecommit_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_git_codecommit_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.git_codecommit[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -145,15 +145,15 @@ resource "aws_vpc_endpoint" "git_codecommit" {
 # VPC Endpoint for Config
 ##########################
 data "aws_vpc_endpoint_service" "config" {
-  count = var.create_vpc && var.enable_config_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_config_endpoint ? 1 : 0
 
   service = "config"
 }
 
 resource "aws_vpc_endpoint" "config" {
-  count = var.create_vpc && var.enable_config_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_config_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.config[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -167,15 +167,15 @@ resource "aws_vpc_endpoint" "config" {
 # VPC Endpoint for SQS
 #######################
 data "aws_vpc_endpoint_service" "sqs" {
-  count = var.create_vpc && var.enable_sqs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sqs_endpoint ? 1 : 0
 
   service = "sqs"
 }
 
 resource "aws_vpc_endpoint" "sqs" {
-  count = var.create_vpc && var.enable_sqs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sqs_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sqs[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -189,15 +189,15 @@ resource "aws_vpc_endpoint" "sqs" {
 # VPC Endpoint for Secrets Manager
 ###################################
 data "aws_vpc_endpoint_service" "secretsmanager" {
-  count = var.create_vpc && var.enable_secretsmanager_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_secretsmanager_endpoint ? 1 : 0
 
   service = "secretsmanager"
 }
 
 resource "aws_vpc_endpoint" "secretsmanager" {
-  count = var.create_vpc && var.enable_secretsmanager_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_secretsmanager_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.secretsmanager[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -211,15 +211,15 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 # VPC Endpoint for SSM
 #######################
 data "aws_vpc_endpoint_service" "ssm" {
-  count = var.create_vpc && var.enable_ssm_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ssm_endpoint ? 1 : 0
 
   service = "ssm"
 }
 
 resource "aws_vpc_endpoint" "ssm" {
-  count = var.create_vpc && var.enable_ssm_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ssm_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ssm[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -233,15 +233,15 @@ resource "aws_vpc_endpoint" "ssm" {
 # VPC Endpoint for SSMMESSAGES
 ###############################
 data "aws_vpc_endpoint_service" "ssmmessages" {
-  count = var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ssmmessages_endpoint ? 1 : 0
 
   service = "ssmmessages"
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
-  count = var.create_vpc && var.enable_ssmmessages_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ssmmessages_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ssmmessages[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -255,15 +255,15 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 # VPC Endpoint for EC2
 #######################
 data "aws_vpc_endpoint_service" "ec2" {
-  count = var.create_vpc && var.enable_ec2_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2_endpoint ? 1 : 0
 
   service = "ec2"
 }
 
 resource "aws_vpc_endpoint" "ec2" {
-  count = var.create_vpc && var.enable_ec2_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ec2[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -277,15 +277,15 @@ resource "aws_vpc_endpoint" "ec2" {
 # VPC Endpoint for EC2MESSAGES
 ###############################
 data "aws_vpc_endpoint_service" "ec2messages" {
-  count = var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2messages_endpoint ? 1 : 0
 
   service = "ec2messages"
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
-  count = var.create_vpc && var.enable_ec2messages_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2messages_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ec2messages[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -299,15 +299,15 @@ resource "aws_vpc_endpoint" "ec2messages" {
 # VPC Endpoint for EC2 Autoscaling
 ###############################
 data "aws_vpc_endpoint_service" "ec2_autoscaling" {
-  count = var.create_vpc && var.enable_ec2_autoscaling_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2_autoscaling_endpoint ? 1 : 0
 
   service = "autoscaling"
 }
 
 resource "aws_vpc_endpoint" "ec2_autoscaling" {
-  count = var.create_vpc && var.enable_ec2_autoscaling_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ec2_autoscaling_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ec2_autoscaling[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -322,15 +322,15 @@ resource "aws_vpc_endpoint" "ec2_autoscaling" {
 # VPC Endpoint for Transfer Server
 ###################################
 data "aws_vpc_endpoint_service" "transferserver" {
-  count = var.create_vpc && var.enable_transferserver_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_transferserver_endpoint ? 1 : 0
 
   service = "transfer.server"
 }
 
 resource "aws_vpc_endpoint" "transferserver" {
-  count = var.create_vpc && var.enable_transferserver_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_transferserver_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.transferserver[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -344,15 +344,15 @@ resource "aws_vpc_endpoint" "transferserver" {
 # VPC Endpoint for ECR API
 ###########################
 data "aws_vpc_endpoint_service" "ecr_api" {
-  count = var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecr_api_endpoint ? 1 : 0
 
   service = "ecr.api"
 }
 
 resource "aws_vpc_endpoint" "ecr_api" {
-  count = var.create_vpc && var.enable_ecr_api_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecr_api_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ecr_api[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -366,15 +366,15 @@ resource "aws_vpc_endpoint" "ecr_api" {
 # VPC Endpoint for ECR DKR
 ###########################
 data "aws_vpc_endpoint_service" "ecr_dkr" {
-  count = var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecr_dkr_endpoint ? 1 : 0
 
   service = "ecr.dkr"
 }
 
 resource "aws_vpc_endpoint" "ecr_dkr" {
-  count = var.create_vpc && var.enable_ecr_dkr_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecr_dkr_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ecr_dkr[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -388,15 +388,15 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
 # VPC Endpoint for API Gateway
 #######################
 data "aws_vpc_endpoint_service" "apigw" {
-  count = var.create_vpc && var.enable_apigw_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_apigw_endpoint ? 1 : 0
 
   service = "execute-api"
 }
 
 resource "aws_vpc_endpoint" "apigw" {
-  count = var.create_vpc && var.enable_apigw_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_apigw_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.apigw[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -410,15 +410,15 @@ resource "aws_vpc_endpoint" "apigw" {
 # VPC Endpoint for KMS
 #######################
 data "aws_vpc_endpoint_service" "kms" {
-  count = var.create_vpc && var.enable_kms_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kms_endpoint ? 1 : 0
 
   service = "kms"
 }
 
 resource "aws_vpc_endpoint" "kms" {
-  count = var.create_vpc && var.enable_kms_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kms_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.kms[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -432,15 +432,15 @@ resource "aws_vpc_endpoint" "kms" {
 # VPC Endpoint for ECS
 #######################
 data "aws_vpc_endpoint_service" "ecs" {
-  count = var.create_vpc && var.enable_ecs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_endpoint ? 1 : 0
 
   service = "ecs"
 }
 
 resource "aws_vpc_endpoint" "ecs" {
-  count = var.create_vpc && var.enable_ecs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ecs[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -455,15 +455,15 @@ resource "aws_vpc_endpoint" "ecs" {
 # VPC Endpoint for ECS Agent
 #######################
 data "aws_vpc_endpoint_service" "ecs_agent" {
-  count = var.create_vpc && var.enable_ecs_agent_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_agent_endpoint ? 1 : 0
 
   service = "ecs-agent"
 }
 
 resource "aws_vpc_endpoint" "ecs_agent" {
-  count = var.create_vpc && var.enable_ecs_agent_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_agent_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ecs_agent[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -478,15 +478,15 @@ resource "aws_vpc_endpoint" "ecs_agent" {
 # VPC Endpoint for ECS Telemetry
 #######################
 data "aws_vpc_endpoint_service" "ecs_telemetry" {
-  count = var.create_vpc && var.enable_ecs_telemetry_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_telemetry_endpoint ? 1 : 0
 
   service = "ecs-telemetry"
 }
 
 resource "aws_vpc_endpoint" "ecs_telemetry" {
-  count = var.create_vpc && var.enable_ecs_telemetry_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ecs_telemetry_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ecs_telemetry[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -501,15 +501,15 @@ resource "aws_vpc_endpoint" "ecs_telemetry" {
 # VPC Endpoint for SNS
 #######################
 data "aws_vpc_endpoint_service" "sns" {
-  count = var.create_vpc && var.enable_sns_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sns_endpoint ? 1 : 0
 
   service = "sns"
 }
 
 resource "aws_vpc_endpoint" "sns" {
-  count = var.create_vpc && var.enable_sns_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sns_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sns[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -524,15 +524,15 @@ resource "aws_vpc_endpoint" "sns" {
 # VPC Endpoint for CloudWatch Monitoring
 #######################
 data "aws_vpc_endpoint_service" "monitoring" {
-  count = var.create_vpc && var.enable_monitoring_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_monitoring_endpoint ? 1 : 0
 
   service = "monitoring"
 }
 
 resource "aws_vpc_endpoint" "monitoring" {
-  count = var.create_vpc && var.enable_monitoring_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_monitoring_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.monitoring[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -547,15 +547,15 @@ resource "aws_vpc_endpoint" "monitoring" {
 # VPC Endpoint for CloudWatch Logs
 #######################
 data "aws_vpc_endpoint_service" "logs" {
-  count = var.create_vpc && var.enable_logs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_logs_endpoint ? 1 : 0
 
   service = "logs"
 }
 
 resource "aws_vpc_endpoint" "logs" {
-  count = var.create_vpc && var.enable_logs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_logs_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.logs[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -570,15 +570,15 @@ resource "aws_vpc_endpoint" "logs" {
 # VPC Endpoint for CloudWatch Events
 #######################
 data "aws_vpc_endpoint_service" "events" {
-  count = var.create_vpc && var.enable_events_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_events_endpoint ? 1 : 0
 
   service = "events"
 }
 
 resource "aws_vpc_endpoint" "events" {
-  count = var.create_vpc && var.enable_events_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_events_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.events[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -593,15 +593,15 @@ resource "aws_vpc_endpoint" "events" {
 # VPC Endpoint for Elastic Load Balancing
 #######################
 data "aws_vpc_endpoint_service" "elasticloadbalancing" {
-  count = var.create_vpc && var.enable_elasticloadbalancing_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticloadbalancing_endpoint ? 1 : 0
 
   service = "elasticloadbalancing"
 }
 
 resource "aws_vpc_endpoint" "elasticloadbalancing" {
-  count = var.create_vpc && var.enable_elasticloadbalancing_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticloadbalancing_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.elasticloadbalancing[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -616,15 +616,15 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
 # VPC Endpoint for CloudTrail
 #######################
 data "aws_vpc_endpoint_service" "cloudtrail" {
-  count = var.create_vpc && var.enable_cloudtrail_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloudtrail_endpoint ? 1 : 0
 
   service = "cloudtrail"
 }
 
 resource "aws_vpc_endpoint" "cloudtrail" {
-  count = var.create_vpc && var.enable_cloudtrail_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloudtrail_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.cloudtrail[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -639,15 +639,15 @@ resource "aws_vpc_endpoint" "cloudtrail" {
 # VPC Endpoint for Kinesis Streams
 #######################
 data "aws_vpc_endpoint_service" "kinesis_streams" {
-  count = var.create_vpc && var.enable_kinesis_streams_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kinesis_streams_endpoint ? 1 : 0
 
   service = "kinesis-streams"
 }
 
 resource "aws_vpc_endpoint" "kinesis_streams" {
-  count = var.create_vpc && var.enable_kinesis_streams_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kinesis_streams_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.kinesis_streams[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -662,15 +662,15 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
 # VPC Endpoint for Kinesis Firehose
 #######################
 data "aws_vpc_endpoint_service" "kinesis_firehose" {
-  count = var.create_vpc && var.enable_kinesis_firehose_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kinesis_firehose_endpoint ? 1 : 0
 
   service = "kinesis-firehose"
 }
 
 resource "aws_vpc_endpoint" "kinesis_firehose" {
-  count = var.create_vpc && var.enable_kinesis_firehose_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_kinesis_firehose_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.kinesis_firehose[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -684,15 +684,15 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
 # VPC Endpoint for Glue
 #######################
 data "aws_vpc_endpoint_service" "glue" {
-  count = var.create_vpc && var.enable_glue_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_glue_endpoint ? 1 : 0
 
   service = "glue"
 }
 
 resource "aws_vpc_endpoint" "glue" {
-  count = var.create_vpc && var.enable_glue_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_glue_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.glue[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -706,15 +706,15 @@ resource "aws_vpc_endpoint" "glue" {
 # VPC Endpoint for Sagemaker Notebooks
 ######################################
 data "aws_vpc_endpoint_service" "sagemaker_notebook" {
-  count = var.create_vpc && var.enable_sagemaker_notebook_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_notebook_endpoint ? 1 : 0
 
   service_name = "aws.sagemaker.${var.sagemaker_notebook_endpoint_region}.notebook"
 }
 
 resource "aws_vpc_endpoint" "sagemaker_notebook" {
-  count = var.create_vpc && var.enable_sagemaker_notebook_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_notebook_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sagemaker_notebook[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -728,15 +728,15 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
 # VPC Endpoint for STS
 #######################
 data "aws_vpc_endpoint_service" "sts" {
-  count = var.create_vpc && var.enable_sts_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sts_endpoint ? 1 : 0
 
   service = "sts"
 }
 
 resource "aws_vpc_endpoint" "sts" {
-  count = var.create_vpc && var.enable_sts_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sts_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sts[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -750,15 +750,15 @@ resource "aws_vpc_endpoint" "sts" {
 # VPC Endpoint for Cloudformation
 #############################
 data "aws_vpc_endpoint_service" "cloudformation" {
-  count = var.create_vpc && var.enable_cloudformation_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloudformation_endpoint ? 1 : 0
 
   service = "cloudformation"
 }
 
 resource "aws_vpc_endpoint" "cloudformation" {
-  count = var.create_vpc && var.enable_cloudformation_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloudformation_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.cloudformation[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -771,15 +771,15 @@ resource "aws_vpc_endpoint" "cloudformation" {
 # VPC Endpoint for CodePipeline
 #############################
 data "aws_vpc_endpoint_service" "codepipeline" {
-  count = var.create_vpc && var.enable_codepipeline_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codepipeline_endpoint ? 1 : 0
 
   service = "codepipeline"
 }
 
 resource "aws_vpc_endpoint" "codepipeline" {
-  count = var.create_vpc && var.enable_codepipeline_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_codepipeline_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.codepipeline[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -792,15 +792,15 @@ resource "aws_vpc_endpoint" "codepipeline" {
 # VPC Endpoint for AppMesh
 #############################
 data "aws_vpc_endpoint_service" "appmesh_envoy_management" {
-  count = var.create_vpc && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
 
   service = "appmesh-envoy-management"
 }
 
 resource "aws_vpc_endpoint" "appmesh_envoy_management" {
-  count = var.create_vpc && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.appmesh_envoy_management[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -813,15 +813,15 @@ resource "aws_vpc_endpoint" "appmesh_envoy_management" {
 # VPC Endpoint for Service Catalog
 #############################
 data "aws_vpc_endpoint_service" "servicecatalog" {
-  count = var.create_vpc && var.enable_servicecatalog_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_servicecatalog_endpoint ? 1 : 0
 
   service = "servicecatalog"
 }
 
 resource "aws_vpc_endpoint" "servicecatalog" {
-  count = var.create_vpc && var.enable_servicecatalog_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_servicecatalog_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.servicecatalog[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -834,15 +834,15 @@ resource "aws_vpc_endpoint" "servicecatalog" {
 # VPC Endpoint for Storage Gateway
 #############################
 data "aws_vpc_endpoint_service" "storagegateway" {
-  count = var.create_vpc && var.enable_storagegateway_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_storagegateway_endpoint ? 1 : 0
 
   service = "storagegateway"
 }
 
 resource "aws_vpc_endpoint" "storagegateway" {
-  count = var.create_vpc && var.enable_storagegateway_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_storagegateway_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.storagegateway[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -855,15 +855,15 @@ resource "aws_vpc_endpoint" "storagegateway" {
 # VPC Endpoint for Transfer
 #############################
 data "aws_vpc_endpoint_service" "transfer" {
-  count = var.create_vpc && var.enable_transfer_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_transfer_endpoint ? 1 : 0
 
   service = "transfer"
 }
 
 resource "aws_vpc_endpoint" "transfer" {
-  count = var.create_vpc && var.enable_transfer_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_transfer_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.transfer[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -876,15 +876,15 @@ resource "aws_vpc_endpoint" "transfer" {
 # VPC Endpoint for SageMaker API
 #############################
 data "aws_vpc_endpoint_service" "sagemaker_api" {
-  count = var.create_vpc && var.enable_sagemaker_api_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_api_endpoint ? 1 : 0
 
   service = "sagemaker.api"
 }
 
 resource "aws_vpc_endpoint" "sagemaker_api" {
-  count = var.create_vpc && var.enable_sagemaker_api_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_api_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sagemaker_api[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -897,15 +897,15 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
 # VPC Endpoint for SageMaker Runtime
 #############################
 data "aws_vpc_endpoint_service" "sagemaker_runtime" {
-  count = var.create_vpc && var.enable_sagemaker_runtime_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_runtime_endpoint ? 1 : 0
 
   service = "sagemaker.runtime"
 }
 
 resource "aws_vpc_endpoint" "sagemaker_runtime" {
-  count = var.create_vpc && var.enable_sagemaker_runtime_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sagemaker_runtime_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sagemaker_runtime[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -919,15 +919,15 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
 # VPC Endpoint for AppStream
 #############################
 data "aws_vpc_endpoint_service" "appstream" {
-  count = var.create_vpc && var.enable_appstream_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_appstream_endpoint ? 1 : 0
 
   service = "appstream"
 }
 
 resource "aws_vpc_endpoint" "appstream" {
-  count = var.create_vpc && var.enable_appstream_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_appstream_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.appstream[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -941,15 +941,15 @@ resource "aws_vpc_endpoint" "appstream" {
 # VPC Endpoint for Athena
 #############################
 data "aws_vpc_endpoint_service" "athena" {
-  count = var.create_vpc && var.enable_athena_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_athena_endpoint ? 1 : 0
 
   service = "athena"
 }
 
 resource "aws_vpc_endpoint" "athena" {
-  count = var.create_vpc && var.enable_athena_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_athena_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.athena[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -963,15 +963,15 @@ resource "aws_vpc_endpoint" "athena" {
 # VPC Endpoint for Rekognition
 #############################
 data "aws_vpc_endpoint_service" "rekognition" {
-  count = var.create_vpc && var.enable_rekognition_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_rekognition_endpoint ? 1 : 0
 
   service = "rekognition"
 }
 
 resource "aws_vpc_endpoint" "rekognition" {
-  count = var.create_vpc && var.enable_rekognition_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_rekognition_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.rekognition[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -985,15 +985,15 @@ resource "aws_vpc_endpoint" "rekognition" {
 # VPC Endpoint for EFS
 #######################
 data "aws_vpc_endpoint_service" "efs" {
-  count = var.create_vpc && var.enable_efs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_efs_endpoint ? 1 : 0
 
   service = "elasticfilesystem"
 }
 
 resource "aws_vpc_endpoint" "efs" {
-  count = var.create_vpc && var.enable_efs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_efs_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.efs[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1008,15 +1008,15 @@ resource "aws_vpc_endpoint" "efs" {
 # VPC Endpoint for Cloud Directory
 #######################
 data "aws_vpc_endpoint_service" "cloud_directory" {
-  count = var.create_vpc && var.enable_cloud_directory_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloud_directory_endpoint ? 1 : 0
 
   service = "clouddirectory"
 }
 
 resource "aws_vpc_endpoint" "cloud_directory" {
-  count = var.create_vpc && var.enable_cloud_directory_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_cloud_directory_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.cloud_directory[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1031,15 +1031,15 @@ resource "aws_vpc_endpoint" "cloud_directory" {
 # VPC Endpoint for Auto Scaling Plans
 #######################
 data "aws_vpc_endpoint_service" "auto_scaling_plans" {
-  count = var.create_vpc && var.enable_auto_scaling_plans_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_auto_scaling_plans_endpoint ? 1 : 0
 
   service = "autoscaling-plans"
 }
 
 resource "aws_vpc_endpoint" "auto_scaling_plans" {
-  count = var.create_vpc && var.enable_auto_scaling_plans_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_auto_scaling_plans_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.auto_scaling_plans[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1054,15 +1054,15 @@ resource "aws_vpc_endpoint" "auto_scaling_plans" {
 # VPC Endpoint for Workspaces
 #######################
 data "aws_vpc_endpoint_service" "workspaces" {
-  count = var.create_vpc && var.enable_workspaces_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_workspaces_endpoint ? 1 : 0
 
   service = "workspaces"
 }
 
 resource "aws_vpc_endpoint" "workspaces" {
-  count = var.create_vpc && var.enable_workspaces_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_workspaces_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.workspaces[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1077,15 +1077,15 @@ resource "aws_vpc_endpoint" "workspaces" {
 # VPC Endpoint for Access Analyzer
 #######################
 data "aws_vpc_endpoint_service" "access_analyzer" {
-  count = var.create_vpc && var.enable_access_analyzer_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_access_analyzer_endpoint ? 1 : 0
 
   service = "access-analyzer"
 }
 
 resource "aws_vpc_endpoint" "access_analyzer" {
-  count = var.create_vpc && var.enable_access_analyzer_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_access_analyzer_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.access_analyzer[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1100,15 +1100,15 @@ resource "aws_vpc_endpoint" "access_analyzer" {
 # VPC Endpoint for EBS
 #######################
 data "aws_vpc_endpoint_service" "ebs" {
-  count = var.create_vpc && var.enable_ebs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ebs_endpoint ? 1 : 0
 
   service = "ebs"
 }
 
 resource "aws_vpc_endpoint" "ebs" {
-  count = var.create_vpc && var.enable_ebs_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ebs_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ebs[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1123,15 +1123,15 @@ resource "aws_vpc_endpoint" "ebs" {
 # VPC Endpoint for Data Sync
 #######################
 data "aws_vpc_endpoint_service" "datasync" {
-  count = var.create_vpc && var.enable_datasync_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_datasync_endpoint ? 1 : 0
 
   service = "datasync"
 }
 
 resource "aws_vpc_endpoint" "datasync" {
-  count = var.create_vpc && var.enable_datasync_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_datasync_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.datasync[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1146,15 +1146,15 @@ resource "aws_vpc_endpoint" "datasync" {
 # VPC Endpoint for Elastic Inference Runtime
 #######################
 data "aws_vpc_endpoint_service" "elastic_inference_runtime" {
-  count = var.create_vpc && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
 
   service = "elastic-inference.runtime"
 }
 
 resource "aws_vpc_endpoint" "elastic_inference_runtime" {
-  count = var.create_vpc && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.elastic_inference_runtime[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1169,15 +1169,15 @@ resource "aws_vpc_endpoint" "elastic_inference_runtime" {
 # VPC Endpoint for SMS
 #######################
 data "aws_vpc_endpoint_service" "sms" {
-  count = var.create_vpc && var.enable_sms_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sms_endpoint ? 1 : 0
 
   service = "sms"
 }
 
 resource "aws_vpc_endpoint" "sms" {
-  count = var.create_vpc && var.enable_sms_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_sms_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.sms[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1192,15 +1192,15 @@ resource "aws_vpc_endpoint" "sms" {
 # VPC Endpoint for EMR
 #######################
 data "aws_vpc_endpoint_service" "emr" {
-  count = var.create_vpc && var.enable_emr_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_emr_endpoint ? 1 : 0
 
   service = "elasticmapreduce"
 }
 
 resource "aws_vpc_endpoint" "emr" {
-  count = var.create_vpc && var.enable_emr_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_emr_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.emr[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1215,15 +1215,15 @@ resource "aws_vpc_endpoint" "emr" {
 # VPC Endpoint for QLDB Session
 #######################
 data "aws_vpc_endpoint_service" "qldb_session" {
-  count = var.create_vpc && var.enable_qldb_session_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_qldb_session_endpoint ? 1 : 0
 
   service = "qldb.session"
 }
 
 resource "aws_vpc_endpoint" "qldb_session" {
-  count = var.create_vpc && var.enable_qldb_session_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_qldb_session_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.qldb_session[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1238,15 +1238,15 @@ resource "aws_vpc_endpoint" "qldb_session" {
 # VPC Endpoint for Step Function
 #############################
 data "aws_vpc_endpoint_service" "states" {
-  count = var.create_vpc && var.enable_states_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_states_endpoint ? 1 : 0
 
   service = "states"
 }
 
 resource "aws_vpc_endpoint" "states" {
-  count = var.create_vpc && var.enable_states_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_states_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.states[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1261,15 +1261,15 @@ resource "aws_vpc_endpoint" "states" {
 # VPC Endpoint for Elastic Beanstalk
 #############################
 data "aws_vpc_endpoint_service" "elasticbeanstalk" {
-  count = var.create_vpc && var.enable_elasticbeanstalk_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticbeanstalk_endpoint ? 1 : 0
 
   service = "elasticbeanstalk"
 }
 
 resource "aws_vpc_endpoint" "elasticbeanstalk" {
-  count = var.create_vpc && var.enable_elasticbeanstalk_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticbeanstalk_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.elasticbeanstalk[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1284,15 +1284,15 @@ resource "aws_vpc_endpoint" "elasticbeanstalk" {
 # VPC Endpoint for Elastic Beanstalk Health
 #############################
 data "aws_vpc_endpoint_service" "elasticbeanstalk_health" {
-  count = var.create_vpc && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
 
   service = "elasticbeanstalk.health"
 }
 
 resource "aws_vpc_endpoint" "elasticbeanstalk_health" {
-  count = var.create_vpc && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.elasticbeanstalk_health[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1307,15 +1307,15 @@ resource "aws_vpc_endpoint" "elasticbeanstalk_health" {
 # VPC Endpoint for ACM PCA
 #############################
 data "aws_vpc_endpoint_service" "acm_pca" {
-  count = var.create_vpc && var.enable_acm_pca_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_acm_pca_endpoint ? 1 : 0
 
   service = "acm-pca"
 }
 
 resource "aws_vpc_endpoint" "acm_pca" {
-  count = var.create_vpc && var.enable_acm_pca_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_acm_pca_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.acm_pca[0].service_name
   vpc_endpoint_type = "Interface"
 
@@ -1330,15 +1330,15 @@ resource "aws_vpc_endpoint" "acm_pca" {
 # VPC Endpoint for SES
 #######################
 data "aws_vpc_endpoint_service" "ses" {
-  count = var.create_vpc && var.enable_ses_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ses_endpoint ? 1 : 0
 
   service = "email-smtp"
 }
 
 resource "aws_vpc_endpoint" "ses" {
-  count = var.create_vpc && var.enable_ses_endpoint ? 1 : 0
+  count = (var.use_existing_vpc_id_for_endpoints || var.create_vpc) && var.enable_ses_endpoint ? 1 : 0
 
-  vpc_id            = local.vpc_id
+  vpc_id            = var.use_existing_vpc_id_for_endpoints && !var.create_vpc ? var.vpc_id : local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.ses[0].service_name
   vpc_endpoint_type = "Interface"
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding functionality to use existing VPC to create endpoints. Added two new variables, vpc_id and use_existing_vpc_id_for_endpoints, as well as adding conditional creation for the endpoints based on their input. If both of the new variables are ignored/left to default, no existing module functionality should be affected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows module to be used with an existing VPC to create endpoints not using the default security group. Also solves the circular reasoning issue below, allowing creation of a VPC, then the endpoint security group, then the endpoints.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/332

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Not that I've seen.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested example code, providing two ids listed in variables doc.
<!--- Include details of your testing environment, and the tests you ran to -->
Unable to get test-kitchen working on my mac to run the tests in the repo. Apologies.
<!--- see how your change affects other areas of the code, etc. -->
