### PR TITLE
fix: Update the terraform to support new provider signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/complete-vpc/versions.tf
+++ b/examples/complete-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/ipv6/README.md
+++ b/examples/ipv6/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/ipv6/versions.tf
+++ b/examples/ipv6/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/issues/versions.tf
+++ b/examples/issues/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -21,7 +21,7 @@ Run `terraform destroy` when you don't need these resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/manage-default-vpc/versions.tf
+++ b/examples/manage-default-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/network-acls/versions.tf
+++ b/examples/network-acls/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/outpost/README.md
+++ b/examples/outpost/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/outpost/versions.tf
+++ b/examples/outpost/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/secondary-cidr-blocks/versions.tf
+++ b/examples/secondary-cidr-blocks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -25,7 +25,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/simple-vpc/versions.tf
+++ b/examples/simple-vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/examples/vpc-separate-private-route-tables/README.md
+++ b/examples/vpc-separate-private-route-tables/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/examples/vpc-separate-private-route-tables/versions.tf
+++ b/examples/vpc-separate-private-route-tables/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -55,7 +55,7 @@ module "endpoints" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers

--- a/modules/vpc-endpoints/versions.tf
+++ b/modules/vpc-endpoints/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
Fixes #679 

Updates the minimum terraform version to 0.12.31 to support the new HashiCorp Signatures

## Motivation and Context
Terraform versions before 0.12.31 only support the AWS Provider version up to 3.37.0 because the GPG key used to create the signatures was changed at this point.

## Breaking Changes
None. This change only increments the terraform version to the latest minor version of the same release version.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

- Verified that for each of the examples fails init when the module's aws provider version is set to 3.38 and the terraform version is 0.12.26
- Verified that it inits as expected when the terraform version is set to 0.12.31.
