### PR TITLE
feature: add public database subnet group

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ Sometimes it is handy to have public access to RDS instances (it is not recommen
   enable_dns_support   = true
 ```
 
+Alternatively, rather than creating an internet gateway to the entire database subnets, the following can be set:
+
+```hcl
+create_database_public_subnet_group = true
+```
+
+Setting this value to `true` will create a database subnet group within the public subnets. Any database created in this subnet group will have public access  (in most cases, this is not recommended).
+
+
 ## Network Access Control Lists (ACL or NACL)
 
 This module can manage network ACL and rules. Once VPC is created, AWS creates the default network ACL, which can be controlled using this module (`manage_default_network_acl = true`).

--- a/main.tf
+++ b/main.tf
@@ -499,6 +499,22 @@ resource "aws_db_subnet_group" "database" {
   )
 }
 
+resource "aws_db_subnet_group" "database_public" {
+  count = var.create_vpc && length(var.public_subnets) > 0 && var.create_database_public_subnet_group ? 1 : 0
+
+  name        = lower(coalesce(var.database_public_subnet_group_name, "${var.name}-public"))
+  description = "Database public subnet group for ${var.name}"
+  subnet_ids  = aws_subnet.public.*.id
+
+  tags = merge(
+    {
+      "Name" = format("%s", lower(coalesce(var.database_public_subnet_group_name, "${var.name}-public")))
+    },
+    var.tags,
+    var.database_public_subnet_group_tags,
+  )
+}
+
 ################################################################################
 # Redshift subnet
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -238,6 +238,12 @@ variable "create_database_subnet_group" {
   default     = true
 }
 
+variable "create_database_public_subnet_group" {
+  description = "Controls if database public subnet group should be created (n.b. public_subnets must also be set). This will allow databases to be created for public access."
+  type        = bool
+  default     = false
+}
+
 variable "create_elasticache_subnet_group" {
   description = "Controls if elasticache subnet group should be created"
   type        = bool
@@ -484,6 +490,12 @@ variable "database_subnet_group_name" {
   default     = null
 }
 
+variable "database_public_subnet_group_name" {
+  description = "Name of database public subnet group"
+  type        = string
+  default     = null
+}
+
 variable "database_subnet_tags" {
   description = "Additional tags for the database subnets"
   type        = map(string)
@@ -492,6 +504,12 @@ variable "database_subnet_tags" {
 
 variable "database_subnet_group_tags" {
   description = "Additional tags for the database subnet group"
+  type        = map(string)
+  default     = {}
+}
+
+variable "database_public_subnet_group_tags" {
+  description = "Additional tags for the database public subnet group"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Rather than adding an internet gateway and route table to the private database subnets, this will create a public subnet database group. This way, private databases can still be created in the database subnet. If there's a need for a public database, it can be created in the public DB subnet group, which will put in the public subnets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows the databse subnet to still be kept private without public ingress, while also allowing the creation of public databases if the need arises.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes, instead a couple new variables are added to create a new resource: `aws_db_subnet_group.database_public[0]` if `create_database_public_subnet_group` is set to `true`.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with `examples/complete-vpc` by added `create_database_public_subnet_group = true` to the module. As expected, the additional resource was created.

Truncated output from `terraform plan` when `create_database_public_subnet_group = true`:
```hcl
 # aws_db_subnet_group.database_public[0] will be created
  + resource "aws_db_subnet_group" "database_public" {
      + arn         = (known after apply)
      + description = "Database public subnet group for test-vpc"
      + id          = (known after apply)
      + name        = "test-vpc-public"
      + name_prefix = (known after apply)
      + subnet_ids  = [
          + "subnet-publicsubnet-1",
          + "subnet-publicsubnet-2",
          + "subnet-publicsubnet-3",
        ]
      + tags        = {
          + "Name"    = "test-vpc-public"
          + "Service" = "test VPC"
        }
      + tags_all    = {
          + "Name"          = "test-vpc-public"
          + "Role"          = "Dev"
          + "Service"       = "test VPC"
        }
    }
```

I have also tested with an existing VPC where a db public subnet group exists. I was able to import that subnet group into the state file and run Terraform against that resource.