### PR TITLE
fix: attach vpn gateway if creating

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1083,6 +1083,13 @@ resource "aws_vpn_gateway" "this" {
   )
 }
 
+resource "aws_vpn_gateway_attachment" "that" {
+  count = var.enable_vpn_gateway ? 1 : 0
+
+  vpc_id         = local.vpc_id
+  vpn_gateway_id = aws_vpn_gateway.this[0].id
+}
+
 resource "aws_vpn_gateway_attachment" "this" {
   count = var.vpn_gateway_id != "" ? 1 : 0
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`aws_vpn_gateway` gets created if `enable_vpn_gateway` is true. But does not attach itself to the VPC. So this PR will attach `aws_vpn_gateway` if `enable_vpn_gateway` is true. Resulting in creation of VPN gateway and attaching itself to the VPC.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
