### PR TITLE
docs: Clarifies default_vpc attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,16 +668,16 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | default\_network\_acl\_id | The ID of the default network ACL |
 | default\_route\_table\_id | The ID of the default route table |
 | default\_security\_group\_id | The ID of the security group created by default on VPC creation |
-| default\_vpc\_arn | The ARN of the VPC |
-| default\_vpc\_cidr\_block | The CIDR block of the VPC |
-| default\_vpc\_default\_network\_acl\_id | The ID of the default network ACL |
-| default\_vpc\_default\_route\_table\_id | The ID of the default route table |
-| default\_vpc\_default\_security\_group\_id | The ID of the security group created by default on VPC creation |
-| default\_vpc\_enable\_dns\_hostnames | Whether or not the VPC has DNS hostname support |
-| default\_vpc\_enable\_dns\_support | Whether or not the VPC has DNS support |
-| default\_vpc\_id | The ID of the VPC |
-| default\_vpc\_instance\_tenancy | Tenancy of instances spin up within VPC |
-| default\_vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
+| default\_vpc\_arn | The ARN of the Default VPC |
+| default\_vpc\_cidr\_block | The CIDR block of the Default VPC |
+| default\_vpc\_default\_network\_acl\_id | The ID of the default network ACL of the Default VPC |
+| default\_vpc\_default\_route\_table\_id | The ID of the default route table of the Default VPC |
+| default\_vpc\_default\_security\_group\_id | The ID of the security group created by default on Default VPC creation |
+| default\_vpc\_enable\_dns\_hostnames | Whether or not the Default VPC has DNS hostname support |
+| default\_vpc\_enable\_dns\_support | Whether or not the Default VPC has DNS support |
+| default\_vpc\_id | The ID of the Default VPC |
+| default\_vpc\_instance\_tenancy | Tenancy of instances spin up within Default VPC |
+| default\_vpc\_main\_route\_table\_id | The ID of the main route table associated with the Default VPC |
 | egress\_only\_internet\_gateway\_id | The ID of the egress only Internet Gateway |
 | elasticache\_network\_acl\_arn | ARN of the elasticache network ACL |
 | elasticache\_network\_acl\_id | ID of the elasticache network ACL |

--- a/outputs.tf
+++ b/outputs.tf
@@ -368,52 +368,52 @@ output "vgw_arn" {
 }
 
 output "default_vpc_id" {
-  description = "The ID of the VPC"
+  description = "The ID of the Default VPC"
   value       = concat(aws_default_vpc.this.*.id, [""])[0]
 }
 
 output "default_vpc_arn" {
-  description = "The ARN of the VPC"
+  description = "The ARN of the Default VPC"
   value       = concat(aws_default_vpc.this.*.arn, [""])[0]
 }
 
 output "default_vpc_cidr_block" {
-  description = "The CIDR block of the VPC"
+  description = "The CIDR block of the Default VPC"
   value       = concat(aws_default_vpc.this.*.cidr_block, [""])[0]
 }
 
 output "default_vpc_default_security_group_id" {
-  description = "The ID of the security group created by default on VPC creation"
+  description = "The ID of the security group created by default on Default VPC creation"
   value       = concat(aws_default_vpc.this.*.default_security_group_id, [""])[0]
 }
 
 output "default_vpc_default_network_acl_id" {
-  description = "The ID of the default network ACL"
+  description = "The ID of the default network ACL of the Default VPC"
   value       = concat(aws_default_vpc.this.*.default_network_acl_id, [""])[0]
 }
 
 output "default_vpc_default_route_table_id" {
-  description = "The ID of the default route table"
+  description = "The ID of the default route table of the Default VPC"
   value       = concat(aws_default_vpc.this.*.default_route_table_id, [""])[0]
 }
 
 output "default_vpc_instance_tenancy" {
-  description = "Tenancy of instances spin up within VPC"
+  description = "Tenancy of instances spin up within Default VPC"
   value       = concat(aws_default_vpc.this.*.instance_tenancy, [""])[0]
 }
 
 output "default_vpc_enable_dns_support" {
-  description = "Whether or not the VPC has DNS support"
+  description = "Whether or not the Default VPC has DNS support"
   value       = concat(aws_default_vpc.this.*.enable_dns_support, [""])[0]
 }
 
 output "default_vpc_enable_dns_hostnames" {
-  description = "Whether or not the VPC has DNS hostname support"
+  description = "Whether or not the Default VPC has DNS hostname support"
   value       = concat(aws_default_vpc.this.*.enable_dns_hostnames, [""])[0]
 }
 
 output "default_vpc_main_route_table_id" {
-  description = "The ID of the main route table associated with this VPC"
+  description = "The ID of the main route table associated with the Default VPC"
   value       = concat(aws_default_vpc.this.*.main_route_table_id, [""])[0]
 }
 


### PR DESCRIPTION
Fixes #551 
Changes the descriptions of 
default_vpc_id
default_vpc_arn
default_vpc_cidr_block
default_vpc_default_network_acl_id
default_vpc_route_tabnle_id
default_vpc_security_group_id
default_vpc_enable_dns_hostnames
default_vpc_enable_dns_support
default_vpc_instance_tenancy
default_vpc_main_route_table_id
in both README.md and outputs.tf to avoid confusion.