### PR TITLE
feat: Add ability to create CodeDeploy endpoint to VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | codecommit\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Codecommit endpoint | `bool` | `false` | no |
 | codecommit\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Codecommit endpoint | `list` | `[]` | no |
 | codecommit\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Codecommit endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
+| codedeploy\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CodeDeploy endpoint | `bool` | `false` | no |
+| codedeploy\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CodeDeploy endpoint | `list(string)` | `[]` | no |
+| codedeploy\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CodeDeploy endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | codepipeline\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CodePipeline endpoint | `bool` | `false` | no |
 | codepipeline\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CodePipeline endpoint | `list(string)` | `[]` | no |
 | codepipeline\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CodePipeline endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -400,6 +403,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | enable\_cloudtrail\_endpoint | Should be true if you want to provision a CloudTrail endpoint to the VPC | `bool` | `false` | no |
 | enable\_codebuild\_endpoint | Should be true if you want to provision an Codebuild endpoint to the VPC | `bool` | `false` | no |
 | enable\_codecommit\_endpoint | Should be true if you want to provision an Codecommit endpoint to the VPC | `bool` | `false` | no |
+| enable\_codedeploy\_endpoint | Should be true if you want to provision an CodeDeploy endpoint to the VPC | `bool` | `false` | no |
 | enable\_codepipeline\_endpoint | Should be true if you want to provision a CodePipeline endpoint to the VPC | `bool` | `false` | no |
 | enable\_config\_endpoint | Should be true if you want to provision an config endpoint to the VPC | `bool` | `false` | no |
 | enable\_datasync\_endpoint | Should be true if you want to provision an Data Sync endpoint to the VPC | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Git-Codecommit, Transfer Server, Kinesis Streams, Kinesis Firehose, SageMaker(No
 CloudFormation, CodePipeline, Storage Gateway, AppMesh, Transfer, Service Catalog, AppStream,
 Athena, Rekognition, Elastic File System (EFS), Cloud Directory, Elastic Beanstalk (+ Health), Elastic Map Reduce(EMR),
 DataSync, EBS, SMS, Elastic Inference Runtime, QLDB Session, Step Functions, Access Analyzer, Auto Scaling Plans,
-Application Auto Scaling, Workspaces, ACM PCA, RDS.
+Application Auto Scaling, Workspaces, ACM PCA, RDS, CodeDeploy, CodeDeploy Commands Secure
 
 * [RDS DB Subnet Group](https://www.terraform.io/docs/providers/aws/r/db_subnet_group.html)
 * [ElastiCache Subnet Group](https://www.terraform.io/docs/providers/aws/r/elasticache_subnet_group.html)
@@ -277,6 +277,9 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | codecommit\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Codecommit endpoint | `bool` | `false` | no |
 | codecommit\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Codecommit endpoint | `list` | `[]` | no |
 | codecommit\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Codecommit endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list` | `[]` | no |
+| codedeploy\_commands\_secure\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CodeDeploy Commands Secure endpoint | `bool` | `false` | no |
+| codedeploy\_commands\_secure\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CodeDeploy Commands Secure endpoint | `list(string)` | `[]` | no |
+| codedeploy\_commands\_secure\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CodeDeploy Commands Secure endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | codedeploy\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CodeDeploy endpoint | `bool` | `false` | no |
 | codedeploy\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CodeDeploy endpoint | `list(string)` | `[]` | no |
 | codedeploy\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CodeDeploy endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -403,6 +406,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | enable\_cloudtrail\_endpoint | Should be true if you want to provision a CloudTrail endpoint to the VPC | `bool` | `false` | no |
 | enable\_codebuild\_endpoint | Should be true if you want to provision an Codebuild endpoint to the VPC | `bool` | `false` | no |
 | enable\_codecommit\_endpoint | Should be true if you want to provision an Codecommit endpoint to the VPC | `bool` | `false` | no |
+| enable\_codedeploy\_commands\_secure\_endpoint | Should be true if you want to provision an CodeDeploy Commands Secure endpoint to the VPC | `bool` | `false` | no |
 | enable\_codedeploy\_endpoint | Should be true if you want to provision an CodeDeploy endpoint to the VPC | `bool` | `false` | no |
 | enable\_codepipeline\_endpoint | Should be true if you want to provision a CodePipeline endpoint to the VPC | `bool` | `false` | no |
 | enable\_config\_endpoint | Should be true if you want to provision an config endpoint to the VPC | `bool` | `false` | no |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -102,9 +102,9 @@ module "vpc" {
   ecs_telemetry_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # VPC endpoint for SQS
-  enable_sqs_endpoint              = true
-  sqs_endpoint_private_dns_enabled = true
-  sqs_endpoint_security_group_ids  = [data.aws_security_group.default.id]
+  enable_codedeploy_endpoint              = true
+  codedeploy_endpoint_private_dns_enabled = true
+  codedeploy_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
   # Default security group - ingress/egress rules cleared to deny all
   manage_default_security_group  = true

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -101,7 +101,7 @@ module "vpc" {
   ecs_telemetry_endpoint_private_dns_enabled = true
   ecs_telemetry_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
-  # VPC endpoint for SQS
+  # VPC endpoint for CodeDeploy
   enable_codedeploy_endpoint              = true
   codedeploy_endpoint_private_dns_enabled = true
   codedeploy_endpoint_security_group_ids  = [data.aws_security_group.default.id]

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -106,6 +106,11 @@ module "vpc" {
   codedeploy_endpoint_private_dns_enabled = true
   codedeploy_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
+  # VPC endpoint for CodeDeploy Commands Secure
+  enable_codedeploy_commands_secure_endpoint              = true
+  codedeploy_commands_secure_endpoint_private_dns_enabled = true
+  codedeploy_commands_secure_endpoint_security_group_ids  = [data.aws_security_group.default.id]
+
   # Default security group - ingress/egress rules cleared to deny all
   manage_default_security_group  = true
   default_security_group_ingress = [{}]

--- a/variables.tf
+++ b/variables.tf
@@ -1694,6 +1694,30 @@ variable "codedeploy_endpoint_private_dns_enabled" {
   default     = false
 }
 
+variable "enable_codedeploy_commands_secure_endpoint" {
+  description = "Should be true if you want to provision an CodeDeploy Commands Secure endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "codedeploy_commands_secure_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for CodeDeploy Commands Secure endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "codedeploy_commands_secure_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for CodeDeploy Commands Secure endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "codedeploy_commands_secure_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for CodeDeploy Commands Secure endpoint"
+  type        = bool
+  default     = false
+}
+
 variable "acm_pca_endpoint_security_group_ids" {
   description = "The ID of one or more security groups to associate with the network interface for ACM PCA endpoint"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -1670,6 +1670,30 @@ variable "rds_endpoint_private_dns_enabled" {
   default     = false
 }
 
+variable "enable_codedeploy_endpoint" {
+  description = "Should be true if you want to provision an CodeDeploy endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "codedeploy_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for CodeDeploy endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "codedeploy_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for CodeDeploy endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "codedeploy_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for CodeDeploy endpoint"
+  type        = bool
+  default     = false
+}
+
 variable "acm_pca_endpoint_security_group_ids" {
   description = "The ID of one or more security groups to associate with the network interface for ACM PCA endpoint"
   default     = []

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1371,3 +1371,26 @@ resource "aws_vpc_endpoint" "rds" {
 
   tags = local.vpce_tags
 }
+
+#############################
+# VPC Endpoint for CodeDeploy
+#############################
+data "aws_vpc_endpoint_service" "codedeploy" {
+  count = var.create_vpc && var.enable_codedeploy_endpoint ? 1 : 0
+
+  service = "codedeploy"
+}
+
+resource "aws_vpc_endpoint" "codedeploy" {
+  count = var.create_vpc && var.enable_codedeploy_endpoint ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.codedeploy[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = var.codedeploy_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.codedeploy_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.codedeploy_endpoint_private_dns_enabled
+
+  tags = local.vpce_tags
+}

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1394,3 +1394,26 @@ resource "aws_vpc_endpoint" "codedeploy" {
 
   tags = local.vpce_tags
 }
+
+#############################################
+# VPC Endpoint for CodeDeploy Commands Secure
+#############################################
+data "aws_vpc_endpoint_service" "codedeploy_commands_secure" {
+  count = var.create_vpc && var.enable_codedeploy_commands_secure_endpoint ? 1 : 0
+
+  service = "codedeploy-commands-secure"
+}
+
+resource "aws_vpc_endpoint" "codedeploy_commands_secure" {
+  count = var.create_vpc && var.enable_codedeploy_commands_secure_endpoint ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.codedeploy_commands_secure[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = var.codedeploy_commands_secure_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.codedeploy_commands_secure_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.codedeploy_commands_secure_endpoint_private_dns_enabled
+
+  tags = local.vpce_tags
+}


### PR DESCRIPTION
## Description
Added ability to create CodeDeploy endpoint to VPC

## Motivation and Context
AWS recently added support for [CodeDeploy VPC endpoints
](https://aws.amazon.com/ru/about-aws/whats-new/2020/08/aws-codedeploy-now-supports-deployments-to-virtual-private-cloud-endpoints/)
## Breaking Changes
This change doesn't break backwards compatibility with current release
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
I've tested it by running `complete-vpc` example and check if endpoints setup correctly.
