### PR TITLE
fix: Fixed SID for assume role policy for flow logs

### DIFF
--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -55,6 +55,8 @@ data "aws_iam_policy_document" "flow_log_cloudwatch_assume_role" {
   count = local.create_flow_log_cloudwatch_iam_role ? 1 : 0
 
   statement {
+    sid = "AWSVPCFlowLogsAssumeRole"
+
     principals {
       type        = "Service"
       identifiers = ["vpc-flow-logs.amazonaws.com"]


### PR DESCRIPTION
## Description
Many Cloudrail users are running into this:
```
Rule: Ensure IAM policies pass Access Analyzer policy validation without WARNING and SUGGESTION issues
 - 1 Resources Exposed:
-----------------------------------------------
   - Exposed Resource: [module.vpc.aws_iam_role.vpc_flow_log_cloudwatch[0]] (../../vpc-flow-logs.tf:44)
     Violating Resource: [module.vpc.aws_iam_role.vpc_flow_log_cloudwatch[0]]  (../../vpc-flow-logs.tf:44)

     Evidence:
         Line 5, Col 13:
             | Add a value to the empty string in the Sid element
             | See https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-suggestion-empty-sid-value
```

Simply because there's no SID in the assume policy and it violates AWS best practices.

## Motivation and Context
To avoid a Cloudrail violation for users of the vpc module.

## Breaking Changes
This updates the assume role policy. It doesn't break backwards compatibility but will introduce an update in user environments that have this module deployed.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.vpc.aws_iam_role.vpc_flow_log_cloudwatch[0] will be updated in-place
  ~ resource "aws_iam_role" "vpc_flow_log_cloudwatch" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Sid       = "" -> "AWSVPCFlowLogsAssumeRole"
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        id                    = "vpc-flow-log-role-20210729162754416900000002"
        name                  = "vpc-flow-log-role-20210729162754416900000002"
        tags                  = {
            "Environment" = "staging"
            "Name"        = "complete"
            "Owner"       = "user"
        }
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

## How Has This Been Tested?
I have tested it using the complete-vpc example. Started with planning and applying as the code is today (and checked that Cloudrail triggers the above violation on the plan). Then I fixed the code, planned again, verified with Cloudrail, and applied (to see the change doesn't break existing deployments).

