### PR TITLE
v2.69.1 proposal, ensure AWS terraform provider v2.70.0 compatibility

### DIFF
--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,11 +1,15 @@
 ######################
 # VPC Endpoint for S3
 ######################
+
 data "aws_vpc_endpoint_service" "s3" {
   count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
-  service_type = var.s3_endpoint_type
-  service      = "s3"
+  service = "s3"
+  filter {
+    name   = "service-type"
+    values = [var.s3_endpoint_type]
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {
@@ -45,8 +49,11 @@ resource "aws_vpc_endpoint_route_table_association" "public_s3" {
 data "aws_vpc_endpoint_service" "dynamodb" {
   count = var.create_vpc && var.enable_dynamodb_endpoint ? 1 : 0
 
-  service_type = var.dynamodb_endpoint_type
-  service      = "dynamodb"
+  service = "dynamodb"
+  filter {
+    name   = "service-type"
+    values = [var.dynamodb_endpoint_type]
+  }
 }
 
 resource "aws_vpc_endpoint" "dynamodb" {


### PR DESCRIPTION
## Description

- Remove s3/dynamodb service endpoint data sources due to incompatible `service_type` parameter.
- Replace dynamic service name from data sources with template strings

## Motivation and Context

After this week's release of privatelink for s3, the fixes implemented in v2.69.0 and v2.70.0 don't mitigate errors when using the AWS Terraform provider `v2.X.X`

Addresses:

- #582
- #585 

## Breaking Changes

This is a proposed patch release for `v2.69.` which did not resolve the original issue.

## How Has This Been Tested?

This was tested by creating vpc endpoint services with AWS Terraform Provider `2.70.0` and that no error occurred.

/cc @tbugfinder 
