### PR TITLE
fix: bumping terraform version from 0.12.6 to 0.12.7 in circleci to include regexall function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:0.12.6
+    - image: hashicorp/terraform:0.12.29
   working_directory: /tmp/workspace/terraform
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:0.12.29
+    - image: hashicorp/terraform:0.12.7
   working_directory: /tmp/workspace/terraform
 
 jobs:


### PR DESCRIPTION
## Description
Circleci tests are failing the last releases. It is complaining about the regexall function that is not included in the current 0.12.6 version.

## Motivation and Context
I saw that the regexall function was not recognized because of an older terraform version that is used in circlci tests. I bumped the terraform version in order to fix the test.

## Breaking Changes
None as far as I know.

## How Has This Been Tested?
I ran the oneliners from the circleci config file.
