### PR TITLE
docs: update the 'conditional creation' section of the README for TF 0.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If your organization requires a permissions boundary to be attached to the VPC F
 
 ## Conditional creation
 
-Sometimes you need to have a way to create VPC resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_vpc`.
+Prior to Terraform 0.13, you were unable to specify `count` in a module block. If you wish to toggle the creation of the module's resources in an older (pre 0.13) version of Terraform, you can use the `create_vpc` argument.
 
 ```hcl
 # This VPC will not be created


### PR DESCRIPTION
…hat modules support the 'count' argument (as of Terraform 0.13).

## Description
Updated the 'Conditional Creation' section of the documentation to reflect the fact that Terraform 0.13+ supports the count argument in module blocks (https://www.terraform.io/docs/language/meta-arguments/count.html).

## Motivation and Context
The documentation was outdated and didn't fully apply to newer versions of Terraform.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
I read it, and my IDE has a spellchecker?
