### PR TITLE
fix: aws_elasticache_subnet_group name must be normalized

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,12 @@ resource "aws_subnet" "elasticache" {
 resource "aws_elasticache_subnet_group" "elasticache" {
   count = "${var.create_vpc && length(var.elasticache_subnets) > 0 && var.create_elasticache_subnet_group ? 1 : 0}"
 
-  name        = "${var.name}"
+  # Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
+  name = "${replace(replace(replace(var.name,
+     "/[[:^alnum:]]/", "-"),
+     "/-+/", "-"),
+     "/^[[:^alpha:]]*|-$/", "")}"
+
   description = "ElastiCache subnet group for ${var.name}"
   subnet_ids  = ["${aws_subnet.elasticache.*.id}"]
 }


### PR DESCRIPTION
## Description

Normalize aws_elasticache_subnet_group name

## Motivation and Context

Fix #463 for terraform 0.11

## Breaking Changes

N/A

## How Has This Been Tested?

Tested against name with `1-a2--b-@-3-` => `a2-b-3`