### PR TITLE
feat: Upgraded minimum required versions of AWS provider to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Inputs
 

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Inputs
 

--- a/examples/complete-vpc/versions.tf
+++ b/examples/complete-vpc/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/ipv6/README.md
+++ b/examples/ipv6/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Inputs
 

--- a/examples/ipv6/versions.tf
+++ b/examples/ipv6/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/issue-108-route-already-exists/README.md
+++ b/examples/issue-108-route-already-exists/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/issue-108-route-already-exists/versions.tf
+++ b/examples/issue-108-route-already-exists/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/issue-44-asymmetric-private-subnets/README.md
+++ b/examples/issue-44-asymmetric-private-subnets/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/issue-44-asymmetric-private-subnets/versions.tf
+++ b/examples/issue-44-asymmetric-private-subnets/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/issue-46-no-private-subnets/README.md
+++ b/examples/issue-46-no-private-subnets/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/issue-46-no-private-subnets/versions.tf
+++ b/examples/issue-46-no-private-subnets/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/manage-default-vpc/versions.tf
+++ b/examples/manage-default-vpc/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/network-acls/versions.tf
+++ b/examples/network-acls/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/secondary-cidr-blocks/versions.tf
+++ b/examples/secondary-cidr-blocks/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 
 ## Providers
 

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -15,7 +15,7 @@ module "vpc" {
 
   enable_ipv6 = true
 
-  enable_nat_gateway = true
+  enable_nat_gateway = false
   single_nat_gateway = true
 
   #  s3_endpoint_type = "Interface"

--- a/examples/simple-vpc/versions.tf
+++ b/examples/simple-vpc/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.21 |
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 | random | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68 |
+| aws | >= 3.10 |
 | random | >= 2 |
 
 ## Inputs

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -2,7 +2,14 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.10"
+    }
   }
 }


### PR DESCRIPTION
Related to #573 since VPC endpoint service_type became available in AWS provider version 3.10.