### PR TITLE
feat: Add support for Neptune cluster networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ No modules.
 | <a name="input_neptune_subnet_group_name"></a> [neptune\_subnet\_group\_name](#input\_neptune\_subnet\_group\_name) | Name of neptune subnet group | `string` | `null` | no |
 | <a name="input_neptune_subnet_group_tags"></a> [neptune\_subnet\_group\_tags](#input\_neptune\_subnet\_group\_tags) | Additional tags for the neptune subnet group | `map(string)` | `{}` | no |
 | <a name="input_neptune_subnet_ipv6_prefixes"></a> [neptune\_subnet\_ipv6\_prefixes](#input\_neptune\_subnet\_ipv6\_prefixes) | Assigns IPv6 neptune subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
-| <a name="input_neptune_subnet_suffix"></a> [neptune\_subnet\_suffix](#input\_neptune\_subnet\_suffix) | Suffix to append to neptune subnets name | `string` | `"db"` | no |
+| <a name="input_neptune_subnet_suffix"></a> [neptune\_subnet\_suffix](#input\_neptune\_subnet\_suffix) | Suffix to append to neptune subnets name | `string` | `"neptune"` | no |
 | <a name="input_neptune_subnet_tags"></a> [neptune\_subnet\_tags](#input\_neptune\_subnet\_tags) | Additional tags for the neptune subnets | `map(string)` | `{}` | no |
 | <a name="input_neptune_subnets"></a> [neptune\_subnets](#input\_neptune\_subnets) | A list of neptune subnets | `list(string)` | `[]` | no |
 | <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, the
 
 ### One NAT Gateway per subnet (default)
 
-By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway. For example, if your configuration looks like the following:
+By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `neptune_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway. For example, if your configuration looks like the following:
 
 ```hcl
 database_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
+neptune_subnets     = ["10.0.61.0/24", "10.0.62.0/24"]
 elasticache_subnets = ["10.0.31.0/24", "10.0.32.0/24"]
 private_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
 redshift_subnets    = ["10.0.41.0/24", "10.0.42.0/24"]
@@ -138,6 +139,14 @@ module "vpc" {
 }
 ```
 
+## Network Access Control Lists (ACL or NACL)
+
+This module can manage network ACL and rules. Once VPC is created, AWS creates the default network ACL, which can be controlled using this module (`manage_default_network_acl = true`).
+
+Also, each type of subnet may have its own network ACL with custom rules per subnet. Eg, set `public_dedicated_network_acl = true` to use dedicated network ACL for the public subnets; set values of `public_inbound_acl_rules` and `public_outbound_acl_rules` to specify all the NACL rules you need to have on public subnets (see `variables.tf` for default values and structures).
+
+By default, all subnets are associated with the default network ACL.
+
 ## Public access to RDS instances
 
 Sometimes it is handy to have public access to RDS instances (it is not recommended for production) by specifying these arguments:
@@ -151,13 +160,18 @@ Sometimes it is handy to have public access to RDS instances (it is not recommen
   enable_dns_support   = true
 ```
 
-## Network Access Control Lists (ACL or NACL)
+## Public access to Neptune cluster
 
-This module can manage network ACL and rules. Once VPC is created, AWS creates the default network ACL, which can be controlled using this module (`manage_default_network_acl = true`).
+Sometimes it is handy to have public access to Neptune clusters (it is not recommended for production) by specifying these arguments:
 
-Also, each type of subnet may have its own network ACL with custom rules per subnet. Eg, set `public_dedicated_network_acl = true` to use dedicated network ACL for the public subnets; set values of `public_inbound_acl_rules` and `public_outbound_acl_rules` to specify all the NACL rules you need to have on public subnets (see `variables.tf` for default values and structures).
+```hcl
+  create_neptune_subnet_group           = true
+  create_neptune_subnet_route_table     = true
+  create_neptune_internet_gateway_route = true
 
-By default, all subnets are associated with the default network ACL.
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+```
 
 ## Public access to Redshift cluster
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 
@@ -421,8 +421,8 @@ No modules.
 | <a name="input_nat_gateway_tags"></a> [nat\_gateway\_tags](#input\_nat\_gateway\_tags) | Additional tags for the NAT gateways | `map(string)` | `{}` | no |
 | <a name="input_neptune_acl_tags"></a> [neptune\_acl\_tags](#input\_neptune\_acl\_tags) | Additional tags for the neptune subnets network ACL | `map(string)` | `{}` | no |
 | <a name="input_neptune_dedicated_network_acl"></a> [neptune\_dedicated\_network\_acl](#input\_neptune\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for neptune subnets | `bool` | `false` | no |
-| <a name="input_neptune_inbound_acl_rules"></a> [neptune\_inbound\_acl\_rules](#input\_neptune\_inbound\_acl\_rules) | Database subnets inbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
-| <a name="input_neptune_outbound_acl_rules"></a> [neptune\_outbound\_acl\_rules](#input\_neptune\_outbound\_acl\_rules) | Database subnets outbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_neptune_inbound_acl_rules"></a> [neptune\_inbound\_acl\_rules](#input\_neptune\_inbound\_acl\_rules) | Neptune subnets inbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_neptune_outbound_acl_rules"></a> [neptune\_outbound\_acl\_rules](#input\_neptune\_outbound\_acl\_rules) | Neptune subnets outbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | <a name="input_neptune_route_table_tags"></a> [neptune\_route\_table\_tags](#input\_neptune\_route\_table\_tags) | Additional tags for the neptune route tables | `map(string)` | `{}` | no |
 | <a name="input_neptune_subnet_assign_ipv6_address_on_creation"></a> [neptune\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_neptune\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on neptune subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | <a name="input_neptune_subnet_group_name"></a> [neptune\_subnet\_group\_name](#input\_neptune\_subnet\_group\_name) | Name of neptune subnet group | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.49.0 |
 
 ## Modules
 
@@ -235,9 +235,11 @@ No modules.
 | [aws_iam_role_policy_attachment.vpc_flow_log_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_neptune_subnet_group.neptune](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/neptune_subnet_group) | resource |
 | [aws_network_acl.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
+| [aws_network_acl.neptune](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.outpost](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
@@ -248,6 +250,8 @@ No modules.
 | [aws_network_acl_rule.elasticache_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.intra_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.intra_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.neptune_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.neptune_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.outpost_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.outpost_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.private_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -260,6 +264,9 @@ No modules.
 | [aws_route.database_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.database_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.database_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.neptune_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.neptune_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.neptune_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -267,12 +274,14 @@ No modules.
 | [aws_route_table.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.neptune](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.neptune](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.outpost](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -281,6 +290,7 @@ No modules.
 | [aws_subnet.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.neptune](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.outpost](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -315,6 +325,10 @@ No modules.
 | <a name="input_create_flow_log_cloudwatch_iam_role"></a> [create\_flow\_log\_cloudwatch\_iam\_role](#input\_create\_flow\_log\_cloudwatch\_iam\_role) | Whether to create IAM role for VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_create_flow_log_cloudwatch_log_group"></a> [create\_flow\_log\_cloudwatch\_log\_group](#input\_create\_flow\_log\_cloudwatch\_log\_group) | Whether to create CloudWatch log group for VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_create_igw"></a> [create\_igw](#input\_create\_igw) | Controls if an Internet Gateway is created for public subnets and the related routes that connect them. | `bool` | `true` | no |
+| <a name="input_create_neptune_internet_gateway_route"></a> [create\_neptune\_internet\_gateway\_route](#input\_create\_neptune\_internet\_gateway\_route) | Controls if an internet gateway route for public neptune access should be created | `bool` | `false` | no |
+| <a name="input_create_neptune_nat_gateway_route"></a> [create\_neptune\_nat\_gateway\_route](#input\_create\_neptune\_nat\_gateway\_route) | Controls if a nat gateway route should be created to give internet access to the neptune subnets | `bool` | `false` | no |
+| <a name="input_create_neptune_subnet_group"></a> [create\_neptune\_subnet\_group](#input\_create\_neptune\_subnet\_group) | Controls if neptune subnet group should be created (n.b. neptune\_subnets must also be set) | `bool` | `true` | no |
+| <a name="input_create_neptune_subnet_route_table"></a> [create\_neptune\_subnet\_route\_table](#input\_create\_neptune\_subnet\_route\_table) | Controls if separate route table for neptune should be created | `bool` | `false` | no |
 | <a name="input_create_redshift_subnet_group"></a> [create\_redshift\_subnet\_group](#input\_create\_redshift\_subnet\_group) | Controls if redshift subnet group should be created | `bool` | `true` | no |
 | <a name="input_create_redshift_subnet_route_table"></a> [create\_redshift\_subnet\_route\_table](#input\_create\_redshift\_subnet\_route\_table) | Controls if separate route table for redshift should be created | `bool` | `false` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Controls if VPC should be created (it affects almost all resources) | `bool` | `true` | no |
@@ -405,6 +419,18 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
 | <a name="input_nat_eip_tags"></a> [nat\_eip\_tags](#input\_nat\_eip\_tags) | Additional tags for the NAT EIP | `map(string)` | `{}` | no |
 | <a name="input_nat_gateway_tags"></a> [nat\_gateway\_tags](#input\_nat\_gateway\_tags) | Additional tags for the NAT gateways | `map(string)` | `{}` | no |
+| <a name="input_neptune_acl_tags"></a> [neptune\_acl\_tags](#input\_neptune\_acl\_tags) | Additional tags for the neptune subnets network ACL | `map(string)` | `{}` | no |
+| <a name="input_neptune_dedicated_network_acl"></a> [neptune\_dedicated\_network\_acl](#input\_neptune\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for neptune subnets | `bool` | `false` | no |
+| <a name="input_neptune_inbound_acl_rules"></a> [neptune\_inbound\_acl\_rules](#input\_neptune\_inbound\_acl\_rules) | Database subnets inbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_neptune_outbound_acl_rules"></a> [neptune\_outbound\_acl\_rules](#input\_neptune\_outbound\_acl\_rules) | Database subnets outbound network ACL rules | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_neptune_route_table_tags"></a> [neptune\_route\_table\_tags](#input\_neptune\_route\_table\_tags) | Additional tags for the neptune route tables | `map(string)` | `{}` | no |
+| <a name="input_neptune_subnet_assign_ipv6_address_on_creation"></a> [neptune\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_neptune\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on neptune subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
+| <a name="input_neptune_subnet_group_name"></a> [neptune\_subnet\_group\_name](#input\_neptune\_subnet\_group\_name) | Name of neptune subnet group | `string` | `null` | no |
+| <a name="input_neptune_subnet_group_tags"></a> [neptune\_subnet\_group\_tags](#input\_neptune\_subnet\_group\_tags) | Additional tags for the neptune subnet group | `map(string)` | `{}` | no |
+| <a name="input_neptune_subnet_ipv6_prefixes"></a> [neptune\_subnet\_ipv6\_prefixes](#input\_neptune\_subnet\_ipv6\_prefixes) | Assigns IPv6 neptune subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
+| <a name="input_neptune_subnet_suffix"></a> [neptune\_subnet\_suffix](#input\_neptune\_subnet\_suffix) | Suffix to append to neptune subnets name | `string` | `"db"` | no |
+| <a name="input_neptune_subnet_tags"></a> [neptune\_subnet\_tags](#input\_neptune\_subnet\_tags) | Additional tags for the neptune subnets | `map(string)` | `{}` | no |
+| <a name="input_neptune_subnets"></a> [neptune\_subnets](#input\_neptune\_subnets) | A list of neptune subnets | `list(string)` | `[]` | no |
 | <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`. | `bool` | `false` | no |
 | <a name="input_outpost_acl_tags"></a> [outpost\_acl\_tags](#input\_outpost\_acl\_tags) | Additional tags for the outpost subnets network ACL | `map(string)` | `{}` | no |
 | <a name="input_outpost_arn"></a> [outpost\_arn](#input\_outpost\_arn) | ARN of Outpost you want to create a subnet in. | `string` | `null` | no |
@@ -521,6 +547,19 @@ No modules.
 | <a name="output_nat_ids"></a> [nat\_ids](#output\_nat\_ids) | List of allocation ID of Elastic IPs created for AWS NAT Gateway |
 | <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
 | <a name="output_natgw_ids"></a> [natgw\_ids](#output\_natgw\_ids) | List of NAT Gateway IDs |
+| <a name="output_neptune_internet_gateway_route_id"></a> [neptune\_internet\_gateway\_route\_id](#output\_neptune\_internet\_gateway\_route\_id) | ID of the neptune internet gateway route. |
+| <a name="output_neptune_ipv6_egress_route_id"></a> [neptune\_ipv6\_egress\_route\_id](#output\_neptune\_ipv6\_egress\_route\_id) | ID of the neptune IPv6 egress route. |
+| <a name="output_neptune_nat_gateway_route_ids"></a> [neptune\_nat\_gateway\_route\_ids](#output\_neptune\_nat\_gateway\_route\_ids) | List of IDs of the neptune nat gateway route. |
+| <a name="output_neptune_network_acl_arn"></a> [neptune\_network\_acl\_arn](#output\_neptune\_network\_acl\_arn) | ARN of the neptune network ACL |
+| <a name="output_neptune_network_acl_id"></a> [neptune\_network\_acl\_id](#output\_neptune\_network\_acl\_id) | ID of the neptune network ACL |
+| <a name="output_neptune_route_table_association_ids"></a> [neptune\_route\_table\_association\_ids](#output\_neptune\_route\_table\_association\_ids) | List of IDs of the neptune route table association |
+| <a name="output_neptune_route_table_ids"></a> [neptune\_route\_table\_ids](#output\_neptune\_route\_table\_ids) | List of IDs of neptune route tables |
+| <a name="output_neptune_subnet_arns"></a> [neptune\_subnet\_arns](#output\_neptune\_subnet\_arns) | List of ARNs of neptune subnets |
+| <a name="output_neptune_subnet_group"></a> [neptune\_subnet\_group](#output\_neptune\_subnet\_group) | ID of neptune subnet group |
+| <a name="output_neptune_subnet_group_name"></a> [neptune\_subnet\_group\_name](#output\_neptune\_subnet\_group\_name) | Name of neptune subnet group |
+| <a name="output_neptune_subnets"></a> [neptune\_subnets](#output\_neptune\_subnets) | List of IDs of neptune subnets |
+| <a name="output_neptune_subnets_cidr_blocks"></a> [neptune\_subnets\_cidr\_blocks](#output\_neptune\_subnets\_cidr\_blocks) | List of cidr\_blocks of neptune subnets |
+| <a name="output_neptune_subnets_ipv6_cidr_blocks"></a> [neptune\_subnets\_ipv6\_cidr\_blocks](#output\_neptune\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of neptune subnets in an IPv6 enabled VPC |
 | <a name="output_outpost_network_acl_arn"></a> [outpost\_network\_acl\_arn](#output\_outpost\_network\_acl\_arn) | ARN of the outpost network ACL |
 | <a name="output_outpost_network_acl_id"></a> [outpost\_network\_acl\_id](#output\_outpost\_network\_acl\_id) | ID of the outpost network ACL |
 | <a name="output_outpost_subnet_arns"></a> [outpost\_subnet\_arns](#output\_outpost\_subnet\_arns) | List of ARNs of outpost subnets |

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -2,7 +2,7 @@
 
 Configuration in this directory creates set of VPC resources which may be sufficient for staging or production environment (look into [simple-vpc](../simple-vpc) for more simplified setup).
 
-There are public, private, database, ElastiCache, intra (private w/o Internet access) subnets, and NAT Gateways created in each availability zone.
+There are public, private, database, ElastiCache, Neptune, intra (private w/o Internet access) subnets, and NAT Gateways created in each availability zone.
 
 ## Usage
 
@@ -28,15 +28,15 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.49.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
-| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ../../modules/vpc-endpoints |  |
-| <a name="module_vpc_endpoints_nocreate"></a> [vpc\_endpoints\_nocreate](#module\_vpc\_endpoints\_nocreate) | ../../modules/vpc-endpoints |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | ../../modules/vpc-endpoints | n/a |
+| <a name="module_vpc_endpoints_nocreate"></a> [vpc\_endpoints\_nocreate](#module\_vpc\_endpoints\_nocreate) | ../../modules/vpc-endpoints | n/a |
 
 ## Resources
 

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -28,7 +28,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 
@@ -60,6 +60,7 @@ No inputs.
 | <a name="output_elasticache_subnets"></a> [elasticache\_subnets](#output\_elasticache\_subnets) | List of IDs of elasticache subnets |
 | <a name="output_intra_subnets"></a> [intra\_subnets](#output\_intra\_subnets) | List of IDs of intra subnets |
 | <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
+| <a name="output_neptune_subnets"></a> [neptune\_subnets](#output\_neptune\_subnets) | List of IDs of neptune subnets |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
 | <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of redshift subnets |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -29,6 +29,7 @@ module "vpc" {
   elasticache_subnets = ["20.10.31.0/24", "20.10.32.0/24", "20.10.33.0/24"]
   redshift_subnets    = ["20.10.41.0/24", "20.10.42.0/24", "20.10.43.0/24"]
   intra_subnets       = ["20.10.51.0/24", "20.10.52.0/24", "20.10.53.0/24"]
+  neptune_subnets     = ["20.10.61.0/24", "20.10.62.0/24", "20.10.63.0/24"]
 
   create_database_subnet_group = false
 

--- a/examples/complete-vpc/outputs.tf
+++ b/examples/complete-vpc/outputs.tf
@@ -20,6 +20,11 @@ output "database_subnets" {
   value       = module.vpc.database_subnets
 }
 
+output "neptune_subnets" {
+  description = "List of IDs of neptune subnets"
+  value       = module.vpc.neptune_subnets
+}
+
 output "elasticache_subnets" {
   description = "List of IDs of elasticache subnets"
   value       = module.vpc.elasticache_subnets

--- a/examples/ipv6/README.md
+++ b/examples/ipv6/README.md
@@ -30,7 +30,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
 
 ## Resources
 

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -35,9 +35,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc_issue_108"></a> [vpc\_issue\_108](#module\_vpc\_issue\_108) | ../../ |  |
-| <a name="module_vpc_issue_44"></a> [vpc\_issue\_44](#module\_vpc\_issue\_44) | ../../ |  |
-| <a name="module_vpc_issue_46"></a> [vpc\_issue\_46](#module\_vpc\_issue\_46) | ../../ |  |
+| <a name="module_vpc_issue_108"></a> [vpc\_issue\_108](#module\_vpc\_issue\_108) | ../../ | n/a |
+| <a name="module_vpc_issue_44"></a> [vpc\_issue\_44](#module\_vpc\_issue\_44) | ../../ | n/a |
+| <a name="module_vpc_issue_46"></a> [vpc\_issue\_46](#module\_vpc\_issue\_46) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -32,7 +32,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -34,7 +34,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/outpost/README.md
+++ b/examples/outpost/README.md
@@ -30,7 +30,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 

--- a/examples/outpost/README.md
+++ b/examples/outpost/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -32,7 +32,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -36,7 +36,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -31,8 +31,8 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -39,9 +39,9 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 1.0 |
-| <a name="module_vpc_with_flow_logs_cloudwatch_logs"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs) | ../../ |  |
-| <a name="module_vpc_with_flow_logs_cloudwatch_logs_default"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs\_default](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs\_default) | ../../ |  |
-| <a name="module_vpc_with_flow_logs_s3_bucket"></a> [vpc\_with\_flow\_logs\_s3\_bucket](#module\_vpc\_with\_flow\_logs\_s3\_bucket) | ../../ |  |
+| <a name="module_vpc_with_flow_logs_cloudwatch_logs"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs) | ../../ | n/a |
+| <a name="module_vpc_with_flow_logs_cloudwatch_logs_default"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs\_default](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs\_default) | ../../ | n/a |
+| <a name="module_vpc_with_flow_logs_s3_bucket"></a> [vpc\_with\_flow\_logs\_s3\_bucket](#module\_vpc\_with\_flow\_logs\_s3\_bucket) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/vpc-separate-private-route-tables/README.md
+++ b/examples/vpc-separate-private-route-tables/README.md
@@ -32,7 +32,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -321,15 +321,15 @@ resource "aws_route_table" "neptune" {
   vpc_id = local.vpc_id
 
   tags = merge(
-  {
-    "Name" = var.single_nat_gateway || var.create_neptune_internet_gateway_route ? "${var.name}-${var.neptune_subnet_suffix}" : format(
-    "%s-${var.neptune_subnet_suffix}-%s",
-    var.name,
-    element(var.azs, count.index),
-    )
-  },
-  var.tags,
-  var.neptune_route_table_tags,
+    {
+      "Name" = var.single_nat_gateway || var.create_neptune_internet_gateway_route ? "${var.name}-${var.neptune_subnet_suffix}" : format(
+        "%s-${var.neptune_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.neptune_route_table_tags,
   )
 }
 
@@ -569,15 +569,15 @@ resource "aws_subnet" "neptune" {
   ipv6_cidr_block = var.enable_ipv6 && length(var.neptune_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.neptune_subnet_ipv6_prefixes[count.index]) : null
 
   tags = merge(
-  {
-    "Name" = format(
-    "%s-${var.neptune_subnet_suffix}-%s",
-    var.name,
-    element(var.azs, count.index),
-    )
-  },
-  var.tags,
-  var.neptune_subnet_tags,
+    {
+      "Name" = format(
+        "%s-${var.neptune_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.neptune_subnet_tags,
   )
 }
 
@@ -589,11 +589,11 @@ resource "aws_neptune_subnet_group" "neptune" {
   subnet_ids  = aws_subnet.neptune.*.id
 
   tags = merge(
-  {
-    "Name" = format("%s", lower(coalesce(var.neptune_subnet_group_name, var.name)))
-  },
-  var.tags,
-  var.neptune_subnet_group_tags,
+    {
+      "Name" = format("%s", lower(coalesce(var.neptune_subnet_group_name, var.name)))
+    },
+    var.tags,
+    var.neptune_subnet_group_tags,
   )
 }
 
@@ -1053,11 +1053,11 @@ resource "aws_network_acl" "neptune" {
   subnet_ids = aws_subnet.neptune.*.id
 
   tags = merge(
-  {
-    "Name" = format("%s-${var.neptune_subnet_suffix}", var.name)
-  },
-  var.tags,
-  var.neptune_acl_tags,
+    {
+      "Name" = format("%s-${var.neptune_subnet_suffix}", var.name)
+    },
+    var.tags,
+    var.neptune_acl_tags,
   )
 }
 
@@ -1324,8 +1324,8 @@ resource "aws_route_table_association" "neptune" {
 
   subnet_id = element(aws_subnet.neptune.*.id, count.index)
   route_table_id = element(
-  coalescelist(aws_route_table.neptune.*.id, aws_route_table.private.*.id),
-  var.create_neptune_subnet_route_table ? var.single_nat_gateway || var.create_neptune_internet_gateway_route ? 0 : count.index : count.index,
+    coalescelist(aws_route_table.neptune.*.id, aws_route_table.private.*.id),
+    var.create_neptune_subnet_route_table ? var.single_nat_gateway || var.create_neptune_internet_gateway_route ? 0 : count.index : count.index,
   )
 }
 

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -62,7 +62,7 @@ module "endpoints" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -158,6 +158,36 @@ output "database_subnet_group_name" {
   value       = concat(aws_db_subnet_group.database.*.name, [""])[0]
 }
 
+output "neptune_subnets" {
+  description = "List of IDs of neptune subnets"
+  value       = aws_subnet.neptune.*.id
+}
+
+output "neptune_subnet_arns" {
+  description = "List of ARNs of neptune subnets"
+  value       = aws_subnet.neptune.*.arn
+}
+
+output "neptune_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of neptune subnets"
+  value       = aws_subnet.neptune.*.cidr_block
+}
+
+output "neptune_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of neptune subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.neptune.*.ipv6_cidr_block
+}
+
+output "neptune_subnet_group" {
+  description = "ID of neptune subnet group"
+  value       = concat(aws_db_subnet_group.neptune.*.id, [""])[0]
+}
+
+output "neptune_subnet_group_name" {
+  description = "Name of neptune subnet group"
+  value       = concat(aws_db_subnet_group.neptune.*.name, [""])[0]
+}
+
 output "redshift_subnets" {
   description = "List of IDs of redshift subnets"
   value       = aws_subnet.redshift.*.id
@@ -248,6 +278,11 @@ output "database_route_table_ids" {
   value       = length(aws_route_table.database.*.id) > 0 ? aws_route_table.database.*.id : aws_route_table.private.*.id
 }
 
+output "neptune_route_table_ids" {
+  description = "List of IDs of neptune route tables"
+  value       = length(aws_route_table.neptune.*.id) > 0 ? aws_route_table.neptune.*.id : aws_route_table.private.*.id
+}
+
 output "redshift_route_table_ids" {
   description = "List of IDs of redshift route tables"
   value       = length(aws_route_table.redshift.*.id) > 0 ? aws_route_table.redshift.*.id : (var.enable_public_redshift ? aws_route_table.public.*.id : aws_route_table.private.*.id)
@@ -288,6 +323,21 @@ output "database_ipv6_egress_route_id" {
   value       = concat(aws_route.database_ipv6_egress.*.id, [""])[0]
 }
 
+output "neptune_internet_gateway_route_id" {
+  description = "ID of the neptune internet gateway route."
+  value       = concat(aws_route.neptune_internet_gateway.*.id, [""])[0]
+}
+
+output "neptune_nat_gateway_route_ids" {
+  description = "List of IDs of the neptune nat gateway route."
+  value       = aws_route.neptune_nat_gateway.*.id
+}
+
+output "neptune_ipv6_egress_route_id" {
+  description = "ID of the neptune IPv6 egress route."
+  value       = concat(aws_route.neptune_ipv6_egress.*.id, [""])[0]
+}
+
 output "private_nat_gateway_route_ids" {
   description = "List of IDs of the private nat gateway route."
   value       = aws_route.private_nat_gateway.*.id
@@ -306,6 +356,11 @@ output "private_route_table_association_ids" {
 output "database_route_table_association_ids" {
   description = "List of IDs of the database route table association"
   value       = aws_route_table_association.database.*.id
+}
+
+output "neptune_route_table_association_ids" {
+  description = "List of IDs of the neptune route table association"
+  value       = aws_route_table_association.neptune.*.id
 }
 
 output "redshift_route_table_association_ids" {
@@ -491,6 +546,16 @@ output "database_network_acl_id" {
 output "database_network_acl_arn" {
   description = "ARN of the database network ACL"
   value       = concat(aws_network_acl.database.*.arn, [""])[0]
+}
+
+output "neptune_network_acl_id" {
+  description = "ID of the neptune network ACL"
+  value       = concat(aws_network_acl.neptune.*.id, [""])[0]
+}
+
+output "neptune_network_acl_arn" {
+  description = "ARN of the neptune network ACL"
+  value       = concat(aws_network_acl.neptune.*.arn, [""])[0]
 }
 
 output "redshift_network_acl_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -180,12 +180,12 @@ output "neptune_subnets_ipv6_cidr_blocks" {
 
 output "neptune_subnet_group" {
   description = "ID of neptune subnet group"
-  value       = concat(aws_db_subnet_group.neptune.*.id, [""])[0]
+  value       = concat(aws_neptune_subnet_group.neptune.*.id, [""])[0]
 }
 
 output "neptune_subnet_group_name" {
   description = "Name of neptune subnet group"
-  value       = concat(aws_db_subnet_group.neptune.*.name, [""])[0]
+  value       = concat(aws_neptune_subnet_group.neptune.*.name, [""])[0]
 }
 
 output "redshift_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "database_subnet_ipv6_prefixes" {
   default     = []
 }
 
+variable "neptune_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 neptune subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
 variable "redshift_subnet_ipv6_prefixes" {
   description = "Assigns IPv6 redshift subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   type        = list(string)
@@ -90,6 +96,12 @@ variable "outpost_subnet_assign_ipv6_address_on_creation" {
 
 variable "database_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on database subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
+  type        = bool
+  default     = null
+}
+
+variable "neptune_subnet_assign_ipv6_address_on_creation" {
+  description = "Assign IPv6 address on neptune subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
   default     = null
 }
@@ -154,6 +166,12 @@ variable "database_subnet_suffix" {
   default     = "db"
 }
 
+variable "neptune_subnet_suffix" {
+  description = "Suffix to append to neptune subnets name"
+  type        = string
+  default     = "db"
+}
+
 variable "redshift_subnet_suffix" {
   description = "Suffix to append to redshift subnets name"
   type        = string
@@ -190,6 +208,12 @@ variable "database_subnets" {
   default     = []
 }
 
+variable "neptune_subnets" {
+  description = "A list of neptune subnets"
+  type        = list(string)
+  default     = []
+}
+
 variable "redshift_subnets" {
   description = "A list of redshift subnets"
   type        = list(string)
@@ -210,6 +234,12 @@ variable "intra_subnets" {
 
 variable "create_database_subnet_route_table" {
   description = "Controls if separate route table for database should be created"
+  type        = bool
+  default     = false
+}
+
+variable "create_neptune_subnet_route_table" {
+  description = "Controls if separate route table for neptune should be created"
   type        = bool
   default     = false
 }
@@ -238,6 +268,12 @@ variable "create_database_subnet_group" {
   default     = true
 }
 
+variable "create_neptune_subnet_group" {
+  description = "Controls if neptune subnet group should be created (n.b. neptune_subnets must also be set)"
+  type        = bool
+  default     = true
+}
+
 variable "create_elasticache_subnet_group" {
   description = "Controls if elasticache subnet group should be created"
   type        = bool
@@ -258,6 +294,18 @@ variable "create_database_internet_gateway_route" {
 
 variable "create_database_nat_gateway_route" {
   description = "Controls if a nat gateway route should be created to give internet access to the database subnets"
+  type        = bool
+  default     = false
+}
+
+variable "create_neptune_nat_gateway_route" {
+  description = "Controls if a nat gateway route should be created to give internet access to the neptune subnets"
+  type        = bool
+  default     = false
+}
+
+variable "create_neptune_internet_gateway_route" {
+  description = "Controls if an internet gateway route for public neptune access should be created"
   type        = bool
   default     = false
 }
@@ -460,6 +508,12 @@ variable "database_route_table_tags" {
   default     = {}
 }
 
+variable "neptune_route_table_tags" {
+  description = "Additional tags for the neptune route tables"
+  type        = map(string)
+  default     = {}
+}
+
 variable "redshift_route_table_tags" {
   description = "Additional tags for the redshift route tables"
   type        = map(string)
@@ -492,6 +546,24 @@ variable "database_subnet_tags" {
 
 variable "database_subnet_group_tags" {
   description = "Additional tags for the database subnet group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "neptune_subnet_group_name" {
+  description = "Name of neptune subnet group"
+  type        = string
+  default     = null
+}
+
+variable "neptune_subnet_tags" {
+  description = "Additional tags for the neptune subnets"
+  type        = map(string)
+  default     = {}
+}
+
+variable "neptune_subnet_group_tags" {
+  description = "Additional tags for the neptune subnet group"
   type        = map(string)
   default     = {}
 }
@@ -546,6 +618,12 @@ variable "intra_acl_tags" {
 
 variable "database_acl_tags" {
   description = "Additional tags for the database subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+variable "neptune_acl_tags" {
+  description = "Additional tags for the neptune subnets network ACL"
   type        = map(string)
   default     = {}
 }
@@ -720,6 +798,12 @@ variable "intra_dedicated_network_acl" {
 
 variable "database_dedicated_network_acl" {
   description = "Whether to use dedicated network ACL (not default) and custom rules for database subnets"
+  type        = bool
+  default     = false
+}
+
+variable "neptune_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for neptune subnets"
   type        = bool
   default     = false
 }
@@ -929,6 +1013,38 @@ variable "database_inbound_acl_rules" {
 }
 
 variable "database_outbound_acl_rules" {
+  description = "Database subnets outbound network ACL rules"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "neptune_inbound_acl_rules" {
+  description = "Database subnets inbound network ACL rules"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "neptune_outbound_acl_rules" {
   description = "Database subnets outbound network ACL rules"
   type        = list(map(string))
 

--- a/variables.tf
+++ b/variables.tf
@@ -169,7 +169,7 @@ variable "database_subnet_suffix" {
 variable "neptune_subnet_suffix" {
   description = "Suffix to append to neptune subnets name"
   type        = string
-  default     = "db"
+  default     = "neptune"
 }
 
 variable "redshift_subnet_suffix" {

--- a/variables.tf
+++ b/variables.tf
@@ -1029,7 +1029,7 @@ variable "database_outbound_acl_rules" {
 }
 
 variable "neptune_inbound_acl_rules" {
-  description = "Database subnets inbound network ACL rules"
+  description = "Neptune subnets inbound network ACL rules"
   type        = list(map(string))
 
   default = [
@@ -1045,7 +1045,7 @@ variable "neptune_inbound_acl_rules" {
 }
 
 variable "neptune_outbound_acl_rules" {
-  description = "Database subnets outbound network ACL rules"
+  description = "Neptune subnets outbound network ACL rules"
   type        = list(map(string))
 
   default = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adding support for Neptune cluster networking. Basically duplicating the existing support for RDS and adding it for Neptune.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Neptune is a relatively new AWS database offering. Without top-level support for Neptune networking in the VPC module, the alternative is re-using database (RDS) networking infrastructure. Which isn't a _problem_, but isn't necessarily ideal.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

I don't think any of these are breaking changes, just minor version changes since there are new properties being added. No existing properties are being changed.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->