### PR TITLE
chore: Private DNS cannot be used with S3 endpoint

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -17,7 +17,6 @@ module "endpoints" {
     s3 = {
       # interface endpoint
       service             = "s3"
-      private_dns_enabled = true
       tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {


### PR DESCRIPTION
Private DNS is not a valid setting for the S3 interface endpoint.

## Description
Updating documentation.

## Motivation and Context
The documentation for this module is invalid.

## Breaking Changes
None

## How Has This Been Tested?
Have tried to run the code as provided in the documentation and it will not work.
