### PR TITLE
feat: Added transit_gateway subnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ If both `single_nat_gateway` and `one_nat_gateway_per_az` are set to `true`, the
 
 ### One NAT Gateway per subnet (default)
 
-By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, and `redshift_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway. For example, if your configuration looks like the following:
+By default, the module will determine the number of NAT Gateways to create based on the the `max()` of the private subnet lists (`database_subnets`, `elasticache_subnets`, `private_subnets`, `redshift_subnets` and `transit_gateway_subnets`). The module **does not** take into account the number of `intra_subnets`, since the latter are designed to have no Internet access via NAT Gateway. For example, if your configuration looks like the following:
 
-```hcl
-database_subnets    = ["10.0.21.0/24", "10.0.22.0/24"]
-elasticache_subnets = ["10.0.31.0/24", "10.0.32.0/24"]
-private_subnets     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
-redshift_subnets    = ["10.0.41.0/24", "10.0.42.0/24"]
-intra_subnets       = ["10.0.51.0/24", "10.0.52.0/24", "10.0.53.0/24"]
+```hcl    
+database_subnets        = ["10.0.21.0/24", "10.0.22.0/24"]
+elasticache_subnets     = ["10.0.31.0/24", "10.0.32.0/24"]
+private_subnets         = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
+redshift_subnets        = ["10.0.41.0/24", "10.0.42.0/24"]
+intra_subnets           = ["10.0.51.0/24", "10.0.52.0/24", "10.0.53.0/24"]
+transit_gateway_subnets = ["10.0.0.0/28", "10.0.0.16/28", "10.0.0.32/28"]
+
 ```
 
 Then `5` NAT Gateways will be created since `5` private subnet CIDR blocks were specified.
@@ -115,6 +117,10 @@ If you need private subnets that should have no Internet routing (in the sense o
 Since AWS Lambda functions allocate Elastic Network Interfaces in proportion to the traffic received ([read more](https://docs.aws.amazon.com/lambda/latest/dg/vpc.html)), it can be useful to allocate a large private subnet for such allocations, while keeping the traffic they generate entirely internal to the VPC.
 
 You can add additional tags with `intra_subnet_tags` as with other subnet types.
+
+## "transit_gateway" subnets
+
+Transit gateway subnets behave as private subnets in all regards. However, following [AWS transit gateway design best practices](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-best-design-practices.html), they are kept separate so different policies can be added to them.
 
 ## VPC Flow Log
 
@@ -228,6 +234,7 @@ No modules.
 | [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
+| [aws_network_acl.transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl_rule.database_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.database_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.elasticache_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
@@ -242,6 +249,8 @@ No modules.
 | [aws_network_acl_rule.public_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.redshift_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.redshift_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.transit_gateway_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.transit_gateway_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_redshift_subnet_group.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_subnet_group) | resource |
 | [aws_route.database_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.database_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -250,12 +259,15 @@ No modules.
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.transit_gateway_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.transit_gateway_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
@@ -264,6 +276,7 @@ No modules.
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.redshift_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_subnet.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -271,6 +284,7 @@ No modules.
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
@@ -441,6 +455,16 @@ No modules.
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_acl_tags"></a> [transit\_gateway\_acl\_tags](#input\_transit\_gateway\_acl\_tags) | Additional tags for the elasticache transit gateway network ACL | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_dedicated_network_acl"></a> [transit\_gateway\_dedicated\_network\_acl](#input\_transit\_gateway\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for transit gateway subnets | `bool` | `false` | no |
+| <a name="input_transit_gateway_inbound_acl_rules"></a> [transit\_gateway\_inbound\_acl\_rules](#input\_transit\_gateway\_inbound\_acl\_rules) | Transit gateway subnets inbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_transit_gateway_outbound_acl_rules"></a> [transit\_gateway\_outbound\_acl\_rules](#input\_transit\_gateway\_outbound\_acl\_rules) | Transit gateway subnets outbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
+| <a name="input_transit_gateway_route_table_tags"></a> [transit\_gateway\_route\_table\_tags](#input\_transit\_gateway\_route\_table\_tags) | Additional tags for the transit gateway route tables | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_subnet_assign_ipv6_address_on_creation"></a> [transit\_gateway\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_transit\_gateway\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on transit gateway subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
+| <a name="input_transit_gateway_subnet_ipv6_prefixes"></a> [transit\_gateway\_subnet\_ipv6\_prefixes](#input\_transit\_gateway\_subnet\_ipv6\_prefixes) | Assigns IPv6 transit gateway subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
+| <a name="input_transit_gateway_subnet_suffix"></a> [transit\_gateway\_subnet\_suffix](#input\_transit\_gateway\_subnet\_suffix) | Suffix to append to transit gateway subnets name | `string` | `"transitgateway"` | no |
+| <a name="input_transit_gateway_subnet_tags"></a> [transit\_gateway\_subnet\_tags](#input\_transit\_gateway\_subnet\_tags) | Additional tags for the transit gateway subnets | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_subnets"></a> [transit\_gateway\_subnets](#input\_transit\_gateway\_subnets) | A list of transit gateway subnets | `list(string)` | `[]` | no |
 | <a name="input_vpc_flow_log_permissions_boundary"></a> [vpc\_flow\_log\_permissions\_boundary](#input\_vpc\_flow\_log\_permissions\_boundary) | The ARN of the Permissions Boundary for the VPC Flow Log IAM Role | `string` | `null` | no |
 | <a name="input_vpc_flow_log_tags"></a> [vpc\_flow\_log\_tags](#input\_vpc\_flow\_log\_tags) | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
 | <a name="input_vpc_tags"></a> [vpc\_tags](#input\_vpc\_tags) | Additional tags for the VPC | `map(string)` | `{}` | no |
@@ -543,6 +567,10 @@ No modules.
 | <a name="output_redshift_subnets_cidr_blocks"></a> [redshift\_subnets\_cidr\_blocks](#output\_redshift\_subnets\_cidr\_blocks) | List of cidr\_blocks of redshift subnets |
 | <a name="output_redshift_subnets_ipv6_cidr_blocks"></a> [redshift\_subnets\_ipv6\_cidr\_blocks](#output\_redshift\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of redshift subnets in an IPv6 enabled VPC |
 | <a name="output_this_customer_gateway"></a> [this\_customer\_gateway](#output\_this\_customer\_gateway) | Map of Customer Gateway attributes |
+| <a name="output_transit_gateway_subnet_arns"></a> [transit\_gateway\_subnet\_arns](#output\_transit\_gateway\_subnet\_arns) | List of ARNs of transit gateway subnets |
+| <a name="output_transit_gateway_subnets"></a> [transit\_gateway\_subnets](#output\_transit\_gateway\_subnets) | List of IDs of transit gateway subnets |
+| <a name="output_transit_gateway_subnets_cidr_blocks"></a> [transit\_gateway\_subnets\_cidr\_blocks](#output\_transit\_gateway\_subnets\_cidr\_blocks) | List of cidr\_blocks of transit gateway subnets |
+| <a name="output_transit_gateway_subnets_ipv6_cidr_blocks"></a> [transit\_gateway\_subnets\_ipv6\_cidr\_blocks](#output\_transit\_gateway\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of transit gateway subnets in an IPv6 enabled VPC |
 | <a name="output_vgw_arn"></a> [vgw\_arn](#output\_vgw\_arn) | The ARN of the VPN Gateway |
 | <a name="output_vgw_id"></a> [vgw\_id](#output\_vgw\_id) | The ID of the VPN Gateway |
 | <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | The ARN of the VPC |

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -22,13 +22,14 @@ module "vpc" {
   name = local.name
   cidr = "20.10.0.0/16" # 10.0.0.0/8 is reserved for EC2-Classic
 
-  azs                 = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  private_subnets     = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
-  public_subnets      = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
-  database_subnets    = ["20.10.21.0/24", "20.10.22.0/24", "20.10.23.0/24"]
-  elasticache_subnets = ["20.10.31.0/24", "20.10.32.0/24", "20.10.33.0/24"]
-  redshift_subnets    = ["20.10.41.0/24", "20.10.42.0/24", "20.10.43.0/24"]
-  intra_subnets       = ["20.10.51.0/24", "20.10.52.0/24", "20.10.53.0/24"]
+  azs                     = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  transit_gateway_subnets = ["20.10.0.0/28", "20.10.0.16/28", "20.10.0.32/28"]
+  private_subnets         = ["20.10.1.0/24", "20.10.2.0/24", "20.10.3.0/24"]
+  public_subnets          = ["20.10.11.0/24", "20.10.12.0/24", "20.10.13.0/24"]
+  database_subnets        = ["20.10.21.0/24", "20.10.22.0/24", "20.10.23.0/24"]
+  elasticache_subnets     = ["20.10.31.0/24", "20.10.32.0/24", "20.10.33.0/24"]
+  redshift_subnets        = ["20.10.41.0/24", "20.10.42.0/24", "20.10.43.0/24"]
+  intra_subnets           = ["20.10.51.0/24", "20.10.52.0/24", "20.10.53.0/24"]
 
   create_database_subnet_group = false
 

--- a/main.tf
+++ b/main.tf
@@ -365,6 +365,29 @@ resource "aws_route_table" "intra" {
 }
 
 ################################################################################
+# Transit Gateway routes
+# There are as many routing tables as the number of NAT gateways
+################################################################################
+
+resource "aws_route_table" "transit_gateway" {
+  count = var.create_vpc && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
+
+  vpc_id = local.vpc_id
+
+  tags = merge(
+    {
+      "Name" = var.single_nat_gateway ? "${var.name}-${var.transit_gateway_subnet_suffix}" : format(
+        "%s-${var.transit_gateway_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.transit_gateway_route_table_tags,
+  )
+}
+
+################################################################################
 # Public subnet
 ################################################################################
 
@@ -603,6 +626,34 @@ resource "aws_subnet" "intra" {
 }
 
 ################################################################################
+# Transit gateway subnet
+################################################################################
+
+resource "aws_subnet" "transit_gateway" {
+  count = var.create_vpc && length(var.transit_gateway_subnets) > 0 ? length(var.transit_gateway_subnets) : 0
+
+  vpc_id                          = local.vpc_id
+  cidr_block                      = var.transit_gateway_subnets[count.index]
+  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  assign_ipv6_address_on_creation = var.transit_gateway_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.transit_gateway_subnet_assign_ipv6_address_on_creation
+
+  ipv6_cidr_block = var.enable_ipv6 && length(var.transit_gateway_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.transit_gateway_subnet_ipv6_prefixes[count.index]) : null
+
+  tags = merge(
+    {
+      "Name" = format(
+        "%s-${var.transit_gateway_subnet_suffix}-%s",
+        var.name,
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.transit_gateway_subnet_tags,
+  )
+}
+
+################################################################################
 # Default Network ACLs
 ################################################################################
 
@@ -622,6 +673,7 @@ resource "aws_default_network_acl" "this" {
       aws_subnet.redshift.*.id,
       aws_subnet.elasticache.*.id,
       aws_subnet.outpost.*.id,
+      aws_subnet.transit_gateway.*.id,
     ])),
     compact(flatten([
       aws_network_acl.public.*.subnet_ids,
@@ -631,6 +683,7 @@ resource "aws_default_network_acl" "this" {
       aws_network_acl.redshift.*.subnet_ids,
       aws_network_acl.elasticache.*.subnet_ids,
       aws_network_acl.outpost.*.subnet_ids,
+      aws_network_acl.transit_gateway.*.subnet_ids,
     ]))
   )
 
@@ -1044,6 +1097,59 @@ resource "aws_network_acl_rule" "elasticache_outbound" {
 }
 
 ################################################################################
+# Transit gateway Network ACLs
+################################################################################
+
+resource "aws_network_acl" "transit_gateway" {
+  count = var.create_vpc && var.transit_gateway_dedicated_network_acl && length(var.transit_gateway_subnets) > 0 ? 1 : 0
+
+  vpc_id     = element(concat(aws_vpc.this.*.id, [""]), 0)
+  subnet_ids = aws_subnet.transit_gateway.*.id
+
+  tags = merge(
+    {
+      "Name" = format("%s-${var.transit_gateway_subnet_suffix}", var.name)
+    },
+    var.tags,
+    var.transit_gateway_acl_tags,
+  )
+}
+
+resource "aws_network_acl_rule" "transit_gateway_inbound" {
+  count = var.create_vpc && var.transit_gateway_dedicated_network_acl && length(var.transit_gateway_subnets) > 0 ? length(var.transit_gateway_inbound_acl_rules) : 0
+
+  network_acl_id = aws_network_acl.transit_gateway[0].id
+
+  egress          = false
+  rule_number     = var.transit_gateway_inbound_acl_rules[count.index]["rule_number"]
+  rule_action     = var.transit_gateway_inbound_acl_rules[count.index]["rule_action"]
+  from_port       = lookup(var.transit_gateway_inbound_acl_rules[count.index], "from_port", null)
+  to_port         = lookup(var.transit_gateway_inbound_acl_rules[count.index], "to_port", null)
+  icmp_code       = lookup(var.transit_gateway_inbound_acl_rules[count.index], "icmp_code", null)
+  icmp_type       = lookup(var.transit_gateway_inbound_acl_rules[count.index], "icmp_type", null)
+  protocol        = var.transit_gateway_inbound_acl_rules[count.index]["protocol"]
+  cidr_block      = lookup(var.transit_gateway_inbound_acl_rules[count.index], "cidr_block", null)
+  ipv6_cidr_block = lookup(var.transit_gateway_inbound_acl_rules[count.index], "ipv6_cidr_block", null)
+}
+
+resource "aws_network_acl_rule" "transit_gateway_outbound" {
+  count = var.create_vpc && var.transit_gateway_dedicated_network_acl && length(var.transit_gateway_subnets) > 0 ? length(var.transit_gateway_outbound_acl_rules) : 0
+
+  network_acl_id = aws_network_acl.transit_gateway[0].id
+
+  egress          = true
+  rule_number     = var.transit_gateway_outbound_acl_rules[count.index]["rule_number"]
+  rule_action     = var.transit_gateway_outbound_acl_rules[count.index]["rule_action"]
+  from_port       = lookup(var.transit_gateway_outbound_acl_rules[count.index], "from_port", null)
+  to_port         = lookup(var.transit_gateway_outbound_acl_rules[count.index], "to_port", null)
+  icmp_code       = lookup(var.transit_gateway_outbound_acl_rules[count.index], "icmp_code", null)
+  icmp_type       = lookup(var.transit_gateway_outbound_acl_rules[count.index], "icmp_type", null)
+  protocol        = var.transit_gateway_outbound_acl_rules[count.index]["protocol"]
+  cidr_block      = lookup(var.transit_gateway_outbound_acl_rules[count.index], "cidr_block", null)
+  ipv6_cidr_block = lookup(var.transit_gateway_outbound_acl_rules[count.index], "ipv6_cidr_block", null)
+}
+
+################################################################################
 # NAT Gateway
 ################################################################################
 
@@ -1127,6 +1233,26 @@ resource "aws_route" "private_ipv6_egress" {
   egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this.*.id, 0)
 }
 
+resource "aws_route" "transit_gateway_nat_gateway" {
+  count = var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
+
+  route_table_id         = element(aws_route_table.transit_gateway.*.id, count.index)
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = element(aws_nat_gateway.this.*.id, count.index)
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_route" "transit_gateway_ipv6_egress" {
+  count = var.create_vpc && var.create_egress_only_igw && var.enable_ipv6 ? length(var.transit_gateway_subnets) : 0
+
+  route_table_id              = element(aws_route_table.transit_gateway.*.id, count.index)
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = element(aws_egress_only_internet_gateway.this.*.id, 0)
+}
+
 ################################################################################
 # Route table association
 ################################################################################
@@ -1206,6 +1332,16 @@ resource "aws_route_table_association" "public" {
 
   subnet_id      = element(aws_subnet.public.*.id, count.index)
   route_table_id = aws_route_table.public[0].id
+}
+
+resource "aws_route_table_association" "transit_gateway" {
+  count = var.create_vpc && length(var.transit_gateway_subnets) > 0 ? length(var.transit_gateway_subnets) : 0
+
+  subnet_id = element(aws_subnet.transit_gateway.*.id, count.index)
+  route_table_id = element(
+    aws_route_table.transit_gateway.*.id,
+    var.single_nat_gateway ? 0 : count.index,
+  )
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -223,6 +223,26 @@ output "intra_subnets_ipv6_cidr_blocks" {
   value       = aws_subnet.intra.*.ipv6_cidr_block
 }
 
+output "transit_gateway_subnets" {
+  description = "List of IDs of transit gateway subnets"
+  value       = aws_subnet.transit_gateway.*.id
+}
+
+output "transit_gateway_subnet_arns" {
+  description = "List of ARNs of transit gateway subnets"
+  value       = aws_subnet.transit_gateway.*.arn
+}
+
+output "transit_gateway_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of transit gateway subnets"
+  value       = aws_subnet.transit_gateway.*.cidr_block
+}
+
+output "transit_gateway_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of transit gateway subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.transit_gateway.*.ipv6_cidr_block
+}
+
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
   value       = concat(aws_elasticache_subnet_group.elasticache.*.id, [""])[0]

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "elasticache_subnet_ipv6_prefixes" {
   default     = []
 }
 
+variable "transit_gateway_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 transit gateway subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
 variable "intra_subnet_ipv6_prefixes" {
   description = "Assigns IPv6 intra subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   type        = list(string)
@@ -108,6 +114,12 @@ variable "elasticache_subnet_assign_ipv6_address_on_creation" {
 
 variable "intra_subnet_assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
+  type        = bool
+  default     = null
+}
+
+variable "transit_gateway_subnet_assign_ipv6_address_on_creation" {
+  description = "Assign IPv6 address on transit gateway subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
   default     = null
 }
@@ -166,6 +178,12 @@ variable "elasticache_subnet_suffix" {
   default     = "elasticache"
 }
 
+variable "transit_gateway_subnet_suffix" {
+  description = "Suffix to append to transit gateway subnets name"
+  type        = string
+  default     = "transitgateway"
+}
+
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
   type        = list(string)
@@ -204,6 +222,12 @@ variable "elasticache_subnets" {
 
 variable "intra_subnets" {
   description = "A list of intra subnets"
+  type        = list(string)
+  default     = []
+}
+
+variable "transit_gateway_subnets" {
+  description = "A list of transit gateway subnets"
   type        = list(string)
   default     = []
 }
@@ -478,6 +502,12 @@ variable "intra_route_table_tags" {
   default     = {}
 }
 
+variable "transit_gateway_route_table_tags" {
+  description = "Additional tags for the transit gateway route tables"
+  type        = map(string)
+  default     = {}
+}
+
 variable "database_subnet_group_name" {
   description = "Name of database subnet group"
   type        = string
@@ -520,6 +550,12 @@ variable "intra_subnet_tags" {
   default     = {}
 }
 
+variable "transit_gateway_subnet_tags" {
+  description = "Additional tags for the transit gateway subnets"
+  type        = map(string)
+  default     = {}
+}
+
 variable "public_acl_tags" {
   description = "Additional tags for the public subnets network ACL"
   type        = map(string)
@@ -558,6 +594,12 @@ variable "redshift_acl_tags" {
 
 variable "elasticache_acl_tags" {
   description = "Additional tags for the elasticache subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+variable "transit_gateway_acl_tags" {
+  description = "Additional tags for the elasticache transit gateway network ACL"
   type        = map(string)
   default     = {}
 }
@@ -732,6 +774,12 @@ variable "redshift_dedicated_network_acl" {
 
 variable "elasticache_dedicated_network_acl" {
   description = "Whether to use dedicated network ACL (not default) and custom rules for elasticache subnets"
+  type        = bool
+  default     = false
+}
+
+variable "transit_gateway_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for transit gateway subnets"
   type        = bool
   default     = false
 }
@@ -994,6 +1042,38 @@ variable "elasticache_inbound_acl_rules" {
 
 variable "elasticache_outbound_acl_rules" {
   description = "Elasticache subnets outbound network ACL rules"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "transit_gateway_inbound_acl_rules" {
+  description = "Transit gateway subnets inbound network ACLs"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "transit_gateway_outbound_acl_rules" {
+  description = "Transit gateway subnets outbound network ACLs"
   type        = list(map(string))
 
   default = [


### PR DESCRIPTION
## Description
Allow transit gateway subnets to be created independently. 

## Motivation and Context
[AWS transit gateway best practices](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-best-design-practices.html) suggest that transit gateway attachments should have their own dedicated /28 subnet, so you can apply different policies on them.

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
Tested with `complete-vpc` example.
Additionally we use this module and we are creating transit gateway subnets using this code.