### PR TITLE
revert: Create only required number of NAT gateways

### DIFF
--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -9,15 +9,14 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs              = ["eu-west-1a", "eu-west-1b", "euw1-az3"]
-  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
-  database_subnets = ["10.0.5.0/24"]
-  public_subnets   = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24", "10.0.104.0/24"]
+  azs             = ["eu-west-1a", "eu-west-1b", "euw1-az3"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_ipv6 = true
 
   enable_nat_gateway = true
-  #  single_nat_gateway = true
-
-  create_database_subnet_group = false
+  single_nat_gateway = true
 
   public_subnet_tags = {
     Name = "overridden-name-public"

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
     length(var.database_subnets),
     length(var.redshift_subnets),
   )
-  nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length < length(var.public_subnets) ? local.max_subnet_length : length(var.public_subnets)
+  nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
   vpc_id = element(


### PR DESCRIPTION
Reverts terraform-aws-modules/terraform-aws-vpc#492

The fix was not necessary and not working as expected.