### PR TITLE
feat: Added optional association of S3 endpoint to DB subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ No Modules.
 | enable\_codedeploy\_endpoint | Should be true if you want to provision an CodeDeploy endpoint to the VPC | `bool` | `false` | no |
 | enable\_codepipeline\_endpoint | Should be true if you want to provision a CodePipeline endpoint to the VPC | `bool` | `false` | no |
 | enable\_config\_endpoint | Should be true if you want to provision an config endpoint to the VPC | `bool` | `false` | no |
+| enable\_database\_s3\_endpoint | Whether to enable S3 VPC Endpoint for database subnets | `bool` | `false` | no |
 | enable\_datasync\_endpoint | Should be true if you want to provision an Data Sync endpoint to the VPC | `bool` | `false` | no |
 | enable\_dhcp\_options | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | `bool` | `false` | no |
 | enable\_dms\_endpoint | Should be true if you want to provision a DMS endpoint to the VPC | `bool` | `false` | no |
@@ -531,7 +532,6 @@ No Modules.
 | enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
 | enable\_public\_redshift | Controls if redshift should have public routing table | `bool` | `false` | no |
 | enable\_public\_s3\_endpoint | Whether to enable S3 VPC Endpoint for public subnets | `bool` | `true` | no |
-| enable\_database\_s3\_endpoint | Whether to enable S3 VPC Endpoint for database subnets | `bool` | `false` | no |
 | enable\_qldb\_session\_endpoint | Should be true if you want to provision an QLDB Session endpoint to the VPC | `bool` | `false` | no |
 | enable\_rds\_endpoint | Should be true if you want to provision an RDS endpoint to the VPC | `bool` | `false` | no |
 | enable\_rekognition\_endpoint | Should be true if you want to provision a Rekognition endpoint to the VPC | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ No Modules.
 | enable\_nat\_gateway | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
 | enable\_public\_redshift | Controls if redshift should have public routing table | `bool` | `false` | no |
 | enable\_public\_s3\_endpoint | Whether to enable S3 VPC Endpoint for public subnets | `bool` | `true` | no |
+| enable\_database\_s3\_endpoint | Whether to enable S3 VPC Endpoint for database subnets | `bool` | `false` | no |
 | enable\_qldb\_session\_endpoint | Should be true if you want to provision an QLDB Session endpoint to the VPC | `bool` | `false` | no |
 | enable\_rds\_endpoint | Should be true if you want to provision an RDS endpoint to the VPC | `bool` | `false` | no |
 | enable\_rekognition\_endpoint | Should be true if you want to provision a Rekognition endpoint to the VPC | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -310,6 +310,12 @@ variable "enable_public_s3_endpoint" {
   type        = bool
 }
 
+variable "enable_database_s3_endpoint" {
+  description = "Whether to enable S3 VPC Endpoint for database subnets"
+  default     = false
+  type        = bool
+}
+
 variable "enable_dynamodb_endpoint" {
   description = "Should be true if you want to provision a DynamoDB endpoint to the VPC"
   type        = bool

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -50,10 +50,10 @@ resource "aws_vpc_endpoint_route_table_association" "public_s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "database_s3" {
-  count = var.create_vpc && var.enable_s3_endpoint && var.enable_database_s3_endpoint && length(var.database_subnets) > 0 && var.s3_endpoint_type == "Gateway" ? 1 : 0
+  count = var.create_vpc && var.enable_s3_endpoint && var.enable_database_s3_endpoint && length(var.database_subnets) > 0 && var.s3_endpoint_type == "Gateway" ? local.nat_gateway_count : 0
 
   vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
-  route_table_id  = aws_route_table.database[0].id
+  route_table_id  = element(aws_route_table.database.*.id, count.index)
 }
 
 ############################

--- a/vpc-endpoints.tf
+++ b/vpc-endpoints.tf
@@ -49,6 +49,13 @@ resource "aws_vpc_endpoint_route_table_association" "public_s3" {
   route_table_id  = aws_route_table.public[0].id
 }
 
+resource "aws_vpc_endpoint_route_table_association" "database_s3" {
+  count = var.create_vpc && var.enable_s3_endpoint && var.enable_database_s3_endpoint && length(var.database_subnets) > 0 && var.s3_endpoint_type == "Gateway" ? 1 : 0
+
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.database[0].id
+}
+
 ############################
 # VPC Endpoint for DynamoDB
 ############################


### PR DESCRIPTION
## Description
This PR adds optional S3 endpoint association with DB subnets route table.

## Motivation and Context
This would help to enable communication from RDS placed in database subnets to S3 via S3 endpoint.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

Tested by creating VPC and validating changes. 
