### PR TITLE
feat: Lambda VPC Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | enable\_kinesis\_firehose\_endpoint | Should be true if you want to provision a Kinesis Firehose endpoint to the VPC | `bool` | `false` | no |
 | enable\_kinesis\_streams\_endpoint | Should be true if you want to provision a Kinesis Streams endpoint to the VPC | `bool` | `false` | no |
 | enable\_kms\_endpoint | Should be true if you want to provision a KMS endpoint to the VPC | `bool` | `false` | no |
+| enable\_lambda\_endpoint | Should be true if you want to provision a Lambda endpoint to the VPC | `bool` | `false` | no |
 | enable\_logs\_endpoint | Should be true if you want to provision a CloudWatch Logs endpoint to the VPC | `bool` | `false` | no |
 | enable\_monitoring\_endpoint | Should be true if you want to provision a CloudWatch Monitoring endpoint to the VPC | `bool` | `false` | no |
 | enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
@@ -519,6 +520,9 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | kms\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for KMS endpoint | `bool` | `false` | no |
 | kms\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for KMS endpoint | `list(string)` | `[]` | no |
 | kms\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for KMS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| lambda\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Lambda endpoint | `bool` | `false` | no |
+| lambda\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Lambda endpoint | `list(string)` | `[]` | no |
+| lambda\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Lambda endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | logs\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Logs endpoint | `bool` | `false` | no |
 | logs\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for CloudWatch Logs endpoint | `list(string)` | `[]` | no |
 | logs\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudWatch Logs endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -855,6 +859,9 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | vpc\_endpoint\_kms\_dns\_entry | The DNS entries for the VPC Endpoint for KMS. |
 | vpc\_endpoint\_kms\_id | The ID of VPC endpoint for KMS |
 | vpc\_endpoint\_kms\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for KMS. |
+| vpc\_endpoint\_lambda\_dns\_entry | The DNS entries for the VPC Endpoint for Lambda. |
+| vpc\_endpoint\_lambda\_id | The ID of VPC endpoint for Lambda |
+| vpc\_endpoint\_lambda\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for Lambda. |
 | vpc\_endpoint\_logs\_dns\_entry | The DNS entries for the VPC Endpoint for CloudWatch Logs. |
 | vpc\_endpoint\_logs\_id | The ID of VPC endpoint for CloudWatch Logs |
 | vpc\_endpoint\_logs\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for CloudWatch Logs. |

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -47,6 +47,9 @@ No input.
 | public\_subnets | List of IDs of public subnets |
 | redshift\_subnets | List of IDs of redshift subnets |
 | this\_customer\_gateway | Map of Customer Gateway attributes |
+| vpc\_endpoint\_lambda\_dns\_entry | The DNS entries for the VPC Endpoint for Lambda. |
+| vpc\_endpoint\_lambda\_id | The ID of VPC endpoint for Lambda |
+| vpc\_endpoint\_lambda\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for Lambda. |
 | vpc\_endpoint\_ssm\_dns\_entry | The DNS entries for the VPC Endpoint for SSM. |
 | vpc\_endpoint\_ssm\_id | The ID of VPC endpoint for SSM |
 | vpc\_endpoint\_ssm\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SSM. |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -61,6 +61,11 @@ module "vpc" {
   ssm_endpoint_private_dns_enabled = true
   ssm_endpoint_security_group_ids  = [data.aws_security_group.default.id]
 
+  # VPC endpoint for Lambda
+  enable_lambda_endpoint              = true
+  lambda_endpoint_private_dns_enabled = true
+  lambda_endpoint_security_group_ids  = [data.aws_security_group.default.id]
+
   # VPC endpoint for SSMMESSAGES
   enable_ssmmessages_endpoint              = true
   ssmmessages_endpoint_private_dns_enabled = true
@@ -133,4 +138,3 @@ module "vpc" {
     Endpoint = "true"
   }
 }
-

--- a/examples/complete-vpc/outputs.tf
+++ b/examples/complete-vpc/outputs.tf
@@ -57,6 +57,21 @@ output "vpc_endpoint_ssm_dns_entry" {
   value       = module.vpc.vpc_endpoint_ssm_dns_entry
 }
 
+output "vpc_endpoint_lambda_id" {
+  description = "The ID of VPC endpoint for Lambda"
+  value       = module.vpc.vpc_endpoint_lambda_id
+}
+
+output "vpc_endpoint_lambda_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for Lambda."
+  value       = module.vpc.vpc_endpoint_lambda_network_interface_ids
+}
+
+output "vpc_endpoint_lambda_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for Lambda."
+  value       = module.vpc.vpc_endpoint_lambda_dns_entry
+}
+
 # Customer Gateway
 output "cgw_ids" {
   description = "List of IDs of Customer Gateway"

--- a/outputs.tf
+++ b/outputs.tf
@@ -513,6 +513,21 @@ output "vpc_endpoint_sqs_dns_entry" {
   value       = flatten(aws_vpc_endpoint.sqs.*.dns_entry)
 }
 
+output "vpc_endpoint_lambda_id" {
+  description = "The ID of VPC endpoint for Lambda"
+  value       = concat(aws_vpc_endpoint.lambda.*.id, [""])[0]
+}
+
+output "vpc_endpoint_lambda_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for Lambda."
+  value       = flatten(aws_vpc_endpoint.lambda.*.network_interface_ids)
+}
+
+output "vpc_endpoint_lambda_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for Lambda."
+  value       = flatten(aws_vpc_endpoint.lambda.*.dns_entry)
+}
+
 output "vpc_endpoint_codebuild_id" {
   description = "The ID of VPC endpoint for codebuild"
   value       = concat(aws_vpc_endpoint.codebuild.*.id, [""])[0]

--- a/variables.tf
+++ b/variables.tf
@@ -490,6 +490,30 @@ variable "sqs_endpoint_private_dns_enabled" {
   default     = false
 }
 
+variable "enable_lambda_endpoint" {
+  description = "Should be true if you want to provision a Lambda endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "lambda_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for Lambda endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for Lambda endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for Lambda endpoint"
+  type        = bool
+  default     = false
+}
+
 variable "enable_ssm_endpoint" {
   description = "Should be true if you want to provision an SSM endpoint to the VPC"
   type        = bool

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,5 +1,3 @@
-data "aws_region" "current" {}
-
 ######################
 # VPC Endpoint for S3
 ######################

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -190,11 +190,16 @@ resource "aws_vpc_endpoint" "sqs" {
 #########################
 # VPC Endpoint for Lambda
 #########################
+data "aws_vpc_endpoint_service" "lambda" {
+  count = var.create_vpc && var.enable_lambda_endpoint ? 1 : 0
+
+  service = "lambda"
+}
 resource "aws_vpc_endpoint" "lambda" {
   count = var.create_vpc && var.enable_lambda_endpoint ? 1 : 0
 
   vpc_id            = local.vpc_id
-  service_name      = format("com.amazonaws.%s.lambda", data.aws_region.current.name)
+  service_name      = data.aws_vpc_endpoint_service.lambda[0].service_name
   vpc_endpoint_type = "Interface"
 
   security_group_ids  = var.lambda_endpoint_security_group_ids

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 ######################
 # VPC Endpoint for S3
 ######################
@@ -182,6 +184,22 @@ resource "aws_vpc_endpoint" "sqs" {
   security_group_ids  = var.sqs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sqs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
+  tags                = local.vpce_tags
+}
+
+#########################
+# VPC Endpoint for Lambda
+#########################
+resource "aws_vpc_endpoint" "lambda" {
+  count = var.create_vpc && var.enable_lambda_endpoint ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  service_name      = format("com.amazonaws.%s.lambda", data.aws_region.current.name)
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = var.lambda_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.lambda_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.lambda_endpoint_private_dns_enabled
   tags                = local.vpce_tags
 }
 


### PR DESCRIPTION
## Description
AWS recently announced [PrivateLink support for Lambda](https://aws.amazon.com/blogs/aws/new-use-aws-privatelink-to-access-aws-lambda-over-private-aws-network/). This PR serves to add the functionality to this module. 

## Motivation and Context
So the new endpoint can be used by projects already integrated with this module.

## Breaking Changes
None.

## How Has This Been Tested?
Locally.
