### PR TITLE
fix: Addresses persistent diff with manage_default_network_acl

### DIFF
--- a/examples/complete-vpc/README.md
+++ b/examples/complete-vpc/README.md
@@ -46,7 +46,6 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | [aws_iam_policy_document.dynamodb_endpoint_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.generic_endpoint_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_vpc_endpoint.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint) | data source |
 
 ## Inputs
 

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -208,7 +208,7 @@ data "aws_iam_policy_document" "dynamodb_endpoint_policy" {
       test     = "StringNotEquals"
       variable = "aws:sourceVpce"
 
-      values = [data.vpc.vpc_id]
+      values = [module.vpc.vpc_id]
     }
   }
 }

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -187,12 +187,6 @@ data "aws_security_group" "default" {
   vpc_id = module.vpc.vpc_id
 }
 
-# Data source used to avoid race condition
-data "aws_vpc_endpoint" "dynamodb" {
-  vpc_id       = module.vpc.vpc_id
-  service_name = "com.amazonaws.${local.region}.dynamodb"
-}
-
 data "aws_iam_policy_document" "dynamodb_endpoint_policy" {
   statement {
     effect    = "Deny"

--- a/main.tf
+++ b/main.tf
@@ -587,28 +587,9 @@ resource "aws_default_network_acl" "this" {
 
   default_network_acl_id = aws_vpc.this[0].default_network_acl_id
 
-  # The value of subnet_ids should be any subnet IDs that are not set as subnet_ids
-  #   for any of the non-default network ACLs
-  subnet_ids = setsubtract(
-    compact(flatten([
-      aws_subnet.public[*].id,
-      aws_subnet.private[*].id,
-      aws_subnet.intra[*].id,
-      aws_subnet.database[*].id,
-      aws_subnet.redshift[*].id,
-      aws_subnet.elasticache[*].id,
-      aws_subnet.outpost[*].id,
-    ])),
-    compact(flatten([
-      aws_network_acl.public[*].subnet_ids,
-      aws_network_acl.private[*].subnet_ids,
-      aws_network_acl.intra[*].subnet_ids,
-      aws_network_acl.database[*].subnet_ids,
-      aws_network_acl.redshift[*].subnet_ids,
-      aws_network_acl.elasticache[*].subnet_ids,
-      aws_network_acl.outpost[*].subnet_ids,
-    ]))
-  )
+  # subnet_ids is using lifecycle ignore_changes, so it is not necessary to list
+  # any explicitly. See https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/736.
+  subnet_ids = null
 
   dynamic "ingress" {
     for_each = var.default_network_acl_ingress
@@ -644,6 +625,10 @@ resource "aws_default_network_acl" "this" {
     var.tags,
     var.default_network_acl_tags,
   )
+
+  lifecycle {
+    ignore_changes = [subnet_ids]
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
As noted in the [terraform docs][0], subnets using the default network acl
will generate a persistent diff if they are not specified to the aws_default_network_acl
resource. This module was handling subnets created by the module, but
of course is not aware of subnets created externally to the module.

The docs suggest using lifecycle ignore_changes as an option to avoid
the persistent diff, which is the approach implemented in this patch.

Fixes #736

[0]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl#managing-subnets-in-a-default-network-acl

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. cd examples/network-acls
2. run terraform apply
3. manually create a new subnet in the vpc
4. run terraform apply
5. view that no changes are planned
