### PR TITLE
feat: Add ability to pass custom IAM policy to VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,16 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_analyzer\_endpoint\_policy | Custom IAM policy for Access Analyzer VPC endpoint | `string` | `""` | no |
 | access\_analyzer\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Access Analyzer endpoint | `bool` | `false` | no |
 | access\_analyzer\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Access Analyzer endpoint | `list(string)` | `[]` | no |
 | access\_analyzer\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Access Analyzer endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
+| acm\_pca\_endpoint\_policy | Custom IAM policy for ACM PCA VPC endpoint | `string` | `""` | no |
 | acm\_pca\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for ACM PCA endpoint | `bool` | `false` | no |
 | acm\_pca\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for ACM PCA endpoint | `list` | `[]` | no |
 | acm\_pca\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Codebuilt endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
 | amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
+| apigw\_endpoint\_policy | Custom IAM policy for API Gateway VPC endpoint | `string` | `""` | no |
 | apigw\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for API GW endpoint | `bool` | `false` | no |
 | apigw\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for API GW  endpoint | `list(string)` | `[]` | no |
 | apigw\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for API GW endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -254,14 +257,17 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | appstream\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for AppStream endpoint | `list(string)` | `[]` | no |
 | appstream\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for AppStream endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | assign\_ipv6\_address\_on\_creation | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
+| athena\_endpoint\_policy | Custom IAM policy for Athena VPC endpoint | `string` | `""` | no |
 | athena\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Athena endpoint | `bool` | `false` | no |
 | athena\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Athena endpoint | `list(string)` | `[]` | no |
 | athena\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Athena endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| auto\_scaling\_plans\_endpoint\_policy | Custom IAM policy for Auto Scaling Plans VPC endpoint | `string` | `""` | no |
 | auto\_scaling\_plans\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Auto Scaling Plans endpoint | `bool` | `false` | no |
 | auto\_scaling\_plans\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Auto Scaling Plans endpoint | `list(string)` | `[]` | no |
 | auto\_scaling\_plans\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Auto Scaling Plans endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
 | azs | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
+| cloud\_directory\_endpoint\_policy | Custom IAM policy for Cloud Directory VPC endpoint | `string` | `""` | no |
 | cloud\_directory\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Cloud Directory endpoint | `bool` | `false` | no |
 | cloud\_directory\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Cloud Directory endpoint | `list(string)` | `[]` | no |
 | cloud\_directory\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Cloud Directory endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -271,9 +277,11 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | cloudtrail\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudTrail endpoint | `bool` | `false` | no |
 | cloudtrail\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CloudTrail endpoint | `list(string)` | `[]` | no |
 | cloudtrail\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudTrail endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| codebuild\_endpoint\_policy | Custom IAM policy for Codebuild VPC endpoint | `string` | `""` | no |
 | codebuild\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Codebuild endpoint | `bool` | `false` | no |
 | codebuild\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Codebuild endpoint | `list` | `[]` | no |
 | codebuild\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Codebuilt endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
+| codecommit\_endpoint\_policy | Custom IAM policy for Code Commit VPC endpoint | `string` | `""` | no |
 | codecommit\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Codecommit endpoint | `bool` | `false` | no |
 | codecommit\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Codecommit endpoint | `list` | `[]` | no |
 | codecommit\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Codecommit endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
@@ -331,21 +339,26 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | dhcp\_options\_netbios\_node\_type | Specify netbios node\_type for DHCP options set (requires enable\_dhcp\_options set to true) | `string` | `""` | no |
 | dhcp\_options\_ntp\_servers | Specify a list of NTP servers for DHCP options set (requires enable\_dhcp\_options set to true) | `list(string)` | `[]` | no |
 | dhcp\_options\_tags | Additional tags for the DHCP option set (requires enable\_dhcp\_options set to true) | `map(string)` | `{}` | no |
+| dynamodb\_endpoint\_policy | Custom IAM policy for DynamoDB VPC endpoint | `string` | `""` | no |
 | ebs\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EBS endpoint | `bool` | `false` | no |
 | ebs\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EBS endpoint | `list(string)` | `[]` | no |
 | ebs\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EBS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
+| ec2\_autoscaling\_endpoint\_policy | Custom IAM policy for EC2 Autoscaling VPC endpoint | `string` | `""` | no |
 | ec2\_autoscaling\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 Autoscaling endpoint | `bool` | `false` | no |
 | ec2\_autoscaling\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 Autoscaling endpoint | `list(string)` | `[]` | no |
 | ec2\_autoscaling\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 Autoscaling endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| ec2\_endpoint\_policy | Custom IAM policy for EC2 VPC endpoint | `string` | `""` | no |
 | ec2\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint | `bool` | `false` | no |
 | ec2\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2 endpoint | `list(string)` | `[]` | no |
 | ec2\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | ec2messages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint | `bool` | `false` | no |
 | ec2messages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EC2MESSAGES endpoint | `list(string)` | `[]` | no |
 | ec2messages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EC2MESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| ecr\_api\_endpoint\_policy | Custom IAM policy for ECR API VPC endpoint | `string` | `""` | no |
 | ecr\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for ECR API endpoint | `bool` | `false` | no |
 | ecr\_api\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for ECR API endpoint | `list(string)` | `[]` | no |
 | ecr\_api\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for ECR api endpoint. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| ecr\_dkr\_endpoint\_policy | Custom IAM policy for ECR DKR VPC endpoint | `string` | `""` | no |
 | ecr\_dkr\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for ECR DKR endpoint | `bool` | `false` | no |
 | ecr\_dkr\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for ECR DKR endpoint | `list(string)` | `[]` | no |
 | ecr\_dkr\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for ECR dkr endpoint. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -358,6 +371,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | ecs\_telemetry\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for ECS Telemetry endpoint | `bool` | `false` | no |
 | ecs\_telemetry\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for ECS Telemetry endpoint | `list(string)` | `[]` | no |
 | ecs\_telemetry\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for ECS Telemetry endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| efs\_endpoint\_policy | Custom IAM policy for EFS VPC endpoint | `string` | `""` | no |
 | efs\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EFS endpoint | `bool` | `false` | no |
 | efs\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EFS endpoint | `list(string)` | `[]` | no |
 | efs\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EFS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -374,15 +388,18 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | `string` | `"elasticache"` | no |
 | elasticache\_subnet\_tags | Additional tags for the elasticache subnets | `map(string)` | `{}` | no |
 | elasticache\_subnets | A list of elasticache subnets | `list(string)` | `[]` | no |
+| elasticbeanstalk\_endpoint\_policy | Custom IAM policy for Elastic Beanstalk VPC endpoint | `string` | `""` | no |
 | elasticbeanstalk\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Elastic Beanstalk endpoint | `bool` | `false` | no |
 | elasticbeanstalk\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Elastic Beanstalk endpoint | `list(string)` | `[]` | no |
 | elasticbeanstalk\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Elastic Beanstalk endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | elasticbeanstalk\_health\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Elastic Beanstalk Health endpoint | `bool` | `false` | no |
 | elasticbeanstalk\_health\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Elastic Beanstalk Health endpoint | `list(string)` | `[]` | no |
 | elasticbeanstalk\_health\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Elastic Beanstalk Health endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| elasticloadbalancing\_endpoint\_policy | Custom IAM policy for Elastic Load Balancing VPC endpoint | `string` | `""` | no |
 | elasticloadbalancing\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Elastic Load Balancing endpoint | `bool` | `false` | no |
 | elasticloadbalancing\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Elastic Load Balancing endpoint | `list(string)` | `[]` | no |
 | elasticloadbalancing\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Elastic Load Balancing endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| emr\_endpoint\_policy | Custom IAM policy for EMR VPC endpoint | `string` | `""` | no |
 | emr\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for EMR endpoint | `bool` | `false` | no |
 | emr\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for EMR endpoint | `list(string)` | `[]` | no |
 | emr\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for EMR endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -455,6 +472,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | enable\_transferserver\_endpoint | Should be true if you want to provision a Transfer Server endpoint to the VPC | `bool` | `false` | no |
 | enable\_vpn\_gateway | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | `bool` | `false` | no |
 | enable\_workspaces\_endpoint | Should be true if you want to provision an Workspaces endpoint to the VPC | `bool` | `false` | no |
+| events\_endpoint\_policy | Custom IAM policy for CloudWatch Events VPC endpoint | `string` | `""` | no |
 | events\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Events endpoint | `bool` | `false` | no |
 | events\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CloudWatch Events endpoint | `list(string)` | `[]` | no |
 | events\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudWatch Events endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -487,15 +505,19 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | intra\_subnet\_suffix | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | intra\_subnet\_tags | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | intra\_subnets | A list of intra subnets | `list(string)` | `[]` | no |
+| kinesis\_firehose\_endpoint\_policy | Custom IAM policy for Kinesis Firehose VPC endpoint | `string` | `""` | no |
 | kinesis\_firehose\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Kinesis Firehose endpoint | `bool` | `false` | no |
 | kinesis\_firehose\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Kinesis Firehose endpoint | `list(string)` | `[]` | no |
 | kinesis\_firehose\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Kinesis Firehose endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| kinesis\_streams\_endpoint\_policy | Custom IAM policy for Kinesis Streams VPC endpoint | `string` | `""` | no |
 | kinesis\_streams\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Kinesis Streams endpoint | `bool` | `false` | no |
 | kinesis\_streams\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Kinesis Streams endpoint | `list(string)` | `[]` | no |
 | kinesis\_streams\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Kinesis Streams endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| kms\_endpoint\_policy | Custom IAM policy for KMS VPC endpoint | `string` | `""` | no |
 | kms\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for KMS endpoint | `bool` | `false` | no |
 | kms\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for KMS endpoint | `list(string)` | `[]` | no |
 | kms\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for KMS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| logs\_endpoint\_policy | Custom IAM policy for CloudWatch Logs VPC endpoint | `string` | `""` | no |
 | logs\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Logs endpoint | `bool` | `false` | no |
 | logs\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CloudWatch Logs endpoint | `list(string)` | `[]` | no |
 | logs\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudWatch Logs endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -503,6 +525,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | manage\_default\_security\_group | Should be true to adopt and manage default security group | `bool` | `false` | no |
 | manage\_default\_vpc | Should be true to adopt and manage Default VPC | `bool` | `false` | no |
 | map\_public\_ip\_on\_launch | Should be false if you do not want to auto-assign public IP on launch | `bool` | `true` | no |
+| monitoring\_endpoint\_policy | Custom IAM policy for CloudWatch Monitoring VPC endpoint | `string` | `""` | no |
 | monitoring\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Monitoring endpoint | `bool` | `false` | no |
 | monitoring\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CloudWatch Monitoring endpoint | `list(string)` | `[]` | no |
 | monitoring\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudWatch Monitoring endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -547,21 +570,27 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | redshift\_subnet\_suffix | Suffix to append to redshift subnets name | `string` | `"redshift"` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | `map(string)` | `{}` | no |
 | redshift\_subnets | A list of redshift subnets | `list(string)` | `[]` | no |
+| rekognition\_endpoint\_policy | Custom IAM policy for Rekognition VPC endpoint | `string` | `""` | no |
 | rekognition\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Rekognition endpoint | `bool` | `false` | no |
 | rekognition\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Rekognition endpoint | `list(string)` | `[]` | no |
 | rekognition\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Rekognition endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
+| s3\_endpoint\_policy | Custom IAM policy for S3 VPC endpoint | `string` | `""` | no |
+| sagemaker\_api\_endpoint\_policy | Custom IAM policy for SageMaker API VPC endpoint | `string` | `""` | no |
 | sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
 | sagemaker\_api\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SageMaker API endpoint | `list(string)` | `[]` | no |
 | sagemaker\_api\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SageMaker API endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sagemaker\_notebook\_endpoint\_policy | Custom IAM policy for Sagemaker Notebooks VPC endpoint | `string` | `""` | no |
 | sagemaker\_notebook\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Sagemaker Notebook endpoint | `bool` | `false` | no |
 | sagemaker\_notebook\_endpoint\_region | Region to use for Sagemaker Notebook endpoint | `string` | `""` | no |
 | sagemaker\_notebook\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Sagemaker Notebook endpoint | `list(string)` | `[]` | no |
 | sagemaker\_notebook\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Sagemaker Notebook endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sagemaker\_runtime\_endpoint\_policy | Custom IAM policy for SageMaker Runtime VPC endpoint | `string` | `""` | no |
 | sagemaker\_runtime\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker Runtime endpoint | `bool` | `false` | no |
 | sagemaker\_runtime\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SageMaker Runtime endpoint | `list(string)` | `[]` | no |
 | sagemaker\_runtime\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SageMaker Runtime endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | secondary\_cidr\_blocks | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
+| secretsmanager\_endpoint\_policy | Custom IAM policy for Secrets Manager VPC endpoint | `string` | `""` | no |
 | secretsmanager\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Secrets Manager endpoint | `bool` | `false` | no |
 | secretsmanager\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Secrets Manager endpoint | `list(string)` | `[]` | no |
 | secretsmanager\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Secrets Manager endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -575,9 +604,11 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | sms\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SMS endpoint | `bool` | `false` | no |
 | sms\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SMS endpoint | `list(string)` | `[]` | no |
 | sms\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SMS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sns\_endpoint\_policy | Custom IAM policy for SNS VPC endpoint | `string` | `""` | no |
 | sns\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SNS endpoint | `bool` | `false` | no |
 | sns\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SNS endpoint | `list(string)` | `[]` | no |
 | sns\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SNS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sqs\_endpoint\_policy | Custom IAM policy for SQS VPC endpoint | `string` | `""` | no |
 | sqs\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SQS endpoint | `bool` | `false` | no |
 | sqs\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SQS endpoint | `list` | `[]` | no |
 | sqs\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SQS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
@@ -587,12 +618,14 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | ssmmessages\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint | `bool` | `false` | no |
 | ssmmessages\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SSMMESSAGES endpoint | `list(string)` | `[]` | no |
 | ssmmessages\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SSMMESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| states\_endpoint\_policy | Custom IAM policy for Step Functions VPC endpoint | `string` | `""` | no |
 | states\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Step Function endpoint | `bool` | `false` | no |
 | states\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Step Function endpoint | `list(string)` | `[]` | no |
 | states\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Step Function endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | storagegateway\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Storage Gateway endpoint | `bool` | `false` | no |
 | storagegateway\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Storage Gateway endpoint | `list(string)` | `[]` | no |
 | storagegateway\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Storage Gateway endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sts\_endpoint\_policy | Custom IAM policy for STS VPC endpoint | `string` | `""` | no |
 | sts\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for STS endpoint | `bool` | `false` | no |
 | sts\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for STS endpoint | `list(string)` | `[]` | no |
 | sts\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for STS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -609,6 +642,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |
 | vpn\_gateway\_id | ID of VPN Gateway to attach to the VPC | `string` | `""` | no |
 | vpn\_gateway\_tags | Additional tags for the VPN gateway | `map(string)` | `{}` | no |
+| workspaces\_endpoint\_policy | Custom IAM policy for Workspaces VPC endpoint | `string` | `""` | no |
 | workspaces\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Workspaces endpoint | `bool` | `false` | no |
 | workspaces\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Workspaces endpoint | `list(string)` | `[]` | no |
 | workspaces\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Workspaces endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -2372,3 +2372,207 @@ variable "create_egress_only_igw" {
   type        = bool
   default     = true
 }
+
+variable "s3_endpoint_policy" {
+  description = "Custom IAM policy for S3 VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "dynamodb_endpoint_policy" {
+  description = "Custom IAM policy for DynamoDB VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "codebuild_endpoint_policy" {
+  description = "Custom IAM policy for Codebuild VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "codecommit_endpoint_policy" {
+  description = "Custom IAM policy for Code Commit VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sqs_endpoint_policy" {
+  description = "Custom IAM policy for SQS VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "secretsmanager_endpoint_policy" {
+  description = "Custom IAM policy for Secrets Manager VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "ec2_endpoint_policy" {
+  description = "Custom IAM policy for EC2 VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "ec2_autoscaling_endpoint_policy" {
+  description = "Custom IAM policy for EC2 Autoscaling VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "ecr_api_endpoint_policy" {
+  description = "Custom IAM policy for ECR API VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "ecr_dkr_endpoint_policy" {
+  description = "Custom IAM policy for ECR DKR VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "apigw_endpoint_policy" {
+  description = "Custom IAM policy for API Gateway VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "kms_endpoint_policy" {
+  description = "Custom IAM policy for KMS VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sns_endpoint_policy" {
+  description = "Custom IAM policy for SNS VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "monitoring_endpoint_policy" {
+  description = "Custom IAM policy for CloudWatch Monitoring VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "logs_endpoint_policy" {
+  description = "Custom IAM policy for CloudWatch Logs VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "events_endpoint_policy" {
+  description = "Custom IAM policy for CloudWatch Events VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "elasticloadbalancing_endpoint_policy" {
+  description = "Custom IAM policy for Elastic Load Balancing VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "kinesis_streams_endpoint_policy" {
+  description = "Custom IAM policy for Kinesis Streams VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "kinesis_firehose_endpoint_policy" {
+  description = "Custom IAM policy for Kinesis Firehose VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sagemaker_notebook_endpoint_policy" {
+  description = "Custom IAM policy for Sagemaker Notebooks VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sts_endpoint_policy" {
+  description = "Custom IAM policy for STS VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sagemaker_api_endpoint_policy" {
+  description = "Custom IAM policy for SageMaker API VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "sagemaker_runtime_endpoint_policy" {
+  description = "Custom IAM policy for SageMaker Runtime VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "athena_endpoint_policy" {
+  description = "Custom IAM policy for Athena VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "rekognition_endpoint_policy" {
+  description = "Custom IAM policy for Rekognition VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "efs_endpoint_policy" {
+  description = "Custom IAM policy for EFS VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "cloud_directory_endpoint_policy" {
+  description = "Custom IAM policy for Cloud Directory VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "auto_scaling_plans_endpoint_policy" {
+  description = "Custom IAM policy for Auto Scaling Plans VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "workspaces_endpoint_policy" {
+  description = "Custom IAM policy for Workspaces VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "access_analyzer_endpoint_policy" {
+  description = "Custom IAM policy for Access Analyzer VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "emr_endpoint_policy" {
+  description = "Custom IAM policy for EMR VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "states_endpoint_policy" {
+  description = "Custom IAM policy for Step Functions VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "elasticbeanstalk_endpoint_policy" {
+  description = "Custom IAM policy for Elastic Beanstalk VPC endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "acm_pca_endpoint_policy" {
+  description = "Custom IAM policy for ACM PCA VPC endpoint"
+  type        = string
+  default     = ""
+}

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,3 +1,17 @@
+data "aws_iam_policy_document" "default" {
+  version = "2008-10-17"
+
+  statement {
+    actions   = ["*"]
+    resources = ["*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
 ######################
 # VPC Endpoint for S3
 ######################
@@ -12,6 +26,7 @@ resource "aws_vpc_endpoint" "s3" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.s3[0].service_name
+  policy       = var.s3_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.s3_endpoint_policy
   tags         = local.vpce_tags
 }
 
@@ -50,6 +65,7 @@ resource "aws_vpc_endpoint" "dynamodb" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.dynamodb[0].service_name
+  policy       = var.dynamodb_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.dynamodb_endpoint_policy
   tags         = local.vpce_tags
 }
 
@@ -94,6 +110,7 @@ resource "aws_vpc_endpoint" "codebuild" {
   security_group_ids  = var.codebuild_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codebuild_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
+  policy              = var.codebuild_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.codebuild_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -116,6 +133,7 @@ resource "aws_vpc_endpoint" "codecommit" {
   security_group_ids  = var.codecommit_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
+  policy              = var.codecommit_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.codecommit_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -182,6 +200,7 @@ resource "aws_vpc_endpoint" "sqs" {
   security_group_ids  = var.sqs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sqs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
+  policy              = var.sqs_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sqs_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -204,6 +223,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   security_group_ids  = var.secretsmanager_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.secretsmanager_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
+  policy              = var.secretsmanager_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.secretsmanager_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -270,6 +290,7 @@ resource "aws_vpc_endpoint" "ec2" {
   security_group_ids  = var.ec2_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2_endpoint_private_dns_enabled
+  policy              = var.ec2_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.ec2_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -314,6 +335,7 @@ resource "aws_vpc_endpoint" "ec2_autoscaling" {
   security_group_ids  = var.ec2_autoscaling_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2_autoscaling_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2_autoscaling_endpoint_private_dns_enabled
+  policy              = var.ec2_autoscaling_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.ec2_autoscaling_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -359,6 +381,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   security_group_ids  = var.ecr_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
+  policy              = var.ecr_api_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.ecr_api_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -381,6 +404,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   security_group_ids  = var.ecr_dkr_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
+  policy              = var.ecr_dkr_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.ecr_dkr_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -403,6 +427,7 @@ resource "aws_vpc_endpoint" "apigw" {
   security_group_ids  = var.apigw_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.apigw_endpoint_private_dns_enabled
+  policy              = var.apigw_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.apigw_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -425,6 +450,7 @@ resource "aws_vpc_endpoint" "kms" {
   security_group_ids  = var.kms_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kms_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kms_endpoint_private_dns_enabled
+  policy              = var.kms_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.kms_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -516,6 +542,7 @@ resource "aws_vpc_endpoint" "sns" {
   security_group_ids  = var.sns_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sns_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sns_endpoint_private_dns_enabled
+  policy              = var.sns_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sns_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -539,6 +566,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   security_group_ids  = var.monitoring_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.monitoring_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
+  policy              = var.monitoring_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.monitoring_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -562,6 +590,7 @@ resource "aws_vpc_endpoint" "logs" {
   security_group_ids  = var.logs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.logs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.logs_endpoint_private_dns_enabled
+  policy              = var.logs_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.logs_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -585,6 +614,7 @@ resource "aws_vpc_endpoint" "events" {
   security_group_ids  = var.events_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.events_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.events_endpoint_private_dns_enabled
+  policy              = var.events_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.events_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -608,6 +638,7 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
   security_group_ids  = var.elasticloadbalancing_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticloadbalancing_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
+  policy              = var.elasticloadbalancing_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.elasticloadbalancing_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -654,6 +685,7 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
   security_group_ids  = var.kinesis_streams_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_streams_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
+  policy              = var.kinesis_streams_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.kinesis_streams_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -677,6 +709,7 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
   security_group_ids  = var.kinesis_firehose_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_firehose_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
+  policy              = var.kinesis_firehose_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.kinesis_firehose_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -721,6 +754,7 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
   security_group_ids  = var.sagemaker_notebook_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_notebook_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
+  policy              = var.sagemaker_notebook_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sagemaker_notebook_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -743,6 +777,7 @@ resource "aws_vpc_endpoint" "sts" {
   security_group_ids  = var.sts_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sts_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sts_endpoint_private_dns_enabled
+  policy              = var.sts_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sts_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -891,6 +926,7 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
   security_group_ids  = var.sagemaker_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
+  policy              = var.sagemaker_api_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sagemaker_api_endpoint_policy
   tags                = local.vpce_tags
 }
 #############################
@@ -912,6 +948,7 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
   security_group_ids  = var.sagemaker_runtime_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_runtime_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
+  policy              = var.sagemaker_runtime_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.sagemaker_runtime_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -956,6 +993,7 @@ resource "aws_vpc_endpoint" "athena" {
   security_group_ids  = var.athena_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.athena_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.athena_endpoint_private_dns_enabled
+  policy              = var.athena_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.athena_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -978,6 +1016,7 @@ resource "aws_vpc_endpoint" "rekognition" {
   security_group_ids  = var.rekognition_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.rekognition_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
+  policy              = var.rekognition_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.rekognition_endpoint_policy
   tags                = local.vpce_tags
 }
 
@@ -1000,8 +1039,8 @@ resource "aws_vpc_endpoint" "efs" {
   security_group_ids  = var.efs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.efs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.efs_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.efs_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.efs_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1023,8 +1062,8 @@ resource "aws_vpc_endpoint" "cloud_directory" {
   security_group_ids  = var.cloud_directory_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloud_directory_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloud_directory_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.cloud_directory_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.cloud_directory_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1046,8 +1085,8 @@ resource "aws_vpc_endpoint" "auto_scaling_plans" {
   security_group_ids  = var.auto_scaling_plans_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.auto_scaling_plans_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.auto_scaling_plans_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.auto_scaling_plans_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.auto_scaling_plans_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1069,8 +1108,8 @@ resource "aws_vpc_endpoint" "workspaces" {
   security_group_ids  = var.workspaces_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.workspaces_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.workspaces_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.workspaces_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.workspaces_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1092,8 +1131,8 @@ resource "aws_vpc_endpoint" "access_analyzer" {
   security_group_ids  = var.access_analyzer_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.access_analyzer_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.access_analyzer_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.access_analyzer_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.access_analyzer_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1207,8 +1246,8 @@ resource "aws_vpc_endpoint" "emr" {
   security_group_ids  = var.emr_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.emr_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.emr_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.emr_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.emr_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################
@@ -1253,8 +1292,8 @@ resource "aws_vpc_endpoint" "states" {
   security_group_ids  = var.states_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.states_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.states_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.states_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.states_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #############################
@@ -1276,8 +1315,8 @@ resource "aws_vpc_endpoint" "elasticbeanstalk" {
   security_group_ids  = var.elasticbeanstalk_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticbeanstalk_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticbeanstalk_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.elasticbeanstalk_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.elasticbeanstalk_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #############################
@@ -1322,8 +1361,8 @@ resource "aws_vpc_endpoint" "acm_pca" {
   security_group_ids  = var.acm_pca_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.acm_pca_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.acm_pca_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  policy              = var.acm_pca_endpoint_policy == "" ? data.aws_iam_policy_document.default.json : var.acm_pca_endpoint_policy
+  tags                = local.vpce_tags
 }
 
 #######################


### PR DESCRIPTION
## Description
In order to fix #437 
Inspired by #341 

Added ability to pass custom IAM policy as JSON string to any VPC endpoint that supports it atm

## Motivation and Context
Default `Full Access` endpoints policy is a security concern. At least, accordingly to ISO27001

## Breaking Changes
No breaking changes

Been tested with custom and default IAM policies.
