### PR TITLE
feat: default to AWS provided NTP

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -623,7 +623,7 @@ variable "dhcp_options_domain_name_servers" {
 }
 
 variable "dhcp_options_ntp_servers" {
-  description = "Specify a list of NTP servers for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
+  description = "Specify a list of NTP server addresses for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
   type        = list(string)
   default     = ["169.254.169.123"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -623,9 +623,9 @@ variable "dhcp_options_domain_name_servers" {
 }
 
 variable "dhcp_options_ntp_servers" {
-  description = "Specify a list of NTP servers for DHCP options set (requires enable_dhcp_options set to true)"
+  description = "Specify a list of NTP servers for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
   type        = list(string)
-  default     = []
+  default     = ["169.254.169.123"]
 }
 
 variable "dhcp_options_netbios_name_servers" {


### PR DESCRIPTION
## Description
DHCP option sets should default to AWS provided NTP servers

## Motivation and Context
Just as DHCP option sets default to `AmazonProvidedDNS`, they should also default to Amazon provided NTP, served by the [Amazon Time Sync Service](https://aws.amazon.com/blogs/mt/manage-amazon-ec2-instance-clock-accuracy-using-amazon-time-sync-service-and-amazon-cloudwatch-part-1/).
Since AWS inexplicably provides no analogous symbol `AmazonProvidedNTP`, we serve the link-local IPv4 address `169.254.169.123` for use by DHCP clients that don't configure it statically (e.g. recent AWS [Linux](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html) or [Windows](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/windows-set-time.html) AMIs).

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
```
$ git checkout use-amazon-time-sync-service
$ cd examples/simple-vpc
$ terraform -version
Terraform v1.0.4
on darwin_amd64
+ provider registry.terraform.io/hashicorp/aws v3.54.0
$ terraform -chdir=../.. init
(...)
$ terraform -chdir=../.. plan -var 'enable_dhcp_options=true' -var 'cidr=172.16.0.0/20'
provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Enter a value: us-west-2
(...)
 # aws_vpc_dhcp_options.this[0] will be created
  + resource "aws_vpc_dhcp_options" "this" {
      + arn                  = (known after apply)
      + domain_name_servers  = [
          + "AmazonProvidedDNS",
        ]
      + id                   = (known after apply)
      + netbios_name_servers = []
      + ntp_servers          = [
          + "169.254.169.123",
        ]
      + owner_id             = (known after apply)
      + tags                 = {
          + "Name" = ""
        }
      + tags_all             = {
          + "Name" = (known after apply)
        }
    }
(...)
$ 
```