### PR TITLE
feat: vpc endpoint names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.66.0"></a>
+## [v2.66.0] - 2021-01-14
+
+- docs: Clarifies default_vpc attributes ([#552](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/552))
+
+
 <a name="v2.65.0"></a>
 ## [v2.65.0] - 2021-01-14
 
@@ -988,13 +994,13 @@ All notable changes to this project will be documented in this file.
 - Reverted bad merge, fixed [#33](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/33)
 
 
-<a name="v1.5.1"></a>
-## [v1.5.1] - 2017-11-23
-
-
-
 <a name="v1.5.0"></a>
 ## [v1.5.0] - 2017-11-23
+
+
+
+<a name="v1.5.1"></a>
+## [v1.5.1] - 2017-11-23
 
 - Reverted bad merge, fixed [#33](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/33)
 - Set enable_dns_support=true by default
@@ -1067,7 +1073,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.65.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.66.0...HEAD
+[v2.66.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.65.0...v2.66.0
 [v2.65.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.64.0...v2.65.0
 [v2.64.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.63.0...v2.64.0
 [v2.63.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v2.62.0...v2.63.0
@@ -1205,9 +1212,9 @@ All notable changes to this project will be documented in this file.
 [v1.8.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.7.0...v1.8.0
 [v1.7.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.6.0...v1.7.0
 [v1.6.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.4.1...v1.6.0
-[v1.4.1]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.5.1...v1.4.1
-[v1.5.1]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.5.0...v1.5.1
-[v1.5.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.4.0...v1.5.0
+[v1.4.1]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.5.0...v1.4.1
+[v1.5.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.5.1...v1.5.0
+[v1.5.1]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.4.0...v1.5.1
 [v1.4.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.3.0...v1.4.0
 [v1.3.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.2.0...v1.3.0
 [v1.2.0]: https://github.com/terraform-aws-modules/terraform-aws-vpc/compare/v1.1.0...v1.2.0

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -14,8 +14,12 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id            = local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.s3[0].service_name
   vpc_endpoint_type = var.s3_endpoint_type
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.s3[0].service)
+    },
+    local.vpce_tags
+  )
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
@@ -53,10 +57,14 @@ resource "aws_vpc_endpoint" "dynamodb" {
   count = var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0
 
   vpc_id            = local.vpc_id
-  vpc_endpoint_type = var.dynamodb_endpoint_type
   service_name      = data.aws_vpc_endpoint_service.dynamodb[0].service_name
-
-  tags = local.vpce_tags
+  vpc_endpoint_type = var.dynamodb_endpoint_type
+  tags = merge(
+    {
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.dynamodb[0].service)
+    },
+    local.vpce_tags
+  )
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_dynamodb" {
@@ -80,7 +88,6 @@ resource "aws_vpc_endpoint_route_table_association" "public_dynamodb" {
   route_table_id  = aws_route_table.public[0].id
 }
 
-
 #############################
 # VPC Endpoint for Codebuild
 #############################
@@ -102,7 +109,7 @@ resource "aws_vpc_endpoint" "codebuild" {
   private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codebuild", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codebuild[0].service)
     },
     local.vpce_tags
   )
@@ -129,7 +136,7 @@ resource "aws_vpc_endpoint" "codecommit" {
   private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codecommit", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codecommit[0].service)
     },
     local.vpce_tags
   )
@@ -156,7 +163,7 @@ resource "aws_vpc_endpoint" "git_codecommit" {
   private_dns_enabled = var.git_codecommit_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-git-codecommit", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.git_codecommit[0].service)
     },
     local.vpce_tags
   )
@@ -183,7 +190,7 @@ resource "aws_vpc_endpoint" "config" {
   private_dns_enabled = var.config_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-config", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.config[0].service)
     },
     local.vpce_tags
   )
@@ -210,7 +217,7 @@ resource "aws_vpc_endpoint" "sqs" {
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sqs", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sqs[0].service)
     },
     local.vpce_tags
   )
@@ -237,7 +244,7 @@ resource "aws_vpc_endpoint" "lambda" {
   private_dns_enabled = var.lambda_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-lambda", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.lambda[0].service)
     },
     local.vpce_tags
   )
@@ -264,7 +271,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-secretsmanager", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.secretsmanager[0].service)
     },
     local.vpce_tags
   )
@@ -291,7 +298,7 @@ resource "aws_vpc_endpoint" "ssm" {
   private_dns_enabled = var.ssm_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ssm", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ssm[0].service)
     },
     local.vpce_tags
   )
@@ -318,7 +325,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ssmmessages", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ssmmessages[0].service)
     },
     local.vpce_tags
   )
@@ -345,7 +352,7 @@ resource "aws_vpc_endpoint" "ec2" {
   private_dns_enabled = var.ec2_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ec2", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ec2[0].service)
     },
     local.vpce_tags
   )
@@ -372,7 +379,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ec2messages", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ec2messages[0].service)
     },
     local.vpce_tags
   )
@@ -399,7 +406,7 @@ resource "aws_vpc_endpoint" "ec2_autoscaling" {
   private_dns_enabled = var.ec2_autoscaling_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-autoscaling", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ec2_autoscaling[0].service)
     },
     local.vpce_tags
   )
@@ -427,7 +434,7 @@ resource "aws_vpc_endpoint" "transferserver" {
   private_dns_enabled = var.transferserver_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-transfer.server", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.transferserver[0].service)
     },
     local.vpce_tags
   )
@@ -454,7 +461,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ecr.api", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ecr_api[0].service)
     },
     local.vpce_tags
   )
@@ -481,7 +488,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ecr.dkr", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ecr_dkr[0].service)
     },
     local.vpce_tags
   )
@@ -508,7 +515,7 @@ resource "aws_vpc_endpoint" "apigw" {
   private_dns_enabled = var.apigw_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-execute-api", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.apigw[0].service)
     },
     local.vpce_tags
   )
@@ -535,7 +542,7 @@ resource "aws_vpc_endpoint" "kms" {
   private_dns_enabled = var.kms_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-kms", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.kms[0].service)
     },
     local.vpce_tags
   )
@@ -562,7 +569,7 @@ resource "aws_vpc_endpoint" "ecs" {
   private_dns_enabled = var.ecs_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ecs", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ecs[0].service)
     },
     local.vpce_tags
   )
@@ -590,7 +597,7 @@ resource "aws_vpc_endpoint" "ecs_agent" {
   private_dns_enabled = var.ecs_agent_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ecs-agent", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ecs_agent[0].service)
     },
     local.vpce_tags
   )
@@ -618,7 +625,7 @@ resource "aws_vpc_endpoint" "ecs_telemetry" {
   private_dns_enabled = var.ecs_telemetry_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ecs-telemetry", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ecs_telemetry[0].service)
     },
     local.vpce_tags
   )
@@ -646,7 +653,7 @@ resource "aws_vpc_endpoint" "sns" {
   private_dns_enabled = var.sns_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sns", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sns[0].service)
     },
     local.vpce_tags
   )
@@ -674,7 +681,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-monitoring", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.monitoring[0].service)
     },
     local.vpce_tags
   )
@@ -702,7 +709,7 @@ resource "aws_vpc_endpoint" "logs" {
   private_dns_enabled = var.logs_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-logs", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.logs[0].service)
     },
     local.vpce_tags
   )
@@ -730,7 +737,7 @@ resource "aws_vpc_endpoint" "events" {
   private_dns_enabled = var.events_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-events", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.events[0].service)
     },
     local.vpce_tags
   )
@@ -758,7 +765,7 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
   private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elasticloadbalancing", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.elasticloadbalancing[0].service)
     },
     local.vpce_tags
   )
@@ -786,7 +793,7 @@ resource "aws_vpc_endpoint" "cloudtrail" {
   private_dns_enabled = var.cloudtrail_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-cloudtrail", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.cloudtrail[0].service)
     },
     local.vpce_tags
   )
@@ -814,7 +821,7 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
   private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-kinesis-streams", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.kinesis_streams[0].service)
     },
     local.vpce_tags
   )
@@ -842,7 +849,7 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
   private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-kinesis-firehose", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.kinesis_firehose[0].service)
     },
     local.vpce_tags
   )
@@ -869,7 +876,7 @@ resource "aws_vpc_endpoint" "glue" {
   private_dns_enabled = var.glue_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-glue", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.glue[0].service)
     },
     local.vpce_tags
   )
@@ -896,7 +903,7 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
   private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-aws.sagemaker.${var.sagemaker_notebook_endpoint_region}.notebook", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sagemaker_notebook[0].service_name)
     },
     local.vpce_tags
   )
@@ -923,7 +930,7 @@ resource "aws_vpc_endpoint" "sts" {
   private_dns_enabled = var.sts_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sts", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sts[0].service)
     },
     local.vpce_tags
   )
@@ -950,7 +957,7 @@ resource "aws_vpc_endpoint" "cloudformation" {
   private_dns_enabled = var.cloudformation_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-cloudformation", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.cloudformation[0].service)
     },
     local.vpce_tags
   )
@@ -976,7 +983,7 @@ resource "aws_vpc_endpoint" "codepipeline" {
   private_dns_enabled = var.codepipeline_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codepipeline", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codepipeline[0].service)
     },
     local.vpce_tags
   )
@@ -1002,7 +1009,7 @@ resource "aws_vpc_endpoint" "appmesh_envoy_management" {
   private_dns_enabled = var.appmesh_envoy_management_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-appmesh-envoy-management", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.appmesh_envoy_management[0].service)
     },
     local.vpce_tags
   )
@@ -1028,7 +1035,7 @@ resource "aws_vpc_endpoint" "servicecatalog" {
   private_dns_enabled = var.servicecatalog_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-servicecatalog", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.servicecatalog[0].service)
     },
     local.vpce_tags
   )
@@ -1054,7 +1061,7 @@ resource "aws_vpc_endpoint" "storagegateway" {
   private_dns_enabled = var.storagegateway_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-storagegateway", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.storagegateway[0].service)
     },
     local.vpce_tags
   )
@@ -1080,7 +1087,7 @@ resource "aws_vpc_endpoint" "transfer" {
   private_dns_enabled = var.transfer_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-transfer", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.transfer[0].service)
     },
     local.vpce_tags
   )
@@ -1106,7 +1113,7 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
   private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sagemaker.api", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sagemaker_api[0].service)
     },
     local.vpce_tags
   )
@@ -1132,7 +1139,7 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
   private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sagemaker.runtime", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sagemaker_runtime[0].service)
     },
     local.vpce_tags
   )
@@ -1159,7 +1166,7 @@ resource "aws_vpc_endpoint" "appstream_api" {
   private_dns_enabled = var.appstream_api_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-appstream.api", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.appstream_api[0].service)
     },
     local.vpce_tags
   )
@@ -1186,7 +1193,7 @@ resource "aws_vpc_endpoint" "appstream_streaming" {
   private_dns_enabled = var.appstream_streaming_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-appstream.streaming", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.appstream_streaming[0].service)
     },
     local.vpce_tags
   )
@@ -1213,7 +1220,7 @@ resource "aws_vpc_endpoint" "athena" {
   private_dns_enabled = var.athena_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-athena", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.athena[0].service)
     },
     local.vpce_tags
   )
@@ -1240,7 +1247,7 @@ resource "aws_vpc_endpoint" "rekognition" {
   private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-rekognition", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.rekognition[0].service)
     },
     local.vpce_tags
   )
@@ -1267,7 +1274,7 @@ resource "aws_vpc_endpoint" "efs" {
   private_dns_enabled = var.efs_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elasticfilesystem", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.efs[0].service)
     },
     local.vpce_tags
   )
@@ -1294,7 +1301,7 @@ resource "aws_vpc_endpoint" "cloud_directory" {
   private_dns_enabled = var.cloud_directory_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-clouddirectory", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.cloud_directory[0].service)
     },
     local.vpce_tags
   )
@@ -1321,7 +1328,7 @@ resource "aws_vpc_endpoint" "auto_scaling_plans" {
   private_dns_enabled = var.auto_scaling_plans_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-autoscaling-plans", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.auto_scaling_plans[0].service)
     },
     local.vpce_tags
   )
@@ -1348,7 +1355,7 @@ resource "aws_vpc_endpoint" "workspaces" {
   private_dns_enabled = var.workspaces_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-workspaces", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.workspaces[0].service)
     },
     local.vpce_tags
   )
@@ -1375,7 +1382,7 @@ resource "aws_vpc_endpoint" "access_analyzer" {
   private_dns_enabled = var.access_analyzer_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-access-analyzer", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.access_analyzer[0].service)
     },
     local.vpce_tags
   )
@@ -1402,7 +1409,7 @@ resource "aws_vpc_endpoint" "ebs" {
   private_dns_enabled = var.ebs_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-ebs", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ebs[0].service)
     },
     local.vpce_tags
   )
@@ -1429,7 +1436,7 @@ resource "aws_vpc_endpoint" "datasync" {
   private_dns_enabled = var.datasync_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-datasync", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.datasync[0].service)
     },
     local.vpce_tags
   )
@@ -1456,7 +1463,7 @@ resource "aws_vpc_endpoint" "elastic_inference_runtime" {
   private_dns_enabled = var.elastic_inference_runtime_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elastic-inference.runtime", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.elastic_inference_runtime[0].service)
     },
     local.vpce_tags
   )
@@ -1483,7 +1490,7 @@ resource "aws_vpc_endpoint" "sms" {
   private_dns_enabled = var.sms_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-sms", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.sms[0].service)
     },
     local.vpce_tags
   )
@@ -1510,7 +1517,7 @@ resource "aws_vpc_endpoint" "emr" {
   private_dns_enabled = var.emr_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elasticmapreduce", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.emr[0].service)
     },
     local.vpce_tags
   )
@@ -1537,7 +1544,7 @@ resource "aws_vpc_endpoint" "qldb_session" {
   private_dns_enabled = var.qldb_session_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-qldb.session", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.qldb_session[0].service)
     },
     local.vpce_tags
   )
@@ -1564,7 +1571,7 @@ resource "aws_vpc_endpoint" "states" {
   private_dns_enabled = var.states_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-states", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.states[0].service)
     },
     local.vpce_tags
   )
@@ -1591,7 +1598,7 @@ resource "aws_vpc_endpoint" "elasticbeanstalk" {
   private_dns_enabled = var.elasticbeanstalk_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elasticbeanstalk", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.elasticbeanstalk[0].service)
     },
     local.vpce_tags
   )
@@ -1618,7 +1625,7 @@ resource "aws_vpc_endpoint" "elasticbeanstalk_health" {
   private_dns_enabled = var.elasticbeanstalk_health_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-elasticbeanstalk-health", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.elasticbeanstalk_health[0].service)
     },
     local.vpce_tags
   )
@@ -1645,7 +1652,7 @@ resource "aws_vpc_endpoint" "acm_pca" {
   private_dns_enabled = var.acm_pca_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-acm-pca", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.acm_pca[0].service)
     },
     local.vpce_tags
   )
@@ -1672,7 +1679,7 @@ resource "aws_vpc_endpoint" "ses" {
   private_dns_enabled = var.ses_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-email-smtp", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.ses[0].service)
     },
     local.vpce_tags
   )
@@ -1699,7 +1706,7 @@ resource "aws_vpc_endpoint" "rds" {
   private_dns_enabled = var.rds_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-rds", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.rds[0].service)
     },
     local.vpce_tags
   )
@@ -1726,7 +1733,7 @@ resource "aws_vpc_endpoint" "codedeploy" {
   private_dns_enabled = var.codedeploy_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codedeploy", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codedeploy[0].service)
     },
     local.vpce_tags
   )
@@ -1753,7 +1760,7 @@ resource "aws_vpc_endpoint" "codedeploy_commands_secure" {
   private_dns_enabled = var.codedeploy_commands_secure_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codedeploy-commands-secure", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codedeploy_commands_secure[0].service)
     },
     local.vpce_tags
   )
@@ -1780,7 +1787,7 @@ resource "aws_vpc_endpoint" "textract" {
   private_dns_enabled = var.textract_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-textract", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.textract[0].service)
     },
     local.vpce_tags
   )
@@ -1807,7 +1814,7 @@ resource "aws_vpc_endpoint" "codeartifact_api" {
   private_dns_enabled = var.codeartifact_api_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codeartifact.api", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codeartifact_api[0].service)
     },
     local.vpce_tags
   )
@@ -1834,7 +1841,7 @@ resource "aws_vpc_endpoint" "codeartifact_repositories" {
   private_dns_enabled = var.codeartifact_repositories_endpoint_private_dns_enabled
   tags = merge(
     {
-      "Name" = format("%s-codeartifact.repositories", var.name)
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.codeartifact_repositories[0].service)
     },
     local.vpce_tags
   )
@@ -1860,6 +1867,10 @@ resource "aws_vpc_endpoint" "dms" {
   security_group_ids  = var.dms_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.dms_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.dms_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-%s", var.name, data.aws_vpc_endpoint_service.dms[0].service)
+    },
+    local.vpce_tags
+  )
 }

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -12,7 +12,12 @@ resource "aws_vpc_endpoint" "s3" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.s3[0].service_name
-  tags         = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-s3", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
@@ -50,7 +55,12 @@ resource "aws_vpc_endpoint" "dynamodb" {
 
   vpc_id       = local.vpc_id
   service_name = data.aws_vpc_endpoint_service.dynamodb[0].service_name
-  tags         = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-dynamodb", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_dynamodb" {
@@ -94,7 +104,12 @@ resource "aws_vpc_endpoint" "codebuild" {
   security_group_ids  = var.codebuild_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codebuild_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codebuild", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###############################
@@ -116,7 +131,12 @@ resource "aws_vpc_endpoint" "codecommit" {
   security_group_ids  = var.codecommit_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codecommit", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###################################
@@ -138,7 +158,12 @@ resource "aws_vpc_endpoint" "git_codecommit" {
   security_group_ids  = var.git_codecommit_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.git_codecommit_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.git_codecommit_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-git-codecommit", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ##########################
@@ -160,7 +185,12 @@ resource "aws_vpc_endpoint" "config" {
   security_group_ids  = var.config_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.config_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.config_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-config", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -182,7 +212,12 @@ resource "aws_vpc_endpoint" "sqs" {
   security_group_ids  = var.sqs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sqs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sqs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sqs", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #########################
@@ -193,6 +228,7 @@ data "aws_vpc_endpoint_service" "lambda" {
 
   service = "lambda"
 }
+
 resource "aws_vpc_endpoint" "lambda" {
   count = var.create_vpc && var.enable_lambda_endpoint ? 1 : 0
 
@@ -203,7 +239,12 @@ resource "aws_vpc_endpoint" "lambda" {
   security_group_ids  = var.lambda_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.lambda_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.lambda_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-lambda", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###################################
@@ -225,7 +266,12 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   security_group_ids  = var.secretsmanager_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.secretsmanager_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-secretsmanager", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -247,7 +293,12 @@ resource "aws_vpc_endpoint" "ssm" {
   security_group_ids  = var.ssm_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ssm_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ssm_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ssm", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###############################
@@ -269,7 +320,12 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   security_group_ids  = var.ssmmessages_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ssmmessages_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ssmmessages", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -291,7 +347,12 @@ resource "aws_vpc_endpoint" "ec2" {
   security_group_ids  = var.ec2_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ec2", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###############################
@@ -313,7 +374,12 @@ resource "aws_vpc_endpoint" "ec2messages" {
   security_group_ids  = var.ec2messages_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2messages_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ec2messages", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###############################
@@ -335,7 +401,12 @@ resource "aws_vpc_endpoint" "ec2_autoscaling" {
   security_group_ids  = var.ec2_autoscaling_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ec2_autoscaling_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ec2_autoscaling_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-autoscaling", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -358,7 +429,12 @@ resource "aws_vpc_endpoint" "transferserver" {
   security_group_ids  = var.transferserver_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.transferserver_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.transferserver_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-transfer.server", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###########################
@@ -380,7 +456,12 @@ resource "aws_vpc_endpoint" "ecr_api" {
   security_group_ids  = var.ecr_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ecr.api", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ###########################
@@ -402,7 +483,12 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   security_group_ids  = var.ecr_dkr_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecr_dkr_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ecr.dkr", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -424,7 +510,12 @@ resource "aws_vpc_endpoint" "apigw" {
   security_group_ids  = var.apigw_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.apigw_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.apigw_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-execute-api", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -446,7 +537,12 @@ resource "aws_vpc_endpoint" "kms" {
   security_group_ids  = var.kms_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kms_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kms_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-kms", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -468,7 +564,12 @@ resource "aws_vpc_endpoint" "ecs" {
   security_group_ids  = var.ecs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ecs", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -491,7 +592,12 @@ resource "aws_vpc_endpoint" "ecs_agent" {
   security_group_ids  = var.ecs_agent_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_agent_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_agent_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ecs-agent", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -514,7 +620,12 @@ resource "aws_vpc_endpoint" "ecs_telemetry" {
   security_group_ids  = var.ecs_telemetry_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ecs_telemetry_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ecs_telemetry_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ecs-telemetry", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -537,7 +648,12 @@ resource "aws_vpc_endpoint" "sns" {
   security_group_ids  = var.sns_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sns_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sns_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sns", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -560,7 +676,12 @@ resource "aws_vpc_endpoint" "monitoring" {
   security_group_ids  = var.monitoring_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.monitoring_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-monitoring", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -583,7 +704,12 @@ resource "aws_vpc_endpoint" "logs" {
   security_group_ids  = var.logs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.logs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.logs_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-logs", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -606,7 +732,12 @@ resource "aws_vpc_endpoint" "events" {
   security_group_ids  = var.events_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.events_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.events_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-events", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -629,7 +760,12 @@ resource "aws_vpc_endpoint" "elasticloadbalancing" {
   security_group_ids  = var.elasticloadbalancing_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticloadbalancing_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elasticloadbalancing", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -652,7 +788,12 @@ resource "aws_vpc_endpoint" "cloudtrail" {
   security_group_ids  = var.cloudtrail_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloudtrail_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloudtrail_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-cloudtrail", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -675,7 +816,12 @@ resource "aws_vpc_endpoint" "kinesis_streams" {
   security_group_ids  = var.kinesis_streams_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_streams_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-kinesis-streams", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 
@@ -698,7 +844,12 @@ resource "aws_vpc_endpoint" "kinesis_firehose" {
   security_group_ids  = var.kinesis_firehose_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.kinesis_firehose_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-kinesis-firehose", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -720,7 +871,12 @@ resource "aws_vpc_endpoint" "glue" {
   security_group_ids  = var.glue_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.glue_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.glue_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-glue", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ######################################
@@ -742,7 +898,12 @@ resource "aws_vpc_endpoint" "sagemaker_notebook" {
   security_group_ids  = var.sagemaker_notebook_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_notebook_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-aws.sagemaker.${var.sagemaker_notebook_endpoint_region}.notebook", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -764,7 +925,12 @@ resource "aws_vpc_endpoint" "sts" {
   security_group_ids  = var.sts_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sts_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sts_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sts", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -786,7 +952,12 @@ resource "aws_vpc_endpoint" "cloudformation" {
   security_group_ids  = var.cloudformation_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloudformation_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloudformation_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-cloudformation", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for CodePipeline
@@ -807,7 +978,12 @@ resource "aws_vpc_endpoint" "codepipeline" {
   security_group_ids  = var.codepipeline_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codepipeline_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codepipeline_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codepipeline", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for AppMesh
@@ -828,7 +1004,12 @@ resource "aws_vpc_endpoint" "appmesh_envoy_management" {
   security_group_ids  = var.appmesh_envoy_management_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.appmesh_envoy_management_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.appmesh_envoy_management_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-appmesh-envoy-management", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for Service Catalog
@@ -849,7 +1030,12 @@ resource "aws_vpc_endpoint" "servicecatalog" {
   security_group_ids  = var.servicecatalog_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.servicecatalog_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.servicecatalog_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-servicecatalog", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for Storage Gateway
@@ -870,7 +1056,12 @@ resource "aws_vpc_endpoint" "storagegateway" {
   security_group_ids  = var.storagegateway_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.storagegateway_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.storagegateway_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-storagegateway", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for Transfer
@@ -891,7 +1082,12 @@ resource "aws_vpc_endpoint" "transfer" {
   security_group_ids  = var.transfer_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.transfer_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.transfer_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-transfer", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for SageMaker API
@@ -912,7 +1108,12 @@ resource "aws_vpc_endpoint" "sagemaker_api" {
   security_group_ids  = var.sagemaker_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sagemaker.api", var.name)
+    },
+    local.vpce_tags
+  )
 }
 #############################
 # VPC Endpoint for SageMaker Runtime
@@ -933,7 +1134,12 @@ resource "aws_vpc_endpoint" "sagemaker_runtime" {
   security_group_ids  = var.sagemaker_runtime_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sagemaker_runtime_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sagemaker.runtime", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -955,7 +1161,12 @@ resource "aws_vpc_endpoint" "appstream_api" {
   security_group_ids  = var.appstream_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.appstream_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.appstream_api_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-appstream.api", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -977,7 +1188,12 @@ resource "aws_vpc_endpoint" "appstream_streaming" {
   security_group_ids  = var.appstream_streaming_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.appstream_streaming_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.appstream_streaming_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-appstream.streaming", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -999,7 +1215,12 @@ resource "aws_vpc_endpoint" "athena" {
   security_group_ids  = var.athena_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.athena_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.athena_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-athena", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1021,7 +1242,12 @@ resource "aws_vpc_endpoint" "rekognition" {
   security_group_ids  = var.rekognition_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.rekognition_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
-  tags                = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-rekognition", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1043,8 +1269,12 @@ resource "aws_vpc_endpoint" "efs" {
   security_group_ids  = var.efs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.efs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.efs_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elasticfilesystem", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1066,8 +1296,12 @@ resource "aws_vpc_endpoint" "cloud_directory" {
   security_group_ids  = var.cloud_directory_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.cloud_directory_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.cloud_directory_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-clouddirectory", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1089,8 +1323,12 @@ resource "aws_vpc_endpoint" "auto_scaling_plans" {
   security_group_ids  = var.auto_scaling_plans_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.auto_scaling_plans_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.auto_scaling_plans_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-autoscaling-plans", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1112,8 +1350,12 @@ resource "aws_vpc_endpoint" "workspaces" {
   security_group_ids  = var.workspaces_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.workspaces_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.workspaces_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-workspaces", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1135,8 +1377,12 @@ resource "aws_vpc_endpoint" "access_analyzer" {
   security_group_ids  = var.access_analyzer_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.access_analyzer_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.access_analyzer_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-access-analyzer", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1158,8 +1404,12 @@ resource "aws_vpc_endpoint" "ebs" {
   security_group_ids  = var.ebs_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ebs_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ebs_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-ebs", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1181,8 +1431,12 @@ resource "aws_vpc_endpoint" "datasync" {
   security_group_ids  = var.datasync_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.datasync_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.datasync_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-datasync", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1204,8 +1458,12 @@ resource "aws_vpc_endpoint" "elastic_inference_runtime" {
   security_group_ids  = var.elastic_inference_runtime_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elastic_inference_runtime_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elastic_inference_runtime_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elastic-inference.runtime", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1227,8 +1485,12 @@ resource "aws_vpc_endpoint" "sms" {
   security_group_ids  = var.sms_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.sms_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.sms_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-sms", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1250,8 +1512,12 @@ resource "aws_vpc_endpoint" "emr" {
   security_group_ids  = var.emr_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.emr_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.emr_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elasticmapreduce", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1273,8 +1539,12 @@ resource "aws_vpc_endpoint" "qldb_session" {
   security_group_ids  = var.qldb_session_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.qldb_session_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.qldb_session_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-qldb.session", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1296,8 +1566,12 @@ resource "aws_vpc_endpoint" "states" {
   security_group_ids  = var.states_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.states_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.states_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-states", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1319,8 +1593,12 @@ resource "aws_vpc_endpoint" "elasticbeanstalk" {
   security_group_ids  = var.elasticbeanstalk_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticbeanstalk_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticbeanstalk_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elasticbeanstalk", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1342,8 +1620,12 @@ resource "aws_vpc_endpoint" "elasticbeanstalk_health" {
   security_group_ids  = var.elasticbeanstalk_health_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.elasticbeanstalk_health_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.elasticbeanstalk_health_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-elasticbeanstalk-health", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1365,8 +1647,12 @@ resource "aws_vpc_endpoint" "acm_pca" {
   security_group_ids  = var.acm_pca_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.acm_pca_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.acm_pca_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-acm-pca", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #######################
@@ -1388,8 +1674,12 @@ resource "aws_vpc_endpoint" "ses" {
   security_group_ids  = var.ses_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.ses_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.ses_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-email-smtp", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 ######################
@@ -1411,8 +1701,12 @@ resource "aws_vpc_endpoint" "rds" {
   security_group_ids  = var.rds_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.rds_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.rds_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-rds", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################
@@ -1434,8 +1728,12 @@ resource "aws_vpc_endpoint" "codedeploy" {
   security_group_ids  = var.codedeploy_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codedeploy_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codedeploy_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codedeploy", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################################
@@ -1457,8 +1755,12 @@ resource "aws_vpc_endpoint" "codedeploy_commands_secure" {
   security_group_ids  = var.codedeploy_commands_secure_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codedeploy_commands_secure_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codedeploy_commands_secure_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codedeploy-commands-secure", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################################
@@ -1480,8 +1782,12 @@ resource "aws_vpc_endpoint" "textract" {
   security_group_ids  = var.textract_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.textract_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.textract_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-textract", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################################
@@ -1503,8 +1809,12 @@ resource "aws_vpc_endpoint" "codeartifact_api" {
   security_group_ids  = var.codeartifact_api_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codeartifact_api_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codeartifact_api_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codeartifact.api", var.name)
+    },
+    local.vpce_tags
+  )
 }
 
 #############################################
@@ -1526,6 +1836,10 @@ resource "aws_vpc_endpoint" "codeartifact_repositories" {
   security_group_ids  = var.codeartifact_repositories_endpoint_security_group_ids
   subnet_ids          = coalescelist(var.codeartifact_repositories_endpoint_subnet_ids, aws_subnet.private.*.id)
   private_dns_enabled = var.codeartifact_repositories_endpoint_private_dns_enabled
-
-  tags = local.vpce_tags
+  tags = merge(
+    {
+      "Name" = format("%s-codeartifact.repositories", var.name)
+    },
+    local.vpce_tags
+  )
 }


### PR DESCRIPTION
## Description
This PR adds a `Name` tag to any vpc endpoints that are created by the module.

At the moment vpc endpoints are passed tags from `local.vpce_tags`; this change merges in a `Name` tag (based on `var.name` and the endpoint service's name) following the same pattern used throughout the rest of the module.

## Motivation and Context
This will add more context to any vpc endpoints in the aws console, as well as allowing any testing tools that rely on the `Name` tag (such as [awspec](https://github.com/k1LoW/awspec/blob/master/doc/resource_types.md#vpc_endpoints)) to pick endpoints up for testing.

## Breaking Changes
None known.

## How Has This Been Tested?
Using terraform 0.13.3 I've deployed the module into an aws account with all endpoints enabled; checking that the deployment was successful and that the endpoints were named as I expected.
The endpoints were enabled in two batches, i.e. from `access_analyzer` to `elasticbeanstalk_health`, and then from `elasticloadbalancing` to `workspaces`, as aws has a 50 vpc endpoint limit by default.
