### PR TITLE
fix: Fixed mistake in separate private route tables example

### DIFF
--- a/examples/vpc-separate-private-route-tables/README.md
+++ b/examples/vpc-separate-private-route-tables/README.md
@@ -51,6 +51,6 @@ No inputs.
 | <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
-| <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of elasticache subnets |
+| <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of redshift subnets |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpc-separate-private-route-tables/outputs.tf
+++ b/examples/vpc-separate-private-route-tables/outputs.tf
@@ -26,7 +26,7 @@ output "elasticache_subnets" {
 }
 
 output "redshift_subnets" {
-  description = "List of IDs of elasticache subnets"
+  description = "List of IDs of redshift subnets"
   value       = module.vpc.redshift_subnets
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix copy/paste mistake of the outputs in VPC with separate private route tables example
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This still working but maybe misleading 
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
I don't think any of these are breaking changes, just fix copy/paste mistake. No existing properties are being changed.
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
