### PR TITLE
feat: Adding vpc_flow_log_permissions_boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,38 +162,9 @@ You can add additional tags with `intra_subnet_tags` as with other subnet types.
 VPC Flow Log allows to capture IP traffic for a specific network interface (ENI), subnet, or entire VPC. This module supports enabling or disabling VPC Flow Logs for entire VPC. If you need to have VPC Flow Logs for subnet or ENI, you have to manage it outside of this module with [aws_flow_log resource](https://www.terraform.io/docs/providers/aws/r/flow_log.html).
 
 ### Permissions Boundary
-If your organization requires a permissions boundary to be attached to the VPC Flow Log Role, [the permissions boundary must have an IAM policy that allows the following](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam):
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}   
-```
 
-Then specify the boundary in the module:
-```terraform
-module "vpc" {
-  source = "git::https://github.com/kelseymok/terraform-aws-vpc.git"
-  
-  enable_flow_log = true
-  flow_log_destination_type = "cloud-watch-logs"
-  create_flow_log_cloudwatch_iam_role = true
-  create_flow_log_cloudwatch_log_group = true
-  vpc_flow_log_permissions_boundary = "arn:aws:iam::ACCOUNT-NUMBER:policy/my-awesome-boundary"
-}
-```
+If your organization requires a permissions boundary to be attached to the VPC Flow Log role, make sure that you specify an ARN of the permissions boundary policy as `vpc_flow_log_permissions_boundary` argument. Read more about required [IAM policy for publishing flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam).
+
 ## Conditional creation
 
 Sometimes you need to have a way to create VPC resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_vpc`.
@@ -670,7 +641,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | `list(string)` | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
-| vpc\_flow\_log\_permissions\_boundary | Permissions Boundary ARN for VPC Flow Log role | `string` | `null` | no |
+| vpc\_flow\_log\_permissions\_boundary | The ARN of the Permissions Boundary for the VPC Flow Log IAM Role | `string` | `null` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,39 @@ You can add additional tags with `intra_subnet_tags` as with other subnet types.
 
 VPC Flow Log allows to capture IP traffic for a specific network interface (ENI), subnet, or entire VPC. This module supports enabling or disabling VPC Flow Logs for entire VPC. If you need to have VPC Flow Logs for subnet or ENI, you have to manage it outside of this module with [aws_flow_log resource](https://www.terraform.io/docs/providers/aws/r/flow_log.html).
 
+### Permissions Boundary
+If your organization requires a permissions boundary to be attached to the VPC Flow Log Role, [the permissions boundary must have an IAM policy that allows the following](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam):
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}   
+```
+
+Then specify the boundary in the module:
+```terraform
+module "vpc" {
+  source = "git::https://github.com/kelseymok/terraform-aws-vpc.git"
+  
+  enable_flow_log = true
+  flow_log_destination_type = "cloud-watch-logs"
+  create_flow_log_cloudwatch_iam_role = true
+  create_flow_log_cloudwatch_log_group = true
+  vpc_flow_log_permissions_boundary = "arn:aws:iam::ACCOUNT-NUMBER:policy/my-awesome-boundary"
+}
+```
 ## Conditional creation
 
 Sometimes you need to have a way to create VPC resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_vpc`.

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | `list(string)` | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
+| vpc\_flow\_log\_permissions\_boundary | Permissions Boundary ARN for VPC Flow Log role | `string` | `""` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | transferserver\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Transfer Server endpoint | `list(string)` | `[]` | no |
 | transferserver\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | vpc\_endpoint\_tags | Additional tags for the VPC Endpoints | `map(string)` | `{}` | no |
-| vpc\_flow\_log\_permissions\_boundary | Permissions Boundary ARN for VPC Flow Log role | `string` | `""` | no |
+| vpc\_flow\_log\_permissions\_boundary | Permissions Boundary ARN for VPC Flow Log role | `string` | `null` | no |
 | vpc\_flow\_log\_tags | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
 | vpc\_tags | Additional tags for the VPC | `map(string)` | `{}` | no |
 | vpn\_gateway\_az | The Availability Zone for the VPN Gateway | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -2119,8 +2119,8 @@ variable "vpc_flow_log_tags" {
 
 variable "vpc_flow_log_permissions_boundary" {
   description = "The ARN of the Permissions Boundary for the VPC Flow Log IAM Role"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "enable_dhcp_options" {

--- a/variables.tf
+++ b/variables.tf
@@ -2120,7 +2120,7 @@ variable "vpc_flow_log_tags" {
 variable "vpc_flow_log_permissions_boundary" {
   description = "The ARN of the Permissions Boundary for the VPC Flow Log IAM Role"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "enable_dhcp_options" {

--- a/variables.tf
+++ b/variables.tf
@@ -2117,6 +2117,12 @@ variable "vpc_flow_log_tags" {
   default     = {}
 }
 
+variable "vpc_flow_log_permissions_boundary" {
+  description = "The ARN of the Permissions Boundary for the VPC Flow Log IAM Role"
+  type = string
+  default = ""
+}
+
 variable "enable_dhcp_options" {
   description = "Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type"
   type        = bool

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -45,11 +45,11 @@ resource "aws_cloudwatch_log_group" "flow_log" {
 resource "aws_iam_role" "vpc_flow_log_cloudwatch" {
   count = local.create_flow_log_cloudwatch_iam_role ? 1 : 0
 
-  name_prefix        = "vpc-flow-log-role-"
-  assume_role_policy = data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0].json
-
-  tags                 = merge(var.tags, var.vpc_flow_log_tags)
+  name_prefix          = "vpc-flow-log-role-"
+  assume_role_policy   = data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0].json
   permissions_boundary = var.vpc_flow_log_permissions_boundary
+
+  tags = merge(var.tags, var.vpc_flow_log_tags)
 }
 
 data "aws_iam_policy_document" "flow_log_cloudwatch_assume_role" {

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "vpc_flow_log_cloudwatch" {
   name_prefix        = "vpc-flow-log-role-"
   assume_role_policy = data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0].json
 
-  tags = merge(var.tags, var.vpc_flow_log_tags)
+  tags                 = merge(var.tags, var.vpc_flow_log_tags)
   permissions_boundary = var.vpc_flow_log_permissions_boundary
 }
 

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -49,6 +49,7 @@ resource "aws_iam_role" "vpc_flow_log_cloudwatch" {
   assume_role_policy = data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0].json
 
   tags = merge(var.tags, var.vpc_flow_log_tags)
+  permissions_boundary = var.vpc_flow_log_permissions_boundary
 }
 
 data "aws_iam_policy_document" "flow_log_cloudwatch_assume_role" {


### PR DESCRIPTION
## Description
Adding `vpc_flow_log_permissions_boundary` so that developers who are required to specify a permissions boundary on IAM roles can enable the VPC Flow Log feature in this module

## Motivation and Context
In many AWS setups, developers are required to assume a role in order to make changes to AWS resources. One of the recommended security measures that is recommended by AWS is to allow roles the ability to create other roles only if a permissions boundary is set directly on the role. This prevents developers (in an assumed-role session) from [unintentionally/intentionally] creating a role with, for example, super powers/administrative rights. Without the ability to set a permissions boundary on the VPC Flow Logs IAM role, those who are bound by this permissions boundary restraint will not be able to enable the VPC Flow Logs feature, but will instead need to create a new module to handle this.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
None

<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
CircleCI pipeline passes. Using the fork in our production code/environment (manual smoke testing/verification) -- the VPC Flow Logs elements (IAM role, IAM cloudwatch log group) are created; other elements are not affected.
```
module "vpc" {
  source = "git::https://github.com/kelseymok/terraform-aws-vpc.git"

  name = "${local.project-name}-${local.module-name}"
  cidr = local.vpc-cidr

  azs = local.azs
  private_subnets = local.private_subnets
  public_subnets  = local.public_subnets

  enable_nat_gateway = true
  enable_dns_hostnames = true
  enable_dns_support   = true

  enable_flow_log = true
  flow_log_destination_type = "cloud-watch-logs"
  create_flow_log_cloudwatch_iam_role = true
  create_flow_log_cloudwatch_log_group = true
  vpc_flow_log_permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/my-awesome-boundary"
}
```
