### PR TITLE
feat: Add support to tag default route table

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | default\_network\_acl\_ingress | List of maps of ingress rules to set on the Default Network ACL | `list(map(string))` | <pre>[<br>  {<br>    "action": "allow",<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_no": 100,<br>    "to_port": 0<br>  },<br>  {<br>    "action": "allow",<br>    "from_port": 0,<br>    "ipv6_cidr_block": "::/0",<br>    "protocol": "-1",<br>    "rule_no": 101,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | default\_network\_acl\_name | Name to be used on the Default Network ACL | `string` | `""` | no |
 | default\_network\_acl\_tags | Additional tags for the Default Network ACL | `map(string)` | `{}` | no |
+| default\_route\_table\_tags | Additional tags for the Default Route Table | `map(string)` | `{}` | no |
 | default\_security\_group\_egress | List of maps of egress rules to set on the default security group | `list(map(string))` | `null` | no |
 | default\_security\_group\_ingress | List of maps of ingress rules to set on the default security group | `list(map(string))` | `null` | no |
 | default\_security\_group\_name | Name to be used on the default security group | `string` | `"default"` | no |

--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,22 @@ resource "aws_egress_only_internet_gateway" "this" {
   )
 }
 
+
+################
+# Default route
+################
+resource "aws_default_route_table" "default" {
+  count                  = var.create_vpc ? 1 : 0
+  default_route_table_id = aws_vpc.this[0].default_route_table_id
+  tags = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.default_route_table_tags,
+  )
+}
+
 ################
 # Publiс routes
 ################

--- a/variables.tf
+++ b/variables.tf
@@ -2596,3 +2596,9 @@ variable "create_egress_only_igw" {
   type        = bool
   default     = true
 }
+
+variable "default_route_table_tags" {
+  description = "Additional tags for the Default Route Table"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Signed-off-by: Lays Rodrigues <laysrodriguessilva@gmail.com>

## Description
Add support to tag default route table since PR #147 is getting dust.

## Motivation and Context
So far this is the only resource on this module that has not set a Name by default. And I like my resources tagged :3

## Breaking Changes
Not that I know.

## How Has This Been Tested?
Used terraform 0.14
```sh
terraform fmt
terraform validate
terraform plan
terraform apply
```
```hcl
  # module.vpc.aws_default_route_table.default[0] must be replaced
-/+ resource "aws_default_route_table" "default" {
      + default_route_table_id = "rtb-id"
      + id                     = (known after apply)
      + owner_id               = (known after apply)
      + route                  = (known after apply)
      + tags                   = {
          + "Name"                            = "my-rt-name"
          + "environment"                     = "development"
          + "kubernetes.io/cluster/beira-rio" = "shared"
        }
      + vpc_id                 = (known after apply)
    }
```
```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
