### PR TITLE
fix: Enabled destination_options only for VPC Flow Logs on S3

### DIFF
--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -24,10 +24,14 @@ resource "aws_flow_log" "this" {
   vpc_id                   = local.vpc_id
   max_aggregation_interval = var.flow_log_max_aggregation_interval
 
-  destination_options {
-    file_format                = var.flow_log_file_format
-    hive_compatible_partitions = var.flow_log_hive_compatible_partitions
-    per_hour_partition         = var.flow_log_per_hour_partition
+  dynamic "destination_options" {
+    for_each = var.flow_log_destination_type == "s3" ? [true] : []
+
+    content {
+      file_format                = var.flow_log_file_format
+      hive_compatible_partitions = var.flow_log_hive_compatible_partitions
+      per_hour_partition         = var.flow_log_per_hour_partition
+    }
   }
 
   tags = merge(var.tags, var.vpc_flow_log_tags)


### PR DESCRIPTION
## Description
Enclosed `destination_options` block in `aws_flow_log` resource inside
"conditional" dynamic block since it is needed only for `s3` destination type

## Motivation and Context
`destination_options` block is unnecessary for `cloud-watch-logs` destination type. I received `InvalidParameter` error while running it with `cloud-watch-logs` type. Full description of the issue is included in #702 

- Closes #702 

## Breaking Changes
No

## How Has This Been Tested?
Tested on the project, where we use VPC module. Also tried to create a log in `s3` as well.
