### PR TITLE
docs: Add minimal example for S3 Gateway VPC Endpoint

### DIFF
--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -44,6 +44,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 |------|------|
 | [aws_iam_policy_document.dynamodb_endpoint_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.generic_endpoint_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_endpoint_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_vpc_endpoint_service.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 


### PR DESCRIPTION
## Description
This PR adds a minimal but complete example for an S3 Gateway VPC Endpoint. I would've loved to add a more complex example (ECR + S3), but the example was getting overwhelming.

## Motivation and Context
This PR is motivated by 2 reasons:
- the previous S3 example did not create a (free) Gateway Endpoint, which led to an embarrassing NAT Gateway bill for me
- it took me longer than I would've liked to figure out how to use the resulting VPC Endpoints

## Breaking Changes
N/A

## How Has This Been Tested?
I ran a `terraform fmt` and `terraform validate` on the `examples/complete-vpc` code. The VPC Endpoint definition was copied from a private project where everything seems to be working fine.
