### PR TITLE
fix: Typo on simple-vpc example

### DIFF
--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -40,7 +40,7 @@ No input.
 
 | Name | Description |
 |------|-------------|
-| azs | A list of availability zones spefified as argument to this module |
+| azs | A list of availability zones specified as argument to this module |
 | nat\_public\_ips | List of public Elastic IPs created for AWS NAT Gateway |
 | private\_subnets | List of IDs of private subnets |
 | public\_subnets | List of IDs of public subnets |

--- a/examples/simple-vpc/outputs.tf
+++ b/examples/simple-vpc/outputs.tf
@@ -29,7 +29,7 @@ output "nat_public_ips" {
 
 # AZs
 output "azs" {
-  description = "A list of availability zones spefified as argument to this module"
+  description = "A list of availability zones specified as argument to this module"
   value       = module.vpc.azs
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Just fixing a typo on the simple vpc example.
