### PR TITLE
fix: vpc endpoint service s3

### DIFF
--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -4,7 +4,9 @@
 data "aws_vpc_endpoint_service" "s3" {
   count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
-  service = "s3"
+  service      = "s3"
+  service_type = "Gateway"
+
 }
 
 resource "aws_vpc_endpoint" "s3" {


### PR DESCRIPTION
## Description
AWS has some kind of bug on vpc endpoint service S3. S3 should be a "gateway" service however "gateway" and "interface" services shows up. This cause terraform to fail with the following error:

`Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service`

Multiple S3 endpoint service (tested region: eu-central-1, eu-west-1)
<img width="760" alt="Screenshot 2021-02-02 at 19 35 45" src="https://user-images.githubusercontent.com/51825189/106648303-63438f00-6590-11eb-9f94-4de9bfeea9a5.png">

## Motivation and Context
I made this PR to able to deploy this able to deploy terraform code.
