### PR TITLE
feat: Add S3 endpoint dns_entry output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ No modules.
 | <a name="output_vpc_endpoint_rekognition_dns_entry"></a> [vpc\_endpoint\_rekognition\_dns\_entry](#output\_vpc\_endpoint\_rekognition\_dns\_entry) | The DNS entries for the VPC Endpoint for Rekognition. |
 | <a name="output_vpc_endpoint_rekognition_id"></a> [vpc\_endpoint\_rekognition\_id](#output\_vpc\_endpoint\_rekognition\_id) | The ID of VPC endpoint for Rekognition |
 | <a name="output_vpc_endpoint_rekognition_network_interface_ids"></a> [vpc\_endpoint\_rekognition\_network\_interface\_ids](#output\_vpc\_endpoint\_rekognition\_network\_interface\_ids) | One or more network interfaces for the VPC Endpoint for Rekognition. |
+| <a name="output_vpc_endpoint_s3_dns_entry"></a> [vpc\_endpoint\_s3\_dns\_entry](#output\_vpc\_endpoint\_s3\_dns\_entry) | The DNS entries for the VPC endpoint for S3. |
 | <a name="output_vpc_endpoint_s3_id"></a> [vpc\_endpoint\_s3\_id](#output\_vpc\_endpoint\_s3\_id) | The ID of VPC endpoint for S3 |
 | <a name="output_vpc_endpoint_s3_pl_id"></a> [vpc\_endpoint\_s3\_pl\_id](#output\_vpc\_endpoint\_s3\_pl\_id) | The prefix list for the S3 VPC endpoint. |
 | <a name="output_vpc_endpoint_sagemaker_api_dns_entry"></a> [vpc\_endpoint\_sagemaker\_api\_dns\_entry](#output\_vpc\_endpoint\_sagemaker\_api\_dns\_entry) | The DNS entries for the VPC Endpoint for SageMaker API. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -523,6 +523,11 @@ output "vpc_endpoint_s3_pl_id" {
   value       = concat(aws_vpc_endpoint.s3.*.prefix_list_id, [""])[0]
 }
 
+output "vpc_endpoint_s3_dns_entry" {
+  description = "The DNS entries for the VPC Endpoint for S3."
+  value       = flatten(aws_vpc_endpoint.s3.*.dns_entry)
+}
+
 output "vpc_endpoint_dynamodb_id" {
   description = "The ID of VPC endpoint for DynamoDB"
   value       = concat(aws_vpc_endpoint.dynamodb.*.id, [""])[0]


### PR DESCRIPTION
## Description
Add output for `dns_entry` of S3 endpoint.

## Motivation and Context
I was missing the output for my use case.

## Breaking Changes
I have not found anything broken. It is a simple addition in outputs, it **should** not break anything.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have tested the change against my own VPC. The output is correctly shown as shown below (details omitted), and I can use it in other resources in my Terragrunt code, as a dependency.

```
vpc_endpoint_s3_dns_entry = [
  {
    "dns_name" = "*.vpce-XXX-YYY.s3.eu-west-1.vpce.amazonaws.com"
    "hosted_zone_id" = "ZZZ"
  },
  {
    "dns_name" = "*.vpce-XXX-YYY-eu-west-1b.s3.eu-west-1.vpce.amazonaws.com"
    "hosted_zone_id" = "ZZZ"
  },
  {
    "dns_name" = "*.vpce-XXX-YYY-eu-west-1a.s3.eu-west-1.vpce.amazonaws.com"
    "hosted_zone_id" = "ZZZ"
  },
  {
    "dns_name" = "*.vpce-XXX-YYY-eu-west-1c.s3.eu-west-1.vpce.amazonaws.com"
    "hosted_zone_id" = "ZZZ"
  },
]
```

Thank you.
