### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
 
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -237,6 +237,48 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 |------|---------|
 | aws | >= 3.10 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/cloudwatch_log_group) |
+| [aws_customer_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/customer_gateway) |
+| [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/db_subnet_group) |
+| [aws_default_network_acl](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/default_network_acl) |
+| [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/default_security_group) |
+| [aws_default_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/default_vpc) |
+| [aws_egress_only_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/egress_only_internet_gateway) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/eip) |
+| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/elasticache_subnet_group) |
+| [aws_flow_log](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/flow_log) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role_policy_attachment) |
+| [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/internet_gateway) |
+| [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/nat_gateway) |
+| [aws_network_acl](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/network_acl) |
+| [aws_network_acl_rule](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/network_acl_rule) |
+| [aws_redshift_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/redshift_subnet_group) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route_table) |
+| [aws_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route_table_association) |
+| [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/subnet) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc) |
+| [aws_vpc_dhcp_options](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_dhcp_options) |
+| [aws_vpc_dhcp_options_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_dhcp_options_association) |
+| [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_endpoint) |
+| [aws_vpc_endpoint_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_endpoint_route_table_association) |
+| [aws_vpc_endpoint_service](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/vpc_endpoint_service) |
+| [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_ipv4_cidr_block_association) |
+| [aws_vpn_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway) |
+| [aws_vpn_gateway_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway_attachment) |
+| [aws_vpn_gateway_route_propagation](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway_route_propagation) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -955,7 +997,6 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
 | vpc\_owner\_id | The ID of the AWS account that owns the VPC |
 | vpc\_secondary\_cidr\_blocks | List of secondary CIDR blocks of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -255,29 +255,29 @@ No Modules.
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/eip) |
 | [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/elasticache_subnet_group) |
 | [aws_flow_log](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/flow_log) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
 | [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/internet_gateway) |
 | [aws_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/nat_gateway) |
-| [aws_network_acl](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/network_acl) |
 | [aws_network_acl_rule](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/network_acl_rule) |
+| [aws_network_acl](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/network_acl) |
 | [aws_redshift_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/redshift_subnet_group) |
-| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route) |
-| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route_table) |
 | [aws_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route_table_association) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route_table) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/route) |
 | [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/subnet) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc) |
-| [aws_vpc_dhcp_options](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_dhcp_options) |
 | [aws_vpc_dhcp_options_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_dhcp_options_association) |
-| [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_endpoint) |
+| [aws_vpc_dhcp_options](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_dhcp_options) |
 | [aws_vpc_endpoint_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_endpoint_route_table_association) |
 | [aws_vpc_endpoint_service](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/vpc_endpoint_service) |
+| [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_endpoint) |
 | [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc_ipv4_cidr_block_association) |
-| [aws_vpn_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpc) |
 | [aws_vpn_gateway_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway_attachment) |
 | [aws_vpn_gateway_route_propagation](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway_route_propagation) |
+| [aws_vpn_gateway](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/vpn_gateway) |
 
 ## Inputs
 

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -30,6 +30,18 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | aws | >= 3.10 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/security_group) |
+
 ## Inputs
 
 No input.
@@ -54,5 +66,4 @@ No input.
 | vpc\_endpoint\_ssm\_id | The ID of VPC endpoint for SSM |
 | vpc\_endpoint\_ssm\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SSM. |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/ipv6/README.md
+++ b/examples/ipv6/README.md
@@ -28,6 +28,18 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|---------|
 | aws | >= 3.10 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../.. |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/availability_zones) |
+
 ## Inputs
 
 No input.
@@ -39,5 +51,4 @@ No input.
 | ipv6\_association\_id | The association ID for the IPv6 CIDR block |
 | ipv6\_cidr\_block | The IPv6 CIDR block |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/issue-108-route-already-exists/README.md
+++ b/examples/issue-108-route-already-exists/README.md
@@ -30,6 +30,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -44,5 +54,4 @@ No input.
 | private\_subnets | List of IDs of private subnets |
 | public\_subnets | List of IDs of public subnets |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/issue-44-asymmetric-private-subnets/README.md
+++ b/examples/issue-44-asymmetric-private-subnets/README.md
@@ -28,6 +28,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -42,5 +52,4 @@ No input.
 | private\_subnets | List of IDs of private subnets |
 | public\_subnets | List of IDs of public subnets |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/issue-46-no-private-subnets/README.md
+++ b/examples/issue-46-no-private-subnets/README.md
@@ -28,6 +28,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -42,5 +52,4 @@ No input.
 | private\_subnets | List of IDs of private subnets |
 | public\_subnets | List of IDs of public subnets |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -28,6 +28,16 @@ Run `terraform destroy` when you don't need these resources.
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -38,5 +48,4 @@ No input.
 |------|-------------|
 | default\_vpc\_cidr\_block | The CIDR block of the VPC |
 | default\_vpc\_id | The ID of the Default VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -30,6 +30,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -51,5 +61,4 @@ No input.
 | public\_subnets | List of IDs of public subnets |
 | vpc\_cidr\_block | The CIDR block of the VPC |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -28,6 +28,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -42,5 +52,4 @@ No input.
 | vpc\_cidr\_block | The CIDR block of the VPC |
 | vpc\_id | The ID of the VPC |
 | vpc\_secondary\_cidr\_blocks | List of secondary CIDR blocks of the VPC |
-
  <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -32,6 +32,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -46,5 +56,4 @@ No input.
 | public\_subnets | List of IDs of public subnets |
 | vpc\_cidr\_block | The CIDR block of the VPC |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -48,10 +48,10 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name |
 |------|
 | [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/cloudwatch_log_group) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
 | [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
 
 ## Inputs

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -34,6 +34,26 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | aws | >= 3.10 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| s3_bucket | terraform-aws-modules/s3-bucket/aws | ~> 1.0 |
+| vpc_with_flow_logs_cloudwatch_logs | ../../ |  |
+| vpc_with_flow_logs_cloudwatch_logs_default | ../../ |  |
+| vpc_with_flow_logs_s3_bucket | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/cloudwatch_log_group) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.10/docs/resources/iam_role_policy_attachment) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -53,5 +73,4 @@ No input.
 | vpc\_with\_flow\_logs\_cloudwatch\_logs\_vpc\_flow\_log\_destination\_arn | The ARN of the destination for VPC Flow Logs |
 | vpc\_with\_flow\_logs\_cloudwatch\_logs\_vpc\_flow\_log\_destination\_type | The type of the destination for VPC Flow Logs |
 | vpc\_with\_flow\_logs\_cloudwatch\_logs\_vpc\_flow\_log\_id | The ID of the Flow Log resource |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpc-separate-private-route-tables/README.md
+++ b/examples/vpc-separate-private-route-tables/README.md
@@ -28,6 +28,16 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| vpc | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -43,5 +53,4 @@ No input.
 | public\_subnets | List of IDs of public subnets |
 | redshift\_subnets | List of IDs of elasticache subnets |
 | vpc\_id | The ID of the VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
