### PR TITLE
fix: Add explicit parameters for S3 interface endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,8 @@ No Modules.
 | enable\_qldb\_session\_endpoint | Should be true if you want to provision an QLDB Session endpoint to the VPC | `bool` | `false` | no |
 | enable\_rds\_endpoint | Should be true if you want to provision an RDS endpoint to the VPC | `bool` | `false` | no |
 | enable\_rekognition\_endpoint | Should be true if you want to provision a Rekognition endpoint to the VPC | `bool` | `false` | no |
-| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | `bool` | `false` | no |
+| enable\_s3\_endpoint | Should be true if you want to provision an S3 gateway endpoint to the VPC | `bool` | `false` | no |
+| enable\_s3\_interface\_endpoint | Should be true if you want to provision an S3 interface endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_api\_endpoint | Should be true if you want to provision a SageMaker API endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_notebook\_endpoint | Should be true if you want to provision a Sagemaker Notebook endpoint to the VPC | `bool` | `false` | no |
 | enable\_sagemaker\_runtime\_endpoint | Should be true if you want to provision a SageMaker Runtime endpoint to the VPC | `bool` | `false` | no |
@@ -665,10 +666,10 @@ No Modules.
 | rekognition\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for Rekognition endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | reuse\_nat\_ips | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
 | s3\_endpoint\_policy | A policy to attach to the endpoint that controls access to the service. Defaults to full access | `string` | `null` | no |
-| s3\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for S3 interface endpoint | `bool` | `false` | no |
-| s3\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for S3 interface endpoint | `list(string)` | `[]` | no |
-| s3\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for S3 interface endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
-| s3\_endpoint\_type | S3 VPC endpoint type. Note - S3 Interface type support is only available on AWS provider 3.10 and later | `string` | `"Gateway"` | no |
+| s3\_interface\_endpoint\_policy | A policy to attach to the endpoint that controls access to the service. Defaults to full access | `string` | `null` | no |
+| s3\_interface\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for S3 interface endpoint | `bool` | `false` | no |
+| s3\_interface\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for S3 interface endpoint | `list(string)` | `[]` | no |
+| s3\_interface\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for S3 interface endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | sagemaker\_api\_endpoint\_policy | A policy to attach to the endpoint that controls access to the service. Defaults to full access | `string` | `null` | no |
 | sagemaker\_api\_endpoint\_private\_dns\_enabled | Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint | `bool` | `false` | no |
 | sagemaker\_api\_endpoint\_security\_group\_ids | The ID of one or more security groups to associate with the network interface for SageMaker API endpoint | `list(string)` | `[]` | no |
@@ -981,6 +982,9 @@ No Modules.
 | vpc\_endpoint\_rekognition\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for Rekognition. |
 | vpc\_endpoint\_s3\_id | The ID of VPC endpoint for S3 |
 | vpc\_endpoint\_s3\_pl\_id | The prefix list for the S3 VPC endpoint. |
+| vpc\_endpoint\_s3\_interface\_dns\_entry | The DNS entries for the VPC Endpoint for S3 interface. |
+| vpc\_endpoint\_s3\_interface\_id | The ID of VPC endpoint for S3 interface |
+| vpc\_endpoint\_s3\_interface\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for S3 interface. |
 | vpc\_endpoint\_sagemaker\_api\_dns\_entry | The DNS entries for the VPC Endpoint for SageMaker API. |
 | vpc\_endpoint\_sagemaker\_api\_id | The ID of VPC endpoint for SageMaker API |
 | vpc\_endpoint\_sagemaker\_api\_network\_interface\_ids | One or more network interfaces for the VPC Endpoint for SageMaker API. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -484,12 +484,12 @@ output "elasticache_network_acl_arn" {
 
 # VPC Endpoints
 output "vpc_endpoint_s3_id" {
-  description = "The ID of VPC endpoint for S3"
+  description = "The ID of VPC endpoint for S3 gateway"
   value       = concat(aws_vpc_endpoint.s3.*.id, [""])[0]
 }
 
 output "vpc_endpoint_s3_pl_id" {
-  description = "The prefix list for the S3 VPC endpoint."
+  description = "The prefix list for the S3 gateway VPC endpoint."
   value       = concat(aws_vpc_endpoint.s3.*.prefix_list_id, [""])[0]
 }
 
@@ -1440,6 +1440,21 @@ output "vpc_endpoint_rds_network_interface_ids" {
 output "vpc_endpoint_rds_dns_entry" {
   description = "The DNS entries for the VPC Endpoint for RDS."
   value       = flatten(aws_vpc_endpoint.rds.*.dns_entry)
+}
+
+output "vpc_endpoint_s3_interface_id" {
+  description = "The ID of VPC endpoint for S3 interface"
+  value       = concat(aws_vpc_endpoint.s3_interface.*.id, [""])[0]
+}
+
+output "vpc_endpoint_s3_interface_network_interface_ids" {
+  description = "One or more network interfaces for the VPC Endpoint for S3 interface."
+  value       = flatten(aws_vpc_endpoint.s3_interface.*.network_interface_ids)
+}
+
+output "vpc_endpoint_s3_interface_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for S3 interface."
+  value       = flatten(aws_vpc_endpoint.s3_interface.*.dns_entry)
 }
 
 # VPC flow log

--- a/variables.tf
+++ b/variables.tf
@@ -347,30 +347,30 @@ variable "dynamodb_endpoint_policy" {
 }
 
 variable "enable_s3_endpoint" {
-  description = "Should be true if you want to provision an S3 endpoint to the VPC"
+  description = "Should be true if you want to provision an S3 gateway endpoint to the VPC"
   type        = bool
   default     = false
 }
 
-variable "s3_endpoint_type" {
-  description = "S3 VPC endpoint type. Note - S3 Interface type support is only available on AWS provider 3.10 and later"
-  type        = string
-  default     = "Gateway"
+variable "enable_s3_interface_endpoint" {
+  description = "Should be true if you want to provision an S3 interface endpoint to the VPC"
+  type        = bool
+  default     = false
 }
 
-variable "s3_endpoint_security_group_ids" {
+variable "s3_interface_endpoint_security_group_ids" {
   description = "The ID of one or more security groups to associate with the network interface for S3 interface endpoint"
   type        = list(string)
   default     = []
 }
 
-variable "s3_endpoint_subnet_ids" {
+variable "s3_interface_endpoint_subnet_ids" {
   description = "The ID of one or more subnets in which to create a network interface for S3 interface endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
   type        = list(string)
   default     = []
 }
 
-variable "s3_endpoint_private_dns_enabled" {
+variable "s3_interface_endpoint_private_dns_enabled" {
   description = "Whether or not to associate a private hosted zone with the specified VPC for S3 interface endpoint"
   type        = bool
   default     = false

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -1,6 +1,6 @@
-######################
-# VPC Endpoint for S3
-######################
+#####################################
+# VPC Endpoint for S3 - gateway type
+#####################################
 data "aws_vpc_endpoint_service" "s3" {
   count = var.create_vpc && var.enable_s3_endpoint ? 1 : 0
 
@@ -9,7 +9,7 @@ data "aws_vpc_endpoint_service" "s3" {
   # Used for backwards compatability where `service_type` is not yet available in the provider used
   filter {
     name   = "service-type"
-    values = [var.s3_endpoint_type]
+    values = ["Gateway"]
   }
 }
 
@@ -18,35 +18,61 @@ resource "aws_vpc_endpoint" "s3" {
 
   vpc_id            = local.vpc_id
   service_name      = data.aws_vpc_endpoint_service.s3[0].service_name
-  vpc_endpoint_type = var.s3_endpoint_type
+  vpc_endpoint_type = "Gateway"
 
-  security_group_ids  = var.s3_endpoint_type == "Interface" ? var.s3_endpoint_security_group_ids : null
-  subnet_ids          = var.s3_endpoint_type == "Interface" ? coalescelist(var.s3_endpoint_subnet_ids, aws_subnet.private.*.id) : null
-  policy              = var.s3_endpoint_policy
-  private_dns_enabled = var.s3_endpoint_type == "Interface" ? var.s3_endpoint_private_dns_enabled : null
+  policy = var.s3_endpoint_policy
 
   tags = local.vpce_tags
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count = var.create_vpc && var.enable_s3_endpoint && var.s3_endpoint_type == "Gateway" ? local.nat_gateway_count : 0
+  count = var.create_vpc && var.enable_s3_endpoint ? local.nat_gateway_count : 0
 
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = element(aws_route_table.private.*.id, count.index)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "intra_s3" {
-  count = var.create_vpc && var.enable_s3_endpoint && length(var.intra_subnets) > 0 && var.s3_endpoint_type == "Gateway" ? 1 : 0
+  count = var.create_vpc && var.enable_s3_endpoint && length(var.intra_subnets) > 0 ? 1 : 0
 
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = element(aws_route_table.intra.*.id, 0)
 }
 
 resource "aws_vpc_endpoint_route_table_association" "public_s3" {
-  count = var.create_vpc && var.enable_s3_endpoint && var.enable_public_s3_endpoint && length(var.public_subnets) > 0 && var.s3_endpoint_type == "Gateway" ? 1 : 0
+  count = var.create_vpc && var.enable_s3_endpoint && var.enable_public_s3_endpoint && length(var.public_subnets) > 0 ? 1 : 0
 
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
   route_table_id  = aws_route_table.public[0].id
+}
+
+#######################################
+# VPC Endpoint for S3 - interface type
+#######################################
+data "aws_vpc_endpoint_service" "s3_interface" {
+  count = var.create_vpc && vpc_enable_s3_interface_endpoint ? 1 : 0
+
+  service = "s3"
+
+  # Used for backwards compatability where `service_type` is not yet available in the provider used
+  filter {
+    name   = "service-type"
+    values = ["Interface"]
+  }
+}
+
+resource "aws_vpc_endpoint" "s3_interface" {
+  count = var.create_vpc && var.enable_s3_interface_endpoint ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  service_name      = data.aws_vpc_endpoint_service.s3_interface[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = var.s3_interface_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.s3_interface_endpoint_subnet_ids, aws_subnet.private.*.id)
+  private_dns_enabled = var.s3_interface_endpoint_private_dns_enabled
+
+  tags = local.vpce_tags
 }
 
 ############################


### PR DESCRIPTION
## Description
This makes the existing S3 endpoint parameters purely for the gateway type and adds new parameters for the S3 interface type. The existing parameters that don't make sense for a gateway endpoint are removed as well as the parameter for choosing the type.

The missing outputs are also added for parity with existing endpoints.

Based on the work in #575.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current module only allows either an interface or gateway endpoint however it's valid to have both types configured.

Fixes #603

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

Yes, sadly. It makes sense to keep the default endpoint type to be a gateway as that was first. Because new parameters are added explicitly for the new interface endpoint type, there are some parameters that now no longer make sense for gateway endpoint types (private DNS, subnet ID's, etc.). You could keep some of the current names however the parameter naming would be confusing and not follow the consistency and conventions of the other parameters in the module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I will update the tests shortly.
