### PR TITLE
Remove general Name tag on examples

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -120,7 +120,6 @@ module "vpc" {
   tags = {
     Owner       = "user"
     Environment = "staging"
-    Name        = "complete"
   }
 
   vpc_endpoint_tags = {


### PR DESCRIPTION
## Description
This PR remove the global Name tag from some examples. This global tag overwrite all names (subnets mainly) with a common name that does not allow to identify resources later

## Motivation and Context
I don't think it is a good practice to overwrite all names, also for starters like myself, it is hard to find the reason when you are learning from the example provided

## Breaking Changes
No, this does not break things

## How Has This Been Tested?
I run the examples with that general name tag and all my subnets were properly named