### PR TITLE
fix: it is impossible to set private_dns_enabled as true for S3

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -17,7 +17,6 @@ module "endpoints" {
     s3 = {
       # interface endpoint
       service             = "s3"
-      private_dns_enabled = true
       tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {


### PR DESCRIPTION
## Description
- update README of sub-module `vpc-endpoints`.

## Motivation and Context
- `private_dns_enabled` cannot be specified for S3 endpoint.

## Breaking Changes
- no

## How Has This Been Tested?
- README change only.
