### PR TITLE
feat: Added timeout block to aws_default_route_table resource

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,8 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.62"
-
+      version = ">= 3.63"
     }
   }
 }


### PR DESCRIPTION
## Description
Added timeout block to the `aws_default_route_table` vpc resource .

## Motivation and Context
Updates the TF VPC module with the latest  aws provider release enhancements.
[3.62.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3620-october-08-2021)

> resource/aws_default_route_table: Add custom timeouts block (#21161)

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

*Testing*

Tested the example/complete_vpc terraform template.
