### PR TITLE
Sre 1509

### DIFF
--- a/examples/ipv6/outputs.tf
+++ b/examples/ipv6/outputs.tf
@@ -4,12 +4,12 @@ output "vpc_id" {
   value       = module.vpc.vpc_id
 }
 
-output "ipv6_association_id" {
+output "ipv6_cidr_block" {
   description = "The IPv6 CIDR block"
   value       = module.vpc.vpc_ipv6_cidr_block
 }
 
-output "ipv6_cidr_block" {
+output "ipv6_association_id" {
   description = "The association ID for the IPv6 CIDR block"
   value       = module.vpc.vpc_ipv6_association_id
 }

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -3,8 +3,11 @@
 ######################
 data "aws_vpc_endpoint_service" "s3" {
   count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
-
   service = "s3"
+  filter {
+    name  = "vpc_id"
+    values = [aws_vpc.this.id]
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {


### PR DESCRIPTION
## Description
Adding additional filters for vpc endpoints

## Motivation and Context
Should resolve the following error when running plans against all accounts for the vpc-main module.
"multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service"

## Breaking Changes

## How Has This Been Tested?

