### PR TITLE
fix: Resource aws_default_network_acl orphaned subnet_ids

### DIFF
--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -28,7 +28,7 @@ module "vpc" {
     local.network_acls["elasticache_outbound"],
   )
 
-  private_dedicated_network_acl     = true
+  private_dedicated_network_acl     = false
   elasticache_dedicated_network_acl = true
 
   manage_default_network_acl = true

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -31,6 +31,8 @@ module "vpc" {
   private_dedicated_network_acl     = true
   elasticache_dedicated_network_acl = true
 
+  manage_default_network_acl = true
+
   enable_ipv6 = true
 
   enable_nat_gateway = false
@@ -200,4 +202,3 @@ locals {
     ]
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -534,6 +534,27 @@ resource "aws_default_network_acl" "this" {
 
   default_network_acl_id = element(concat(aws_vpc.this.*.default_network_acl_id, [""]), 0)
 
+  # The value of subnet_ids should be any subnet IDs that are not set as subnet_ids
+  #   for any of the non-default network ACLs
+  subnet_ids = setsubtract(
+    compact(flatten([
+      aws_subnet.public.*.id,
+      aws_subnet.private.*.id,
+      aws_subnet.intra.*.id,
+      aws_subnet.database.*.id,
+      aws_subnet.redshift.*.id,
+      aws_subnet.elasticache.*.id,
+    ])),
+    compact(flatten([
+      aws_network_acl.public.*.subnet_ids,
+      aws_network_acl.private.*.subnet_ids,
+      aws_network_acl.intra.*.subnet_ids,
+      aws_network_acl.database.*.subnet_ids,
+      aws_network_acl.redshift.*.subnet_ids,
+      aws_network_acl.elasticache.*.subnet_ids,
+    ]))
+  )
+
   dynamic "ingress" {
     for_each = var.default_network_acl_ingress
     content {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fix sets the value for the `subnet_ids` attribute of the `aws_default_network_acl` to be any subnets created by the module that are not allocated to any other `aws_network_acl` resources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#529 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This fix involves the usage of the `setsubtract`, `compact`, and `flatten` functions which should not break any backward compatibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did the following:

- Added the `manage_default_network_acl` attribute set as `true` to the `network-acls` example
- `terraform apply`
- Set the `private_dedicated_network_acl` attribute as `false` in the example
- `terraform apply`
- `terraform plan`
- Noticed that the plan was complaining that the previously created subnets would be removed from the `aws_default_network_acl` resource
- `terraform apply`
- `terraform plan`
- Noticed that the plan was *still* complaining that the previously created subnets would be removed from the `aws_default_network_acl` resource
- Implemented my changes to default the `subnet_ids` attribute of the `aws_default_network_acl` resource
- `terraform plan`
- No changes needed
- Set the `private_dedicated_network_acl` attribute back to `true` in the example
- `terraform apply`
- `terraform plan`
- No changes needed