### PR TITLE
feat: Add support for NAT Gateway and NAT Gateway EIP name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,8 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | name | Name to be used on all the resources as identifier | `string` | `""` | no |
 | nat\_eip\_tags | Additional tags for the NAT EIP | `map(string)` | `{}` | no |
 | nat\_gateway\_tags | Additional tags for the NAT gateways | `map(string)` | `{}` | no |
+| nat\_gateway\_name\_prefix | Specify the prefix name for the nat gateway | `string` | `""` | no |
+| nat\_gateway\_eips\_name\_prefix | Specify the prefix name for the nat gateway's EIP's | `string` | `""` | no |
 | one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | `bool` | `false` | no |
 | private\_acl\_tags | Additional tags for the private subnets network ACL | `map(string)` | `{}` | no |
 | private\_dedicated\_network\_acl | Whether to use dedicated network ACL (not default) and custom rules for private subnets | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -932,7 +932,7 @@ resource "aws_eip" "nat" {
     {
       "Name" = format(
         "%s-%s",
-        var.name,
+        var.nat_gateway_eips_name_prefix != "" ? var.nat_gateway_eips_name_prefix : var.name,
         element(var.azs, var.single_nat_gateway ? 0 : count.index),
       )
     },
@@ -957,7 +957,7 @@ resource "aws_nat_gateway" "this" {
     {
       "Name" = format(
         "%s-%s",
-        var.name,
+        var.nat_gateway_name_prefix != "" ? var.nat_gateway_name_prefix : var.name,
         element(var.azs, var.single_nat_gateway ? 0 : count.index),
       )
     },

--- a/variables.tf
+++ b/variables.tf
@@ -274,6 +274,12 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "nat_gateway_name_prefix" {
+  description = "Optionally specify a name for your nat gateways, if not var.name will be used"
+  type        = string
+  default     = ""
+}
+
 variable "single_nat_gateway" {
   description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
   type        = bool
@@ -302,6 +308,12 @@ variable "external_nat_ips" {
   description = "List of EIPs to be used for `nat_public_ips` output (used in combination with reuse_nat_ips and external_nat_ip_ids)"
   type        = list(string)
   default     = []
+}
+
+variable "nat_gateway_eips_name_prefix" {
+  description = "Optionally specify a name for your nat gateways's eips, if not var.name will be used"
+  type        = string
+  default     = ""
 }
 
 variable "enable_public_s3_endpoint" {


### PR DESCRIPTION
## Description
Add the ability to define a name prefix for the NAT Gateway and the EIP's that are created for the NAT Gateway.

## Motivation and Context
Currently based on the name tag alone for the NAT Gateway and NAT Gateway's EIP's it is hard to know that the NAT Gateway is a NAT Gateway and that the EIP's that are created belong to the NAT Gateway. I wanted a way to make this more clear for reporting purposes. While I could have overridden the name using the `nat_gateway_tags` and `nat_eip_tags` options respectively it would have removed the subnet part of the name which would have left me with several NAT Gateways and EIPs with matching names in VPC's that have more than one. Adding a prefix option seemed like a sensible compromise.

## Breaking Changes
No breaking changes, if the new option is not used the previous naming scheme is used.

## How Has This Been Tested?
I ran `terraform plan` on the `examples/simple-vpc` and verified the names matched what was previously there. Then I modified `examples/simple-vpc/main.tf` adding: 
```
  nat_gateway_name_prefix = "my-overridden-nat-name"
  nat_gateway_eips_name_prefix = "my-overridden-eips-name"
```  
the new plan had:
```
  # module.vpc.aws_eip.nat[0] will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Environment" = "dev"
          + "Name"        = "my-overridden-eips-name-eu-west-1a"
          + "Owner"       = "user"
        }
      + vpc                  = true
    }

  # module.vpc.aws_nat_gateway.this[0] will be created
  + resource "aws_nat_gateway" "this" {
      + allocation_id        = (known after apply)
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Environment" = "dev"
          + "Name"        = "my-overridden-nat-name-eu-west-1a"
          + "Owner"       = "user"
        }
    }
```    