### PR TITLE
fix: #481 - InvalidServiceName for elasticbeanstalk_health

### DIFF
--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1286,7 +1286,7 @@ resource "aws_vpc_endpoint" "elasticbeanstalk" {
 data "aws_vpc_endpoint_service" "elasticbeanstalk_health" {
   count = var.create_vpc && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
 
-  service = "elasticbeanstalk.health"
+  service = "elasticbeanstalk-health"
 }
 
 resource "aws_vpc_endpoint" "elasticbeanstalk_health" {


### PR DESCRIPTION
## Description
Fixes InvalidServiceName for elasticbeanstalk_health (Issue #481)

## Breaking Changes
No

## How Has This Been Tested?
We used this branch to create the endpoint successfully in eu-central-1
