### PR TITLE
feat: Enable support for Terraform 0.13 as a valid version by setting minimum version required

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6"
 
   required_providers {
     aws = "~> 2.53"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
     aws = "~> 2.53"


### PR DESCRIPTION
## Description
- Set minimum version required which will allow for 0.13 to start being used with module

## Motivation and Context
Closes #453

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
