### PR TITLE
fix: 0.13 upgrade

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 2.68, < 4.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.7, < 0.14"
 
   required_providers {
-    aws = ">= 2.68, < 4.0"
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 2.68, < 4.0"
+    }
   }
 }


### PR DESCRIPTION
## Description
Updated version so it loads the provider correctly

## Motivation and Context
Getting this error when running on Terraform cloud
```
Failed to instantiate provider "registry.terraform.io/-/aws" to obtain schema:
unknown provider "registry.terraform.io/-/aws"
```

## Breaking Changes
none

## How Has This Been Tested?
testing it locally
