### PR TITLE
Fix: Use map instead of list for subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,29 @@ module "vpc" {
   name = "my-vpc"
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.2.0/24",
+      az   = "eu-west-1a"
+    }
 
+  }
+  public_subnets = {
+    "subnet-3" = {
+      cidr = "10.0.101.0/24",
+      az   = "eu-west-1a"
+    },
+     "subnet-4" = {
+      cidr = "10.0.102.0/24",
+      az   = "eu-west-1b"
+    }
+
+
+ }
   enable_nat_gateway = true
   enable_vpn_gateway = true
 
@@ -127,11 +146,76 @@ If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, the
 By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway.  For example, if your configuration looks like the following:
 
 ```hcl
-database_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
-elasticache_subnets = ["10.0.31.0/24", "10.0.32.0/24"]
-private_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
-redshift_subnets    = ["10.0.41.0/24", "10.0.42.0/24"]
-intra_subnets       = ["10.0.51.0/24", "10.0.52.0/24", "10.0.53.0/24"]
+database__subnets = {
+    "subnet-1" = {
+      cidr = "10.0.21.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.22.0/24",
+      az   = "eu-west-1a"
+    }
+
+  }
+elasticache_subnets = {
+    "subnet-3" = {
+      cidr = "10.0.31.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-4" = {
+      cidr = "10.0.32.0/24",
+      az   = "eu-west-1a"
+    }
+
+  }
+private_subnets = {
+    "subnet-5" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-6" = {
+      cidr = "10.0.2.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-7" = {
+      cidr = "10.0.3.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-8" = {
+      cidr = "10.0.4.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-9" = {
+      cidr = "10.0.5.0/24",
+      az   = "eu-west-1a"
+    }
+  }
+redshift_subnets = {
+    "subnet-10" = {
+      cidr = "10.0.41.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-11" = {
+      cidr = "10.0.42.0/24",
+      az   = "eu-west-1a"
+    }
+
+  }
+
+intra_subnets = {
+    "subnet-12" = {
+      cidr = "10.0.51.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-13" = {
+      cidr = "10.0.52.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-14" = {
+      cidr = "10.0.53.0/24",
+      az   = "eu-west-1a"
+    }
+  }
 ```
 
 Then `5` NAT Gateways will be created since `5` private subnet CIDR blocks were specified.
@@ -263,7 +347,6 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | auto\_scaling\_plans\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Auto Scaling Plans endpoint | `bool` | `false` | no |
 | auto\_scaling\_plans\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Auto Scaling Plans endpoint | `list(string)` | `[]` | no |
 | auto\_scaling\_plans\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Auto Scaling Plans endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
-| azs | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
 | cloud\_directory\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Cloud Directory endpoint | `bool` | `false` | no |
 | cloud\_directory\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Cloud Directory endpoint | `list(string)` | `[]` | no |
@@ -317,7 +400,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | database\_subnet\_ipv6\_prefixes | Assigns IPv6 database subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | database\_subnet\_suffix | Suffix to append to database subnets name | `string` | `"db"` | no |
 | database\_subnet\_tags | Additional tags for the database subnets | `map(string)` | `{}` | no |
-| database\_subnets | A list of database subnets | `list(string)` | `[]` | no |
+| database\_subnets | A list of database subnets | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | datasync\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Data Sync endpoint | `bool` | `false` | no |
 | datasync\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Data Sync endpoint | `list(string)` | `[]` | no |
 | datasync\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Data Sync endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -382,7 +465,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | elasticache\_subnet\_ipv6\_prefixes | Assigns IPv6 elasticache subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | elasticache\_subnet\_suffix | Suffix to append to elasticache subnets name | `string` | `"elasticache"` | no |
 | elasticache\_subnet\_tags | Additional tags for the elasticache subnets | `map(string)` | `{}` | no |
-| elasticache\_subnets | A list of elasticache subnets | `list(string)` | `[]` | no |
+| elasticache\_subnets | A list of elasticache subnets | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | elasticbeanstalk\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Elastic Beanstalk endpoint | `bool` | `false` | no |
 | elasticbeanstalk\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Elastic Beanstalk endpoint | `list(string)` | `[]` | no |
 | elasticbeanstalk\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Elastic Beanstalk endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -501,7 +584,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | intra\_subnet\_ipv6\_prefixes | Assigns IPv6 intra subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | intra\_subnet\_suffix | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | intra\_subnet\_tags | Additional tags for the intra subnets | `map(string)` | `{}` | no |
-| intra\_subnets | A list of intra subnets | `list(string)` | `[]` | no |
+| intra\_subnets | A list of intra subnets | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | kinesis\_firehose\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Kinesis Firehose endpoint | `bool` | `false` | no |
 | kinesis\_firehose\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Kinesis Firehose endpoint | `list(string)` | `[]` | no |
 | kinesis\_firehose\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Kinesis Firehose endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -534,7 +617,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | private\_subnet\_ipv6\_prefixes | Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | private\_subnet\_suffix | Suffix to append to private subnets name | `string` | `"private"` | no |
 | private\_subnet\_tags | Additional tags for the private subnets | `map(string)` | `{}` | no |
-| private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
+| private\_subnets | A list of private subnets inside the VPC | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | propagate\_intra\_route\_tables\_vgw | Should be true if you want route table propagation | `bool` | `false` | no |
 | propagate\_private\_route\_tables\_vgw | Should be true if you want route table propagation | `bool` | `false` | no |
 | propagate\_public\_route\_tables\_vgw | Should be true if you want route table propagation | `bool` | `false` | no |
@@ -547,7 +630,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | public\_subnet\_ipv6\_prefixes | Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | public\_subnet\_suffix | Suffix to append to public subnets name | `string` | `"public"` | no |
 | public\_subnet\_tags | Additional tags for the public subnets | `map(string)` | `{}` | no |
-| public\_subnets | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
+| public\_subnets | A list of public subnets inside the VPC | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | qldb\_session\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for QLDB Session endpoint | `bool` | `false` | no |
 | qldb\_session\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for QLDB Session endpoint | `list(string)` | `[]` | no |
 | qldb\_session\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for QLDB Session endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -564,7 +647,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | redshift\_subnet\_ipv6\_prefixes | Assigns IPv6 redshift subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | redshift\_subnet\_suffix | Suffix to append to redshift subnets name | `string` | `"redshift"` | no |
 | redshift\_subnet\_tags | Additional tags for the redshift subnets | `map(string)` | `{}` | no |
-| redshift\_subnets | A list of redshift subnets | `list(string)` | `[]` | no |
+| redshift\_subnets | A list of redshift subnets | <pre>map(object({<br>    cidr = string,<br>    az   = string<br>  }))</pre> | `{}` | no |
 | rekognition\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Rekognition endpoint | `bool` | `false` | no |
 | rekognition\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Rekognition endpoint | `list(string)` | `[]` | no |
 | rekognition\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Rekognition endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -638,7 +721,6 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Description |
 |------|-------------|
-| azs | A list of availability zones specified as argument to this module |
 | cgw\_arns | List of ARNs of Customer Gateway |
 | cgw\_ids | List of IDs of Customer Gateway |
 | database\_internet\_gateway\_route\_id | ID of the database internet gateway route. |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -14,13 +14,90 @@ module "vpc" {
 
   cidr = "20.10.0.0/16" # 10.0.0.0/8 is reserved for EC2-Classic
 
-  azs                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets     = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
-  public_subnets      = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
-  database_subnets    = ["20.10.21.0/24", "20.10.22.0/24", "20.10.23.0/24"]
-  elasticache_subnets = ["20.10.31.0/24", "20.10.32.0/24", "20.10.33.0/24"]
-  redshift_subnets    = ["20.10.41.0/24", "20.10.42.0/24", "20.10.43.0/24"]
-  intra_subnets       = ["20.10.51.0/24", "20.10.52.0/24", "20.10.53.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "20.10.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "20.10.2.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "20.10.3.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "20.10.11.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "20.10.12.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "20.10.13.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  database_subnets = {
+    "subnet-7" = {
+      cidr = "20.10.21.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-8" = {
+      cidr = "20.10.22.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-9" = {
+      cidr = "20.10.23.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  elasticache_subnets = {
+    "subnet-10" = {
+      cidr = "20.10.31.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-11" = {
+      cidr = "20.10.32.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-12" = {
+      cidr = "20.10.33.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  redshift_subnets = {
+    "subnet-13" = {
+      cidr = "20.10.41.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-14" = {
+      cidr = "20.10.42.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-15" = {
+      cidr = "20.10.43.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  intra_subnets = {
+    "subnet-16" = {
+      cidr = "20.10.51.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-17" = {
+      cidr = "20.0.52.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-18" = {
+      cidr = "20.0.53.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   create_database_subnet_group = false
 

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -11,10 +11,36 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs              = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
-  public_subnets   = ["10.0.101.0/24", "10.0.102.0/24"]
-  database_subnets = ["10.0.103.0/24", "10.0.104.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = data.aws_availability_zones.available.names[0]
+    },
+    "subnet-2" = {
+      cidr = "10.0.2.0/24",
+      az   = data.aws_availability_zones.available.names[1]
+    }
+  }
+  public_subnets = {
+    "subnet-3" = {
+      cidr = "10.0.101.0/24",
+      az   = data.aws_availability_zones.available.names[0]
+    },
+    "subnet-4" = {
+      cidr = "10.0.102.0/24",
+      az   = data.aws_availability_zones.available.names[1]
+    }
+  }
+  database_subnets = {
+    "subnet-5" = {
+      cidr = "10.0.103.0/24",
+      az   = data.aws_availability_zones.available.names[0]
+    },
+    "subnet-6" = {
+      cidr = "10.0.104.0/24",
+      az   = data.aws_availability_zones.available.names[1]
+    }
+  }
 
   enable_nat_gateway = false
 

--- a/examples/issue-108-route-already-exists/main.tf
+++ b/examples/issue-108-route-already-exists/main.tf
@@ -9,9 +9,34 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  private_subnets = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
-  public_subnets  = ["10.0.254.240/28", "10.0.254.224/28", "10.0.254.208/28"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.0.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "10.0.2.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.254.240/28",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.254.224/28",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "10.0.254.208/28",
+      az   = "eu-west-1c"
+    }
+  }
 
   single_nat_gateway = true
   enable_nat_gateway = true

--- a/examples/issue-44-asymmetric-private-subnets/main.tf
+++ b/examples/issue-44-asymmetric-private-subnets/main.tf
@@ -12,10 +12,36 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs              = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets  = ["10.0.1.0/24"]
-  public_subnets   = ["10.0.101.0/24", "10.0.102.0/24"]
-  database_subnets = ["10.0.21.0/24", "10.0.22.0/24", "10.0.23.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    }
+  }
+  public_subnets = {
+    "subnet-2" = {
+      cidr = "10.0.101.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-3" = {
+      cidr = "10.0.102.0/24",
+      az   = "eu-west-1b"
+    }
+  }
+  database_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.21.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.22.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "10.0.23.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   create_database_subnet_group = true
   enable_nat_gateway           = true

--- a/examples/issue-46-no-private-subnets/main.tf
+++ b/examples/issue-46-no-private-subnets/main.tf
@@ -8,11 +8,44 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  public_subnets      = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"]
-  private_subnets     = []
-  database_subnets    = ["10.0.128.0/24", "10.0.129.0/24"]
-  elasticache_subnets = ["10.0.131.0/24", "10.0.132.0/24", "10.0.133.0/24"]
+  public_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.0.0/22",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.4.0/22",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "10.0.8.0/22",
+      az   = "eu-west-1c"
+    }
+  }
+  database_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.128.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.129.0/24",
+      az   = "eu-west-1b"
+    }
+  }
+  elasticache_subnets = {
+    "subnet-6" = {
+      cidr = "10.0.131.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-7" = {
+      cidr = "10.0.132.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-8" = {
+      cidr = "10.0.133.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -9,10 +9,48 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets      = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  elasticache_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.2.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-3" = {
+      cidr = "10.0.3.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.101.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.102.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-6" = {
+      cidr = "10.0.103.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  elasticache_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.201.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.202.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-6" = {
+      cidr = "10.0.203.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   public_dedicated_network_acl = true
   public_inbound_acl_rules = concat(

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -10,9 +10,34 @@ module "vpc" {
   cidr                  = "10.0.0.0/16"
   secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.1.2.0/24", "10.2.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.1.102.0/24", "10.2.103.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.1.2.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "10.2.3.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.101.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.1.102.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "10.2.103.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   enable_ipv6 = true
 

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -9,9 +9,34 @@ module "vpc" {
 
   cidr = "10.0.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "euw1-az3"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.0.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.0.2.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "10.0.3.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "10.0.101.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.0.102.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "10.0.103.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   enable_ipv6 = true
 

--- a/examples/vpc-flow-logs/cloud-watch-logs.tf
+++ b/examples/vpc-flow-logs/cloud-watch-logs.tf
@@ -8,8 +8,13 @@ module "vpc_with_flow_logs_cloudwatch_logs_default" {
 
   cidr = "10.10.0.0/16"
 
-  azs            = ["eu-west-1a"]
-  public_subnets = ["10.10.101.0/24"]
+  public_subnets = {
+    "subnet-1" = {
+      cidr = "10.10.101.0/24",
+      az   = "eu-west-1a"
+    }
+  }
+
 
   # Cloudwatch log group and IAM role will be created
   enable_flow_log                      = true
@@ -32,9 +37,12 @@ module "vpc_with_flow_logs_cloudwatch_logs" {
 
   cidr = "10.20.0.0/16"
 
-  azs            = ["eu-west-1a"]
-  public_subnets = ["10.20.101.0/24"]
-
+  public_subnets = {
+    "subnet-2" = {
+      cidr = "10.20.101.0/24",
+      az   = "eu-west-1a"
+    }
+  }
   enable_flow_log                  = true
   flow_log_destination_type        = "cloud-watch-logs"
   flow_log_destination_arn         = aws_cloudwatch_log_group.flow_log.arn

--- a/examples/vpc-flow-logs/s3.tf
+++ b/examples/vpc-flow-logs/s3.tf
@@ -8,8 +8,13 @@ module "vpc_with_flow_logs_s3_bucket" {
 
   cidr = "10.30.0.0/16"
 
-  azs            = ["eu-west-1a"]
-  public_subnets = ["10.30.101.0/24"]
+
+  public_subnets = {
+    "subnet-1" = {
+      cidr = "10.30.101.0/24",
+      az   = "eu-west-1a"
+    }
+  }
 
   enable_flow_log           = true
   flow_log_destination_type = "s3"

--- a/examples/vpc-separate-private-route-tables/main.tf
+++ b/examples/vpc-separate-private-route-tables/main.tf
@@ -9,12 +9,76 @@ module "vpc" {
 
   cidr = "10.10.0.0/16"
 
-  azs                 = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets     = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
-  public_subnets      = ["10.10.11.0/24", "10.10.12.0/24", "10.10.13.0/24"]
-  database_subnets    = ["10.10.21.0/24", "10.10.22.0/24", "10.10.23.0/24"]
-  elasticache_subnets = ["10.10.31.0/24", "10.10.32.0/24", "10.10.33.0/24"]
-  redshift_subnets    = ["10.10.41.0/24", "10.10.42.0/24", "10.10.43.0/24"]
+  private_subnets = {
+    "subnet-1" = {
+      cidr = "10.10.1.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-2" = {
+      cidr = "10.10.2.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-3" = {
+      cidr = "10.10.3.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  public_subnets = {
+    "subnet-4" = {
+      cidr = "10.10.11.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-5" = {
+      cidr = "10.10.12.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-6" = {
+      cidr = "10.10.13.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  database_subnets = {
+    "subnet-7" = {
+      cidr = "10.10.21.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-8" = {
+      cidr = "10.10.22.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-9" = {
+      cidr = "10.10.23.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  elasticache_subnets = {
+    "subnet-10" = {
+      cidr = "10.10.31.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-11" = {
+      cidr = "10.10.32.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-12" = {
+      cidr = "10.10.33.0/24",
+      az   = "eu-west-1c"
+    }
+  }
+  redshift_subnets = {
+    "subnet-13" = {
+      cidr = "10.10.41.0/24",
+      az   = "eu-west-1a"
+    },
+    "subnet-14" = {
+      cidr = "10.10.42.0/24",
+      az   = "eu-west-1b"
+    },
+    "subnet-15" = {
+      cidr = "10.10.43.0/24",
+      az   = "eu-west-1c"
+    }
+  }
 
   create_database_subnet_route_table    = true
   create_elasticache_subnet_route_table = true

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-ocals {
+locals {
   max_subnet_length = max(
     length(var.private_subnets),
     length(var.elasticache_subnets),

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,34 @@
-locals {
+ocals {
   max_subnet_length = max(
     length(var.private_subnets),
     length(var.elasticache_subnets),
     length(var.database_subnets),
     length(var.redshift_subnets),
   )
-  nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length
+  azs = flatten([
+    [
+      for elem in values(var.private_subnets) :
+      elem["az"]
+    ],
+    [
+      for elem in values(var.public_subnets) :
+      elem["az"]
+    ],
+    [
+      for elem in values(var.redshift_subnets) :
+      elem["az"]
+    ],
+    [
+      for elem in values(var.database_subnets) :
+      elem["az"]
+    ],
+    [
+      for elem in values(var.elasticache_subnets) :
+      elem["az"]
+    ],
+  ])
+
+  nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(local.azs) : local.max_subnet_length
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
   vpc_id = element(
@@ -21,6 +44,7 @@ locals {
     var.tags,
     var.vpc_endpoint_tags,
   )
+
 }
 
 ######
@@ -211,7 +235,7 @@ resource "aws_route_table" "private" {
       "Name" = var.single_nat_gateway ? "${var.name}-${var.private_subnet_suffix}" : format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.private_subnets), count.index),
       )
     },
     var.tags,
@@ -327,12 +351,12 @@ resource "aws_route_table" "intra" {
 # Public subnet
 ################
 resource "aws_subnet" "public" {
-  count = var.create_vpc && length(var.public_subnets) > 0 && (false == var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0
+  count = var.create_vpc && length(var.public_subnets) > 0 && (false == var.one_nat_gateway_per_az || length(var.public_subnets) > 0) ? length(var.public_subnets) : 0
 
   vpc_id                          = local.vpc_id
-  cidr_block                      = element(concat(var.public_subnets, [""]), count.index)
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  cidr_block                      = var.public_subnets[element(keys(var.public_subnets), count.index)]["cidr"]
+  availability_zone               = length(regexall("^[a-z]{2}-", var.public_subnets[element(keys(var.public_subnets), count.index)]["az"])) > 0 ? var.public_subnets[element(keys(var.public_subnets), count.index)]["az"] : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", var.public_subnets[element(keys(var.public_subnets), count.index)]["az"])) == 0 ? var.public_subnets[element(keys(var.public_subnets), count.index)]["az"] : null
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   assign_ipv6_address_on_creation = var.public_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.public_subnet_assign_ipv6_address_on_creation
 
@@ -343,13 +367,14 @@ resource "aws_subnet" "public" {
       "Name" = format(
         "%s-${var.public_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.public_subnets), count.index),
       )
     },
     var.tags,
     var.public_subnet_tags,
   )
 }
+
 
 #################
 # Private subnet
@@ -358,9 +383,9 @@ resource "aws_subnet" "private" {
   count = var.create_vpc && length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
   vpc_id                          = local.vpc_id
-  cidr_block                      = var.private_subnets[count.index]
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  cidr_block                      = var.private_subnets[element(keys(var.private_subnets), count.index)]["cidr"]
+  availability_zone               = length(regexall("^[a-z]{2}-", var.private_subnets[element(keys(var.private_subnets), count.index)]["az"])) > 0 ? var.private_subnets[element(keys(var.private_subnets), count.index)]["az"] : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", var.private_subnets[element(keys(var.private_subnets), count.index)]["az"])) == 0 ? var.private_subnets[element(keys(var.private_subnets), count.index)]["az"] : null
   assign_ipv6_address_on_creation = var.private_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.private_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.private_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.private_subnet_ipv6_prefixes[count.index]) : null
@@ -370,13 +395,14 @@ resource "aws_subnet" "private" {
       "Name" = format(
         "%s-${var.private_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.private_subnets), count.index),
       )
     },
     var.tags,
     var.private_subnet_tags,
   )
 }
+
 
 ##################
 # Database subnet
@@ -385,9 +411,9 @@ resource "aws_subnet" "database" {
   count = var.create_vpc && length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
   vpc_id                          = local.vpc_id
-  cidr_block                      = var.database_subnets[count.index]
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  cidr_block                      = var.database_subnets[element(keys(var.database_subnets), count.index)]["cidr"]
+  availability_zone               = length(regexall("^[a-z]{2}-", var.database_subnets[element(keys(var.database_subnets), count.index)]["az"])) > 0 ? var.database_subnets[element(keys(var.database_subnets), count.index)]["az"] : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", var.database_subnets[element(keys(var.database_subnets), count.index)]["az"])) == 0 ? var.database_subnets[element(keys(var.database_subnets), count.index)]["az"] : null
   assign_ipv6_address_on_creation = var.database_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.database_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.database_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.database_subnet_ipv6_prefixes[count.index]) : null
@@ -397,7 +423,7 @@ resource "aws_subnet" "database" {
       "Name" = format(
         "%s-${var.database_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.database_subnets), count.index),
       )
     },
     var.tags,
@@ -427,10 +453,11 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_subnet" "redshift" {
   count = var.create_vpc && length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  vpc_id                          = local.vpc_id
-  cidr_block                      = var.redshift_subnets[count.index]
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  vpc_id               = local.vpc_id
+  cidr_block           = var.redshift_subnets[element(keys(var.redshift_subnets), count.index)]["cidr"]
+  availability_zone    = length(regexall("^[a-z]{2}-", var.redshift_subnets[element(keys(var.redshift_subnets), count.index)]["az"])) > 0 ? var.redshift_subnets[element(keys(var.redshift_subnets), count.index)]["az"] : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", var.redshift_subnets[element(keys(var.redshift_subnets), count.index)]["az"])) == 0 ? var.redshift_subnets[element(keys(var.redshift_subnets), count.index)]["az"] : null
+
   assign_ipv6_address_on_creation = var.redshift_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.redshift_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.redshift_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.redshift_subnet_ipv6_prefixes[count.index]) : null
@@ -440,7 +467,7 @@ resource "aws_subnet" "redshift" {
       "Name" = format(
         "%s-${var.redshift_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.redshift_subnets), count.index),
       )
     },
     var.tags,
@@ -470,10 +497,11 @@ resource "aws_redshift_subnet_group" "redshift" {
 resource "aws_subnet" "elasticache" {
   count = var.create_vpc && length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  vpc_id                          = local.vpc_id
-  cidr_block                      = var.elasticache_subnets[count.index]
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  vpc_id               = local.vpc_id
+  cidr_block           = var.elasticache_subnets[element(keys(var.elasticache_subnets), count.index)]["cidr"]
+  availability_zone    = length(regexall("^[a-z]{2}-", var.elasticache_subnets[element(keys(var.elasticache_subnets), count.index)]["az"])) > 0 ? var.elasticache_subnets[element(keys(var.elasticache_subnets), count.index)]["az"] : null
+  availability_zone_id = length(regexall("^[a-z]{2}-", var.elasticache_subnets[element(keys(var.elasticache_subnets), count.index)]["az"])) == 0 ? var.elasticache_subnets[element(keys(var.elasticache_subnets), count.index)]["az"] : null
+
   assign_ipv6_address_on_creation = var.elasticache_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.elasticache_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.elasticache_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.elasticache_subnet_ipv6_prefixes[count.index]) : null
@@ -483,7 +511,7 @@ resource "aws_subnet" "elasticache" {
       "Name" = format(
         "%s-${var.elasticache_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.elasticache_subnets), count.index),
       )
     },
     var.tags,
@@ -506,9 +534,9 @@ resource "aws_subnet" "intra" {
   count = var.create_vpc && length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
   vpc_id                          = local.vpc_id
-  cidr_block                      = var.intra_subnets[count.index]
-  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  cidr_block                      = var.intra_subnets[element(keys(var.intra_subnets), count.index)]["cidr"]
+  availability_zone               = length(regexall("^[a-z]{2}-", var.intra_subnets[element(keys(var.intra_subnets), count.index)]["az"])) > 0 ? var.intra_subnets[element(keys(var.intra_subnets), count.index)]["az"] : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", var.intra_subnets[element(keys(var.intra_subnets), count.index)]["az"])) == 0 ? var.intra_subnets[element(keys(var.intra_subnets), count.index)]["az"] : null
   assign_ipv6_address_on_creation = var.intra_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.intra_subnet_assign_ipv6_address_on_creation
 
   ipv6_cidr_block = var.enable_ipv6 && length(var.intra_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null
@@ -518,7 +546,7 @@ resource "aws_subnet" "intra" {
       "Name" = format(
         "%s-${var.intra_subnet_suffix}-%s",
         var.name,
-        element(var.azs, count.index),
+        element(keys(var.intra_subnets), count.index),
       )
     },
     var.tags,
@@ -912,7 +940,7 @@ resource "aws_eip" "nat" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, var.single_nat_gateway ? 0 : count.index),
+        element(local.azs, var.single_nat_gateway ? 0 : count.index),
       )
     },
     var.tags,
@@ -937,7 +965,7 @@ resource "aws_nat_gateway" "this" {
       "Name" = format(
         "%s-%s",
         var.name,
-        element(var.azs, var.single_nat_gateway ? 0 : count.index),
+        element(local.azs, var.single_nat_gateway ? 0 : count.index),
       )
     },
     var.tags,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1383,11 +1383,6 @@ output "vpc_flow_log_cloudwatch_iam_role_arn" {
   value       = local.flow_log_iam_role_arn
 }
 
-# Static values (arguments)
-output "azs" {
-  description = "A list of availability zones specified as argument to this module"
-  value       = var.azs
-}
 
 output "name" {
   description = "The name of the VPC specified as argument to this module"

--- a/variables.tf
+++ b/variables.tf
@@ -150,38 +150,56 @@ variable "elasticache_subnet_suffix" {
 
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "private_subnets" {
   description = "A list of private subnets inside the VPC"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "database_subnets" {
   description = "A list of database subnets"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "redshift_subnets" {
   description = "A list of redshift subnets"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "elasticache_subnets" {
   description = "A list of elasticache subnets"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "intra_subnets" {
   description = "A list of intra subnets"
-  type        = list(string)
-  default     = []
+  type = map(object({
+    cidr = string,
+    az   = string
+  }))
+  default = {}
 }
 
 variable "create_database_subnet_route_table" {
@@ -236,12 +254,6 @@ variable "create_database_nat_gateway_route" {
   description = "Controls if a nat gateway route should be created to give internet access to the database subnets"
   type        = bool
   default     = false
-}
-
-variable "azs" {
-  description = "A list of availability zones names or ids in the region"
-  type        = list(string)
-  default     = []
 }
 
 variable "enable_dns_hostnames" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Defining subnet as list is destructive, when trying to remove one/multiple subnet from that list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Let's say i want to deploy this configuration : 
```HCL
module "vpc-test" {
  ...
  cidr             = "10.40.0.0/16"
  azs              = ["us-east-1a", "us-east-1b"]
  private_subnets  = ["10.40.3.0/24", "10.40.4.0/24","10.40.5.0/24", "10.40.6.0/24"]
```
Once applied, i remove one subnet from that list

```HCL
module "vpc-test" {
  ...
  cidr             = "10.40.0.0/16"
  azs              = ["us-east-1a", "us-east-1b"]
  private_subnets  = ["10.40.3.0/24", "10.40.5.0/24", "10.40.6.0/24"]
```

If i apply this last configuration all private subnets will be destroyed and 3 new ones will be created
<!--- If it fixes an open issue, please link to the issue here. -->
#403 
#178 
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
The idea is to use map instead of list for subnets definitions.
From
```HCL
private_subnets  = ["10.40.3.0/24", "10.40.5.0/24", "10.40.6.0/24"]
```
To
```HCL
private_subnets = {
    "subnet-1" = {
      cidr = "10.40.3.0/24",
      az   = "eu-west-1a"
    },
    "subnet-2" = {
      cidr = "10.40.5.0/24",
      az   = "eu-west-1b"
    },
    "subnet-3" = {
      cidr = "10.40.6.0/24",
      az   = "eu-west-1c"
    }
  }
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```HCL
module "vpc" {
  source = ".."
  name = "automate-vpc"

  cidr = "20.10.0.0/16"
  enable_nat_gateway = true
  one_nat_gateway_per_az = true

  private_subnets = {
    "subnet-1" = {
      cidr = "20.10.1.0/24",
      az   = "eu-west-1a"
    },
    "subnet-2" = {
      cidr = "20.10.2.0/24",
      az   = "eu-west-1a"
    }
  public_subnets = {
        "subnet-3" = {
          cidr = "20.10.11.0/24",
          az   = "eu-west-1a"
        }
     }
  }

```