### PR TITLE
chore: align ci-cd static checks to use individual minimum Terraform versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,14 +7,65 @@ on:
       - master
 
 jobs:
-  getBaseVersion:
-    name: Get min/max versions
-    runs-on: ubuntu-latest
+# Min Terraform version(s)
+  getDirectories:
+      name: Get root directories
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v2
+          - name: Install Python
+            uses: actions/setup-python@v2
+          - name: Build matrix
+            id: matrix
+            run: |
+              DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
+              echo "::set-output name=directories::$DIRS"
+      outputs:
+          directories: ${{ steps.matrix.outputs.directories }}
 
+  preCommitMinVersions:
+    name: Min TF validate
+    needs: getDirectories
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.0.1
+        with:
+          directory: ${{ matrix.directory }}
+      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ steps.minMax.outputs.minVersion }}
+      - name: Install pre-commit dependencies
+        run: pip install pre-commit
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory !=  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory ==  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
 
+
+# Max Terraform version
+  getBaseVersion:
+    name: Module max TF version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Terraform min/max versions
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.1
@@ -22,40 +73,29 @@ jobs:
       minVersion: ${{ steps.minMax.outputs.minVersion }}
       maxVersion: ${{ steps.minMax.outputs.maxVersion }}
 
-  preCommit:
-    name: Pre-commit check
+  preCommitMaxVersion:
+    name: Max TF pre-commit
     runs-on: ubuntu-latest
     needs: getBaseVersion
     strategy:
       fail-fast: false
       matrix:
         version:
-          - ${{ needs.getBaseVersion.outputs.minVersion }}
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Install Python
         uses: actions/setup-python@v2
-
       - name: Install Terraform v${{ matrix.version }}
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ matrix.version }}
-
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-
-      - name: Execute pre-commit
-        # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files terraform_validate
-
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.46.0
+    rev: v1.47.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.21 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.70 |
 | random | >= 2 |
 

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
- align ci-cd static checks to use individual minimum Terraform versions

## Motivation and Context
- ensure that the modules are all following a similar workflow and the static checks that performed

## Breaking Changes
- No

## How Has This Been Tested?
- ci-cd static checks