### PR TITLE
feat: Added device_name to customer gateway object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ It is possible to integrate this VPC module with [terraform-aws-transit-gateway 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
 
 ## Modules
 

--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
 
 ## Modules
 

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -46,8 +46,9 @@ module "vpc" {
 
   customer_gateways = {
     IP1 = {
-      bgp_asn    = 65112
-      ip_address = "1.2.3.4"
+      bgp_asn     = 65112
+      ip_address  = "1.2.3.4"
+      device_name = "some_name"
     },
     IP2 = {
       bgp_asn    = 65112

--- a/examples/complete-vpc/versions.tf
+++ b/examples/complete-vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/ipv6/README.md
+++ b/examples/ipv6/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/ipv6/versions.tf
+++ b/examples/ipv6/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -25,7 +25,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/issues/versions.tf
+++ b/examples/issues/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/manage-default-vpc/versions.tf
+++ b/examples/manage-default-vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/network-acls/versions.tf
+++ b/examples/network-acls/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/outpost/README.md
+++ b/examples/outpost/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
 
 ## Modules
 

--- a/examples/outpost/versions.tf
+++ b/examples/outpost/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/secondary-cidr-blocks/versions.tf
+++ b/examples/secondary-cidr-blocks/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/simple-vpc/README.md
+++ b/examples/simple-vpc/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/simple-vpc/versions.tf
+++ b/examples/simple-vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
 
 ## Modules

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
 
     random = {

--- a/examples/vpc-separate-private-route-tables/README.md
+++ b/examples/vpc-separate-private-route-tables/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 

--- a/examples/vpc-separate-private-route-tables/versions.tf
+++ b/examples/vpc-separate-private-route-tables/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1215,9 +1215,10 @@ resource "aws_route_table_association" "public" {
 resource "aws_customer_gateway" "this" {
   for_each = var.customer_gateways
 
-  bgp_asn    = each.value["bgp_asn"]
-  ip_address = each.value["ip_address"]
-  type       = "ipsec.1"
+  bgp_asn     = each.value["bgp_asn"]
+  ip_address  = each.value["ip_address"]
+  device_name = lookup(each.value, "device_name", null)
+  type        = "ipsec.1"
 
   tags = merge(
     {

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -56,13 +56,13 @@ module "endpoints" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.28 |
 
 ## Modules
 

--- a/modules/vpc-endpoints/versions.tf
+++ b/modules/vpc-endpoints/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 3.28"
     }
   }
 }


### PR DESCRIPTION
## Description
Minimal change adding the `device_name` property into the `aws_customer_gateway` resource.

## Motivation and Context
I already had a Customer Gateway created, and when I imported the resource state into this module, terraform was trying to recreate the resource. Without this change, I  cannot use the module with pre-existent AWS customer gateway resources with the "device_name" set. 

## Breaking Changes
There are no break changes. 

## How Has This Been Tested?
I have two Gateway resources. One with the `device_name` property set, and the other don't set. 

```
    customer_gateways = {
      "cgw1"      = {
        bgp_asn     = 65000
        ip_address  = "1.2.3.4"
        device_name = "USG"
      },
      "cgw2" = {
        bgp_asn    = 65000
        ip_address = "5.6.7.8"
      },
    }
```

I tested both importing the resources and created the resources from scratch. 
