### PR TITLE
feat: bump version of aws provider version to support 3.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.57 |
+| terraform | >= 0.12.7, < 0.14 |
+| aws | >= 2.57, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.57 |
+| aws | >= 2.57, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.57"
+    aws = ">= 2.57"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.7, < 0.14"
 
   required_providers {
-    aws = ">= 2.57"
+    aws = ">= 2.57, < 4.0"
   }
 }


### PR DESCRIPTION
## Description
Bumping aws-provider requirement to ">= 2.57"

Should fix https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/478

## Motivation and Context
There is newer provider version available.

## Breaking Changes
As stated [here](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v3.0.0)

## How Has This Been Tested?
Ran it locally