### PR TITLE
feat: add database_subnet_group_name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | database\_route\_table\_ids | List of IDs of database route tables |
 | database\_subnet\_arns | List of ARNs of database subnets |
 | database\_subnet\_group | ID of database subnet group |
+| database\_subnet\_group\_name | Name of database subnet group |
 | database\_subnets | List of IDs of database subnets |
 | database\_subnets\_cidr\_blocks | List of cidr\_blocks of database subnets |
 | database\_subnets\_ipv6\_cidr\_blocks | List of IPv6 cidr\_blocks of database subnets in an IPv6 enabled VPC |

--- a/outputs.tf
+++ b/outputs.tf
@@ -138,6 +138,11 @@ output "database_subnet_group" {
   value       = concat(aws_db_subnet_group.database.*.id, [""])[0]
 }
 
+output "database_subnet_group_name" {
+  description = "Name of database subnet group"
+  value       = concat(aws_db_subnet_group.database.*.name, [""])[0]
+}
+
 output "redshift_subnets" {
   description = "List of IDs of redshift subnets"
   value       = aws_subnet.redshift.*.id


### PR DESCRIPTION
## Description
This will add `database_subnet_group_name` to outputs.

## Motivation and Context
This output will be able to be passed directly into `aws_db_instance`'s `db_subnet_group_name` argument. Previously, one had to use something like `module.vpc.name`. Although this is (functionally) the same thing, relying on the `name` variable is implicit. Additionally, this makes DB subnet groups consistent with Elasticache subnet groups.

As far as I'm aware, there is no open issue for this.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
I've tested running the modified version locally and it produces output as expected.
