### PR TITLE
fix: remove incorrect logic from complete example

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -182,16 +182,8 @@ data "aws_security_group" "default" {
   vpc_id = module.vpc.vpc_id
 }
 
-# Data source used to avoid race condition
-data "aws_vpc_endpoint_service" "dynamodb" {
-  service = "dynamodb"
-
-  filter {
-    name   = "service-type"
-    values = ["Gateway"]
-  }
-}
-
+data "aws_caller_identity" "current" {}
+  
 data "aws_iam_policy_document" "dynamodb_endpoint_policy" {
   statement {
     effect    = "Deny"
@@ -205,9 +197,9 @@ data "aws_iam_policy_document" "dynamodb_endpoint_policy" {
 
     condition {
       test     = "StringNotEquals"
-      variable = "aws:sourceVpce"
+      variable = "aws:PrincipalAccount"
 
-      values = [data.aws_vpc_endpoint_service.dynamodb.id]
+      values = [data.aws_caller_identity.current.account_id]
     }
   }
 }
@@ -225,9 +217,9 @@ data "aws_iam_policy_document" "generic_endpoint_policy" {
 
     condition {
       test     = "StringNotEquals"
-      variable = "aws:sourceVpce"
+      variable = "aws:PrincipalAccount"
 
-      values = [data.aws_vpc_endpoint_service.dynamodb.id]
+      values = [data.aws_caller_identity.current.account_id]
     }
   }
 }


### PR DESCRIPTION
- Replace `aws:SourceVpce` conditions
- Remove `aws_vpc_endpoint_service` data objects

## Description
Fix Complete VPC example code by removing several incorrect examples.

## Motivation and Context
- Firstly, it makes no sense to use `aws:SourceVpce` in a VPC endpoint IAM policy; all traffic that the VPC endpoint will receive will always have its own id here. You can read more about this key [here](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-ddb.html) under the section titled "Use IAM policies to control access to DynamoDB", in which the document states (emphasis mine):

"You can create an IAM policy for your **IAM users, groups, or roles** to restrict access to DynamoDB tables from a specific VPC endpoint only. To do this, you can use the aws:sourceVpce condition key for the table resource in your IAM policy."

- Secondly, at some point there was a change from the data `aws_vpc_endpoint` to `aws_vpc_endpoint_service`. It's important to note this because previously the code used `data.aws_vpc_endpoint.dynamodb.id` which does exist and provides an id like `vpce-12345` but was later replaced by `data.aws_vpc_endpoint_service.dynamodb.id`. You can see [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) that `id` is not a valid attribute and the output of this data type was a numerical id like `1234` that seemed to have no bearing to vpc, vpc endpoint or any other active resource.

The changes I've made continue to provide a policy for an example case, but the example now provides a somewhat more sensible value. In the new example code, the deny rule is set to reject any users who are outside of the current account.

## Breaking Changes
This does not break any module code as it only affects an example

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I had to extensively debug why the example wasn't working and have cited all of my documentation.
