### PR TITLE
feat: s3 interface endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Sometimes it is handy to have public access to Redshift clusters (for example if
 
 It is possible to integrate this VPC module with [terraform-aws-transit-gateway module](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway) which handles the creation of TGW resources and VPC attachments. See [complete example there](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/tree/master/examples/complete).
 
+## S3 gateway type vs S3 interface type endpoint
+
+AWS currently support two types of S3 endpoint: gateway type and interface type. To preserve backwards compatibility 'enable\_s3\_endpoint' means it will create gateway type endpoint and attach it to the route table of the VPC. The new 'enable\_s3\_interface\_endpoint' acts as a rest of the interface type endpoint and does not attach itself to the route table of the VPC.
+
 ## Examples
 
 * [Simple VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/simple-vpc)
@@ -468,7 +472,8 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | enable\_qldb\_session\_endpoint | Should be true if you want to provision an QLDB Session endpoint to the VPC | `bool` | `false` | no |
 | enable\_rds\_endpoint | Should be true if you want to provision an RDS endpoint to the VPC | `bool` | `false` | no |
 | enable\_rekognition\_endpoint | Should be true if you want to provision a Rekognition endpoint to the VPC | `bool` | `false` | no |
-| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | `bool` | `false` | no |
+| enable\_s3\_endpoint | Should be true if you want to provision an S3 gateway type endpoint to the VPC | `bool` | `false` | no |
+| enable\_s3\_interface\_endpoint | Should be true if you want to provision an S3 interface type endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_api\_endpoint | Should be true if you want to provision a SageMaker API endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_notebook\_endpoint | Should be true if you want to provision a Sagemaker Notebook endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_runtime\_endpoint | Should be true if you want to provision a SageMaker Runtime endpoint to the VPC | `bool` | `false` | no |
@@ -590,7 +595,10 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | rekognition\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for Rekognition endpoint | `list(string)` | `[]` | no |
 | rekognition\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Rekognition endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
-| s3\_endpoint\_type | S3 VPC endpoint type | `string` | `"Gateway"` | no |
+| s3\_interface\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for S3 interface type endpoint | `bool` | `false` | no |
+| s3\_interface\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for S3 interface type endpoint | `list(string)` | `[]` | no |
+| s3\_interface\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for S3 interface type endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
+| sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
 | sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
 | sagemaker\_api\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SageMaker API endpoint | `list(string)` | `[]` | no |
 | sagemaker\_api\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SageMaker API endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
@@ -893,6 +901,9 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | vpc\_endpoint\_rekognition\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for Rekognition. |
 | vpc\_endpoint\_s3\_id | The ID of VPC endpoint for S3 |
 | vpc\_endpoint\_s3\_pl\_id | The prefix list for the S3 VPC endpoint. |
+| vpc\_endpoint\_s3\_interface\_dns\_entry | The DNS entries for the VPC Endpoint for S3 interface. |
+| vpc\_endpoint\_s3\_interface\_id | The ID of VPC endpoint for S3 interface |
+| vpc\_endpoint\_s3\_interface\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for S3 interface. |
 | vpc\_endpoint\_sagemaker\_api\_dns\_entry | The DNS entries for the VPC Endpoint for SageMaker API. |
 | vpc\_endpoint\_sagemaker\_api\_id | The ID of VPC endpoint for SageMaker API |
 | vpc\_endpoint\_sagemaker\_api\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SageMaker API. |

--- a/README.md
+++ b/README.md
@@ -599,7 +599,6 @@ AWS currently support two types of S3 endpoint: gateway type and interface type.
 | s3\_interface\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for S3 interface type endpoint | `list(string)` | `[]` | no |
 | s3\_interface\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for S3 interface type endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
-| sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
 | sagemaker\_api\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SageMaker API endpoint | `list(string)` | `[]` | no |
 | sagemaker\_api\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for SageMaker API endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | sagemaker\_notebook\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for Sagemaker Notebook endpoint | `bool` | `false` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1409,17 +1409,17 @@ output "vpc_endpoint_codeartifact_repositories_dns_entry" {
 
 output "vpc_endpoint_dms_id" {
   description = "The ID of VPC endpoint for DMS"
-  value       = concat(aws_vpc_endpoint.sns.*.id, [""])[0]
+  value       = concat(aws_vpc_endpoint.dms.*.id, [""])[0]
 }
 
 output "vpc_endpoint_dms_network_interface_ids" {
   description = "One or more network interfaces for the VPC Endpoint for DMS."
-  value       = flatten(aws_vpc_endpoint.sns.*.network_interface_ids)
+  value       = flatten(aws_vpc_endpoint.dms.*.network_interface_ids)
 }
 
 output "vpc_endpoint_dms_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for DMS."
-  value       = flatten(aws_vpc_endpoint.sns.*.dns_entry)
+  value       = flatten(aws_vpc_endpoint.dms.*.dns_entry)
 }
 
 output "vpc_endpoint_rds_id" {
@@ -1435,6 +1435,21 @@ output "vpc_endpoint_rds_network_interface_ids" {
 output "vpc_endpoint_rds_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for RDS."
   value       = flatten(aws_vpc_endpoint.rds.*.dns_entry)
+}
+
+output "vpc_endpoint_s3_interface_id" {
+  description = "The ID of VPC endpoint for S3 interface"
+  value       = concat(aws_vpc_endpoint.s3_interface.*.id, [""])[0]
+}
+
+output "vpc_endpoint_s3_interface_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for S3 interface."
+  value       = flatten(aws_vpc_endpoint.s3_interface.*.network_interface_ids)
+}
+
+output "vpc_endpoint_s3_interface_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for S3 interface."
+  value       = flatten(aws_vpc_endpoint.s3_interface.*.dns_entry)
 }
 
 # VPC flow log

--- a/variables.tf
+++ b/variables.tf
@@ -323,16 +323,35 @@ variable "dynamodb_endpoint_type" {
 }
 
 variable "enable_s3_endpoint" {
-  description = "Should be true if you want to provision an S3 endpoint to the VPC"
+  description = "Should be true if you want to provision an S3 gateway type endpoint to the VPC"
   type        = bool
   default     = false
 }
 
-variable "s3_endpoint_type" {
-  description = "S3 VPC endpoint type"
-  type        = string
-  default     = "Gateway"
+variable "enable_s3_interface_endpoint" {
+  description = "Should be true if you want to provision an S3 interface type endpoint to the VPC"
+  type        = bool
+  default     = false
 }
+
+variable "s3_interface_endpoint_security_group_ids" {
+  description = "The ID of one or more security groups to associate with the network interface for S3 interface type endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_interface_endpoint_subnet_ids" {
+  description = "The ID of one or more subnets in which to create a network interface for S3 interface type endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_interface_endpoint_private_dns_enabled" {
+  description = "Whether or not to associate a private hosted zone with the specified VPC for S3 interface type endpoint"
+  type        = bool
+  default     = false
+}
+
 
 variable "enable_codeartifact_api_endpoint" {
   description = "Should be true if you want to provision an Codeartifact API endpoint to the VPC"


### PR DESCRIPTION
## Description
Creates the opportunity to create interface style S3 endpoint while it maintains backward API compatibility.
Fixing the error which was introduced in #573 and #564 

## Motivation and Context
In the PR #573 variable "s3_endpoint_type" was introduced. This works with default ("Gateway") value. However if you try to  attach "Interface" interface style endpoint to a route table it will cause error

Used configuration
```  #S3 Endpoint
  enable_s3_endpoint        = true
  enable_public_s3_endpoint = false
  s3_endpoint_type          = "Interface"
```

  
Error message
```
Error: An Interface VPC Endpoint must always have at least one Security Group
```

 <br><br>  
A gateway style endpoint attach itself to a route table
<img width="881" alt="Screenshot 2021-02-02 at 22 20 44" src="https://user-images.githubusercontent.com/51825189/106664286-23d36d80-65a5-11eb-8752-1bce1415d251.png">
   
 <br><br>
An interface style endpoint attach itself to subnets and needs SG to make it work
<img width="881" alt="Screenshot 2021-02-02 at 22 21 08" src="https://user-images.githubusercontent.com/51825189/106664751-cc81cd00-65a5-11eb-8122-ae65c617525f.png">

