### PR TITLE
feat: Add support for EKS secondary cidr range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- feat: Add EKS secondary CIDR support ()[https://aws.amazon.com/about-aws/whats-new/2018/10/amazon-eks-now-supports-additional-vpc-cidr-blocks/]
+
 
 
 <a name="v3.1.0"></a>

--- a/examples/eks-secondary-cidr/README.md
+++ b/examples/eks-secondary-cidr/README.md
@@ -1,0 +1,58 @@
+# Simple VPC with secondary CIDR blocks for AWS EKS
+
+Configuration in this directory creates set of VPC resources across multiple CIDR blocks.
+
+There is a public and private subnet created per availability zone in addition to single NAT Gateway shared between all 3 availability zones.
+
+[Multiple CIDR Range for Amazon EKS](https://aws.amazon.com/premiumsupport/knowledge-center/eks-multiple-cidr-ranges/)
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
+| <a name="output_eks_secondary_cidr_subnets"></a> [eks_secondary_cidr\_subnets](#output\_eks_secondary_cidr\_subnets) | List of IDs of EKS secondary CIDR subnets |
+| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
+| <a name="output_vpc_secondary_cidr_blocks"></a> [vpc\_secondary\_cidr\_blocks](#output\_vpc\_secondary\_cidr\_blocks) | List of secondary CIDR blocks of the VPC |
+ <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/eks-secondary-cidr/main.tf
+++ b/examples/eks-secondary-cidr/main.tf
@@ -1,0 +1,51 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  region = "eu-west-1"
+}
+
+################################################################################
+# VPC Module
+################################################################################
+
+module "vpc" {
+  source = "../../"
+
+  name = "secondary-cidr-blocks-example"
+
+  cidr                  = "10.0.0.0/16"
+  secondary_cidr_blocks = ["100.64.0.0/16"]
+
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  eks_secondary_cidr_subnets = ["100.64.0.0/21", "100.64.8.0/21", "100.64.16.0/21"]
+
+  enable_ipv6 = true
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  public_subnet_tags = {
+    Name = "overridden-name-public"
+  }
+ 
+  private_subnet_tags = {
+    "kubernetes.io/cluster/yourClusterName" = "shared"
+  }
+
+  eks_secondary_cidr_subnet_tags = {
+    "kubernetes.io/cluster/yourClusterName" = "shared"
+  }
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+
+  vpc_tags = {
+    Name = "vpc-name"
+  }
+}

--- a/examples/eks-secondary-cidr/outputs.tf
+++ b/examples/eks-secondary-cidr/outputs.tf
@@ -1,0 +1,39 @@
+# VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+# CIDR blocks
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "vpc_secondary_cidr_blocks" {
+  description = "List of secondary CIDR blocks of the VPC"
+  value       = module.vpc.vpc_secondary_cidr_blocks
+}
+
+# Subnets
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "eks_secondary_cidr_subnets" {
+  description = "List of IDs of eks secondary cidr subnets"
+  value       = module.vpc.eks_secondary_cidr_subnets
+}
+
+# NAT gateways
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = module.vpc.nat_public_ips
+}
+

--- a/examples/eks-secondary-cidr/versions.tf
+++ b/examples/eks-secondary-cidr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.15"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,16 @@ output "private_subnet_arns" {
   value       = aws_subnet.private.*.arn
 }
 
+output "eks_secondary_cidr_subnets" {
+  description = "List of IDs of eks secondary cidr subnets"
+  value       = aws_subnet.eks_secondary_cidr.*.id
+}
+
+output "eks_secondary_cidr_subnet_arns" {
+  description = "List of ARNs of eks secondary cidr subnets"
+  value       = aws_subnet.eks_secondary_cidr.*.arn
+}
+
 output "private_subnets_cidr_blocks" {
   description = "List of cidr_blocks of private subnets"
   value       = aws_subnet.private.*.cidr_block
@@ -86,6 +96,11 @@ output "private_subnets_cidr_blocks" {
 output "private_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
   value       = aws_subnet.private.*.ipv6_cidr_block
+}
+
+output "eks_secondary_cidr_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of eks secondary cidr subnets"
+  value       = aws_subnet.eks_secondary_cidr.*.cidr_block
 }
 
 output "public_subnets" {
@@ -258,6 +273,11 @@ output "elasticache_route_table_ids" {
   value       = length(aws_route_table.elasticache.*.id) > 0 ? aws_route_table.elasticache.*.id : aws_route_table.private.*.id
 }
 
+output "eks_secondary_cidr_route_table_ids" {
+  description = "List of IDs of eks secondary cidr route tables"
+  value       = length(aws_route_table.eks_secondary_cidr.*.id) > 0 ? aws_route_table.eks_secondary_cidr.*.id : aws_route_table.private.*.id
+}
+
 output "intra_route_table_ids" {
   description = "List of IDs of intra route tables"
   value       = aws_route_table.intra.*.id
@@ -301,6 +321,11 @@ output "private_ipv6_egress_route_ids" {
 output "private_route_table_association_ids" {
   description = "List of IDs of the private route table association"
   value       = aws_route_table_association.private.*.id
+}
+
+output "eks_secondary_cidr_route_table_association_ids" {
+  description = "List of IDs of the eks secondary cidr route table association"
+  value       = aws_route_table_association.eks_secondary_cidr.*.id
 }
 
 output "database_route_table_association_ids" {
@@ -456,6 +481,16 @@ output "private_network_acl_id" {
 output "private_network_acl_arn" {
   description = "ARN of the private network ACL"
   value       = concat(aws_network_acl.private.*.arn, [""])[0]
+}
+
+output "eks_secondary_cidr_network_acl_id" {
+  description = "ID of the eks secondary cidr network ACL"
+  value       = concat(aws_network_acl.eks_secondary_cidr.*.id, [""])[0]
+}
+
+output "eks_secondary_cidr_network_acl_arn" {
+  description = "ARN of the eks secondary cidr network ACL"
+  value       = concat(aws_network_acl.eks_secondary_cidr.*.arn, [""])[0]
 }
 
 output "outpost_network_acl_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "private_subnet_suffix" {
   default     = "private"
 }
 
+variable "eks_secondary_cidr_subnet_suffix" {
+  description = "Suffix to append to eks secondary cidr subnets name"
+  type        = string
+  default     = "eks_secondary_cidr"
+}
+
 variable "outpost_subnet_suffix" {
   description = "Suffix to append to outpost subnets name"
   type        = string
@@ -178,6 +184,12 @@ variable "private_subnets" {
   default     = []
 }
 
+variable "eks_secondary_cidr_subnets" {
+  description = "A list of eks secondary cidr subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
 variable "outpost_subnets" {
   description = "A list of outpost subnets inside the VPC"
   type        = list(string)
@@ -216,6 +228,12 @@ variable "create_database_subnet_route_table" {
 
 variable "create_redshift_subnet_route_table" {
   description = "Controls if separate route table for redshift should be created"
+  type        = bool
+  default     = false
+}
+
+variable "create_eks_secondary_cidr_subnet_route_table" {
+  description = "Controls if separate route table for eks secondary cidr should be created"
   type        = bool
   default     = false
 }
@@ -436,6 +454,12 @@ variable "private_subnet_tags" {
   default     = {}
 }
 
+variable "eks_secondary_cidr_subnet_tags" {
+  description = "Additional tags for the eks secondary cidr subnets"
+  type        = map(string)
+  default     = {}
+}
+
 variable "outpost_subnet_tags" {
   description = "Additional tags for the outpost subnets"
   type        = map(string)
@@ -450,6 +474,12 @@ variable "public_route_table_tags" {
 
 variable "private_route_table_tags" {
   description = "Additional tags for the private route tables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "eks_secondary_cidr_route_table_tags" {
+  description = "Additional tags for the eks secondary cidr route tables"
   type        = map(string)
   default     = {}
 }
@@ -522,6 +552,12 @@ variable "public_acl_tags" {
 
 variable "private_acl_tags" {
   description = "Additional tags for the private subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+variable "eks_secondary_cidr_acl_tags" {
+  description = "Additional tags for the eks secondary cidr subnets network ACL"
   type        = map(string)
   default     = {}
 }
@@ -700,6 +736,12 @@ variable "private_dedicated_network_acl" {
   default     = false
 }
 
+variable "eks_secondary_cidr_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for eks secondary cidr subnets"
+  type        = bool
+  default     = false
+}
+
 variable "outpost_dedicated_network_acl" {
   description = "Whether to use dedicated network ACL (not default) and custom rules for outpost subnets"
   type        = bool
@@ -828,6 +870,38 @@ variable "private_inbound_acl_rules" {
 
 variable "private_outbound_acl_rules" {
   description = "Private subnets outbound network ACLs"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "eks_secondary_cidr_inbound_acl_rules" {
+  description = "EKS secondary cidr subnets inbound network ACLs"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "eks_secondary_cidr_outbound_acl_rules" {
+  description = "EKS secondary cidr subnets outbound network ACLs"
   type        = list(map(string))
 
   default = [


### PR DESCRIPTION
## Description
Adds capability to a another subnet with NAT GW that can be used by EKS worker nodes for its secondary IP addresses
(AWS)[https://aws.amazon.com/about-aws/whats-new/2018/10/amazon-eks-now-supports-additional-vpc-cidr-blocks/]  

## Motivation and Context
Provisioning EKS worker nodes on a /24 subnet will consume a lot of address space to address this AWS added support for secondary CIDR range for EKS. 


## Breaking Changes
No breaking change, this just add a new subnet resource named for EKS 

## How Has This Been Tested?
- I have tested and validated these changes using one or more of the provided `examples/eks-secondary-cidr` projects
- Using the example above I created a simple vpc first without the secondary cidr then added the secondary cidr range afterwards.

[eks_secondary_cidr_test.log](https://github.com/terraform-aws-modules/terraform-aws-vpc/files/6625004/eks_secondary_cidr_test.log)

