### PR TITLE
feat: Optionally create separate nat gateway subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,12 @@ No Modules.
 | monitoring\_endpoint\_subnet\_ids | The ID of one or more subnets in which to create a network interface for CloudWatch Monitoring endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used. | `list(string)` | `[]` | no |
 | name | Name to be used on all the resources as identifier | `string` | `""` | no |
 | nat\_eip\_tags | Additional tags for the NAT EIP | `map(string)` | `{}` | no |
+| nat\_gateway\_route\_table\_tags | Additional tags for the nat gateway route tables | `map(string)` | `{}` | no |
+| nat\_gateway\_subnet\_assign\_ipv6\_address\_on\_creation | Assign IPv6 address on nat\_gateway subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
+| nat\_gateway\_subnet\_ipv6\_prefixes | Assigns IPv6 nat\_gateway subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
+| nat\_gateway\_subnet\_suffix | Suffix to append to public subnets name | `string` | `"nat-gateway"` | no |
+| nat\_gateway\_subnet\_tags | Additional tags for the nat gateway subnets | `map(string)` | `{}` | no |
+| nat\_gateway\_subnets | A list of nat gateway subnets inside the VPC | `list(string)` | `[]` | no |
 | nat\_gateway\_tags | Additional tags for the NAT gateways | `map(string)` | `{}` | no |
 | one\_nat\_gateway\_per\_az | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | `bool` | `false` | no |
 | private\_acl\_tags | Additional tags for the private subnets network ACL | `map(string)` | `{}` | no |
@@ -799,6 +805,7 @@ No Modules.
 | intra\_subnets\_cidr\_blocks | List of cidr\_blocks of intra subnets |
 | intra\_subnets\_ipv6\_cidr\_blocks | List of IPv6 cidr\_blocks of intra subnets in an IPv6 enabled VPC |
 | name | The name of the VPC specified as argument to this module |
+| nat\_gateway\_route\_table\_ids | List of IDs of nat gateway route tables |
 | nat\_ids | List of allocation ID of Elastic IPs created for AWS NAT Gateway |
 | nat\_public\_ips | List of public Elastic IPs created for AWS NAT Gateway |
 | natgw\_ids | List of NAT Gateway IDs |

--- a/main.tf
+++ b/main.tf
@@ -1011,7 +1011,7 @@ resource "aws_subnet" "nat_gateway" {
   map_public_ip_on_launch         = var.map_public_ip_on_launch
   assign_ipv6_address_on_creation = var.nat_gateway_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.nat_gateway_subnet_assign_ipv6_address_on_creation
 
-  ipv6_cidr_block = var.enable_ipv6 && length(var.public_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.public_subnet_ipv6_prefixes[count.index]) : null
+  ipv6_cidr_block = var.enable_ipv6 && length(var.nat_gateway_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.nat_gateway_subnet_ipv6_prefixes[count.index]) : null
 
   tags = merge(
     {
@@ -1022,7 +1022,7 @@ resource "aws_subnet" "nat_gateway" {
       )
     },
     var.tags,
-    var.public_subnet_tags,
+    var.nat_gateway_subnet_tags,
   )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -243,6 +243,11 @@ output "intra_route_table_ids" {
   value       = aws_route_table.intra.*.id
 }
 
+output "nat_gateway_route_table_ids" {
+  description = "List of IDs of nat gateway route tables"
+  value       = aws_route_table.nat_gateway.*.id
+}
+
 output "public_internet_gateway_route_id" {
   description = "ID of the internet gateway route."
   value       = concat(aws_route.public_internet_gateway.*.id, [""])[0]

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "intra_subnet_ipv6_prefixes" {
   default     = []
 }
 
+variable "nat_gateway_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 nat_gateway subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
 variable "assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
@@ -96,6 +102,12 @@ variable "elasticache_subnet_assign_ipv6_address_on_creation" {
 
 variable "intra_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
+  type        = bool
+  default     = null
+}
+
+variable "nat_gateway_subnet_assign_ipv6_address_on_creation" {
+  description = "Assign IPv6 address on nat_gateway subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
   default     = null
 }
@@ -148,6 +160,12 @@ variable "elasticache_subnet_suffix" {
   default     = "elasticache"
 }
 
+variable "nat_gateway_subnet_suffix" {
+  description = "Suffix to append to public subnets name"
+  type        = string
+  default     = "nat-gateway"
+}
+
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
   type        = list(string)
@@ -180,6 +198,12 @@ variable "elasticache_subnets" {
 
 variable "intra_subnets" {
   description = "A list of intra subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "nat_gateway_subnets" {
+  description = "A list of nat gateway subnets inside the VPC"
   type        = list(string)
   default     = []
 }
@@ -2267,6 +2291,12 @@ variable "private_subnet_tags" {
   default     = {}
 }
 
+variable "nat_gateway_subnet_tags" {
+  description = "Additional tags for the nat gateway subnets"
+  type        = map(string)
+  default     = {}
+}
+
 variable "public_route_table_tags" {
   description = "Additional tags for the public route tables"
   type        = map(string)
@@ -2299,6 +2329,12 @@ variable "elasticache_route_table_tags" {
 
 variable "intra_route_table_tags" {
   description = "Additional tags for the intra route tables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "nat_gateway_route_table_tags" {
+  description = "Additional tags for the nat gateway route tables"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Description
If a list of NAT Gateway subnets is specified, generate the NAT Gateway(s) in those subnets.

## Motivation and Context
This enables architecture pieces, like a Network Firewall, to live in the public subnet: https://docs.aws.amazon.com/network-firewall/latest/developerguide/arch-igw-ngw.html

## Breaking Changes
This does not break backwards compatibility as the resources are gated behind a `length(var.nat_gateway_subnets) > 0` check, no existing variables are modified, and no existing outputs are modified.

## How Has This Been Tested?
It was tested with:
```
enable_nat_gateway     = true
one_nat_gateway_per_az = true
create_igw             = false
```

With and without a value for `nat_gateway_subnets`. And resources to add a network firewall to the public subnet.

It was also tested with:
```
enable_nat_gateway     = true
one_nat_gateway_per_az = true
create_igw             = true
```

With and without a value for `nat_gateway_subnets`.