### PR TITLE
feat: Dedicated subnets for Transit Gateway Attachement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
     length(var.elasticache_subnets),
     length(var.database_subnets),
     length(var.redshift_subnets),
+    length(var.tgwattach_subnets),
   )
   nat_gateway_count = var.single_nat_gateway ? 1 : var.one_nat_gateway_per_az ? length(var.azs) : local.max_subnet_length
 
@@ -344,6 +345,63 @@ resource "aws_route_table" "intra" {
 }
 
 ################################################################################
+# Transit Gateway Attachement routes
+################################################################################
+
+resource "aws_route_table" "tgwattach" {
+  count = var.create_vpc && var.create_tgwattach_subnet_route_table && length(var.tgwattach_subnets) > 0 ? var.single_nat_gateway || var.create_tgwattach_internet_gateway_route ? 1 : length(var.tgwattach_subnets) : 0
+
+  vpc_id = local.vpc_id
+
+  tags = merge(
+    {
+      "Name" = var.single_nat_gateway || var.create_tgwattach_internet_gateway_route ? "${var.name}-${var.tgwattach_subnet_suffix}" : format(
+        "${var.name}-${var.tgwattach_subnet_suffix}-%s",
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.tgwattach_route_table_tags,
+  )
+}
+
+resource "aws_route" "tgwattach_internet_gateway" {
+  count = var.create_vpc && var.create_igw && var.create_tgwattach_subnet_route_table && length(var.tgwattach_subnets) > 0 && var.create_tgwattach_internet_gateway_route && false == var.create_tgwattach_nat_gateway_route ? 1 : 0
+
+  route_table_id         = aws_route_table.database[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this[0].id
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_route" "tgwattach_nat_gateway" {
+  count = var.create_vpc && var.create_tgwattach_subnet_route_table && length(var.tgwattach_subnets) > 0 && false == var.create_tgwattach_internet_gateway_route && var.create_tgwattach_nat_gateway_route && var.enable_nat_gateway ? var.single_nat_gateway ? 1 : length(var.tgwattach_subnets) : 0
+
+  route_table_id         = element(aws_route_table.tgwattach[*].id, count.index)
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = element(aws_nat_gateway.this[*].id, count.index)
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_route" "tgwattach_ipv6_egress" {
+  count = var.create_vpc && var.create_egress_only_igw && var.enable_ipv6 && var.create_tgwattach_subnet_route_table && length(var.tgwattach_subnets) > 0 && var.create_tgwattach_internet_gateway_route ? 1 : 0
+
+  route_table_id              = aws_route_table.tgwattach[0].id
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.this[0].id
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+################################################################################
 # Public subnet
 ################################################################################
 
@@ -578,6 +636,33 @@ resource "aws_subnet" "intra" {
   )
 }
 
+######################################################################################
+# Transit Gateway Attachement subnets - private subnet for Transit Gateway Attachement
+######################################################################################
+
+resource "aws_subnet" "tgwattach" {
+  count = var.create_vpc && length(var.tgwattach_subnets) > 0 ? length(var.tgwattach_subnets) : 0
+
+  vpc_id                          = local.vpc_id
+  cidr_block                      = var.tgwattach_subnets[count.index]
+  availability_zone               = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+  availability_zone_id            = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  assign_ipv6_address_on_creation = var.tgwattach_subnet_assign_ipv6_address_on_creation == null ? var.assign_ipv6_address_on_creation : var.tgwattach_subnet_assign_ipv6_address_on_creation
+
+  ipv6_cidr_block = var.enable_ipv6 && length(var.tgwattach_subnet_ipv6_prefixes) > 0 ? cidrsubnet(aws_vpc.this[0].ipv6_cidr_block, 8, var.intra_subnet_ipv6_prefixes[count.index]) : null
+
+  tags = merge(
+    {
+      "Name" = format(
+        "${var.name}-${var.tgwattach_subnet_suffix}-%s",
+        element(var.azs, count.index),
+      )
+    },
+    var.tags,
+    var.tgwattach_subnet_tags,
+  )
+}
+
 ################################################################################
 # Default Network ACLs
 ################################################################################
@@ -594,6 +679,7 @@ resource "aws_default_network_acl" "this" {
       aws_subnet.public[*].id,
       aws_subnet.private[*].id,
       aws_subnet.intra[*].id,
+      aws_subnet.tgwattach[*].id,
       aws_subnet.database[*].id,
       aws_subnet.redshift[*].id,
       aws_subnet.elasticache[*].id,
@@ -603,6 +689,7 @@ resource "aws_default_network_acl" "this" {
       aws_network_acl.public[*].subnet_ids,
       aws_network_acl.private[*].subnet_ids,
       aws_network_acl.intra[*].subnet_ids,
+      aws_network_acl.tgwattach[*].subnet_ids,
       aws_network_acl.database[*].subnet_ids,
       aws_network_acl.redshift[*].subnet_ids,
       aws_network_acl.elasticache[*].subnet_ids,
@@ -848,6 +935,57 @@ resource "aws_network_acl_rule" "intra_outbound" {
   protocol        = var.intra_outbound_acl_rules[count.index]["protocol"]
   cidr_block      = lookup(var.intra_outbound_acl_rules[count.index], "cidr_block", null)
   ipv6_cidr_block = lookup(var.intra_outbound_acl_rules[count.index], "ipv6_cidr_block", null)
+}
+
+################################################################################
+# Transit Gateway Attachement Network ACLs
+################################################################################
+
+resource "aws_network_acl" "tgwattach" {
+  count = var.create_vpc && var.tgwattach_dedicated_network_acl && length(var.tgwattach_subnets) > 0 ? 1 : 0
+
+  vpc_id     = local.vpc_id
+  subnet_ids = aws_subnet.tgwattach[*].id
+
+  tags = merge(
+    { "Name" = "${var.name}-${var.tgwattach_subnet_suffix}" },
+    var.tags,
+    var.tgwattach_acl_tags,
+  )
+}
+
+resource "aws_network_acl_rule" "tgwattach_inbound" {
+  count = var.create_vpc && var.tgwattach_dedicated_network_acl && length(var.tgwattach_subnets) > 0 ? length(var.tgwattach_inbound_acl_rules) : 0
+
+  network_acl_id = aws_network_acl.tgwattach[0].id
+
+  egress          = false
+  rule_number     = var.tgwattach_inbound_acl_rules[count.index]["rule_number"]
+  rule_action     = var.tgwattach_inbound_acl_rules[count.index]["rule_action"]
+  from_port       = lookup(var.tgwattach_inbound_acl_rules[count.index], "from_port", null)
+  to_port         = lookup(var.tgwattach_inbound_acl_rules[count.index], "to_port", null)
+  icmp_code       = lookup(var.tgwattach_inbound_acl_rules[count.index], "icmp_code", null)
+  icmp_type       = lookup(var.tgwattach_inbound_acl_rules[count.index], "icmp_type", null)
+  protocol        = var.tgwattach_inbound_acl_rules[count.index]["protocol"]
+  cidr_block      = lookup(var.tgwattach_inbound_acl_rules[count.index], "cidr_block", null)
+  ipv6_cidr_block = lookup(var.tgwattach_inbound_acl_rules[count.index], "ipv6_cidr_block", null)
+}
+
+resource "aws_network_acl_rule" "tgwattach_outbound" {
+  count = var.create_vpc && var.tgwattach_dedicated_network_acl && length(var.tgwattach_subnets) > 0 ? length(var.tgwattach_outbound_acl_rules) : 0
+
+  network_acl_id = aws_network_acl.tgwattach[0].id
+
+  egress          = true
+  rule_number     = var.tgwattach_outbound_acl_rules[count.index]["rule_number"]
+  rule_action     = var.tgwattach_outbound_acl_rules[count.index]["rule_action"]
+  from_port       = lookup(var.tgwattach_outbound_acl_rules[count.index], "from_port", null)
+  to_port         = lookup(var.tgwattach_outbound_acl_rules[count.index], "to_port", null)
+  icmp_code       = lookup(var.tgwattach_outbound_acl_rules[count.index], "icmp_code", null)
+  icmp_type       = lookup(var.tgwattach_outbound_acl_rules[count.index], "icmp_type", null)
+  protocol        = var.tgwattach_outbound_acl_rules[count.index]["protocol"]
+  cidr_block      = lookup(var.tgwattach_outbound_acl_rules[count.index], "cidr_block", null)
+  ipv6_cidr_block = lookup(var.tgwattach_outbound_acl_rules[count.index], "ipv6_cidr_block", null)
 }
 
 ################################################################################
@@ -1146,6 +1284,16 @@ resource "aws_route_table_association" "intra" {
 
   subnet_id      = element(aws_subnet.intra[*].id, count.index)
   route_table_id = element(aws_route_table.intra[*].id, 0)
+}
+
+resource "aws_route_table_association" "tgwattach" {
+  count = var.create_vpc && var.create_tgwattach_subnet_route_table && length(var.tgwattach_subnets) > 0 ? length(var.tgwattach_subnets) : 0
+
+  subnet_id = element(aws_subnet.tgwattach[*].id, count.index)
+  route_table_id = element(
+    aws_route_table.tgwattach[*].id,
+    var.single_nat_gateway ? 0 : count.index,
+  )
 }
 
 resource "aws_route_table_association" "public" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -223,6 +223,26 @@ output "intra_subnets_ipv6_cidr_blocks" {
   value       = aws_subnet.intra[*].ipv6_cidr_block
 }
 
+output "tgwattach_subnets" {
+  description = "List of IDs of TGW Attachement subnets"
+  value       = aws_subnet.tgwattach[*].id
+}
+
+output "tgwattach_subnet_arns" {
+  description = "List of ARNs of TGW Attachement subnets"
+  value       = aws_subnet.tgwattach[*].arn
+}
+
+output "tgwattach_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of TGW Attachement subnets"
+  value       = aws_subnet.tgwattach[*].cidr_block
+}
+
+output "tgwattach_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of TGW Attachement subnets in an IPv6 enabled VPC"
+  value       = aws_subnet.tgwattach[*].ipv6_cidr_block
+}
+
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
   value       = try(aws_elasticache_subnet_group.elasticache[0].id, "")
@@ -261,6 +281,11 @@ output "elasticache_route_table_ids" {
 output "intra_route_table_ids" {
   description = "List of IDs of intra route tables"
   value       = aws_route_table.intra[*].id
+}
+
+output "tgwattach_route_table_ids" {
+  description = "List of IDs of TGW Attachement route tables"
+  value       = aws_route_table.tgwattach[*].id
 }
 
 output "public_internet_gateway_route_id" {
@@ -326,6 +351,11 @@ output "elasticache_route_table_association_ids" {
 output "intra_route_table_association_ids" {
   description = "List of IDs of the intra route table association"
   value       = aws_route_table_association.intra[*].id
+}
+
+output "tgwattach_route_table_association_ids" {
+  description = "List of IDs of the TGW Attachement route table association"
+  value       = aws_route_table_association.tgwattach[*].id
 }
 
 output "public_route_table_association_ids" {
@@ -481,6 +511,16 @@ output "intra_network_acl_id" {
 output "intra_network_acl_arn" {
   description = "ARN of the intra network ACL"
   value       = try(aws_network_acl.intra[0].arn, "")
+}
+
+output "tgwattach_network_acl_id" {
+  description = "ID of the TGW Attachement network ACL"
+  value       = try(aws_network_acl.tgwattach[0].id, "")
+}
+
+output "tgwattach_network_acl_arn" {
+  description = "ARN of the TGW Attachement network ACL"
+  value       = try(aws_network_acl.tgwattach[0].arn, "")
 }
 
 output "database_network_acl_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -283,11 +283,6 @@ output "intra_route_table_ids" {
   value       = aws_route_table.intra[*].id
 }
 
-output "tgwattach_route_table_ids" {
-  description = "List of IDs of TGW Attachement route tables"
-  value       = aws_route_table.tgwattach[*].id
-}
-
 output "public_internet_gateway_route_id" {
   description = "ID of the internet gateway route"
   value       = try(aws_route.public_internet_gateway[0].id, "")
@@ -511,16 +506,6 @@ output "intra_network_acl_id" {
 output "intra_network_acl_arn" {
   description = "ARN of the intra network ACL"
   value       = try(aws_network_acl.intra[0].arn, "")
-}
-
-output "tgwattach_network_acl_id" {
-  description = "ID of the TGW Attachement network ACL"
-  value       = try(aws_network_acl.tgwattach[0].id, "")
-}
-
-output "tgwattach_network_acl_arn" {
-  description = "ARN of the TGW Attachement network ACL"
-  value       = try(aws_network_acl.tgwattach[0].arn, "")
 }
 
 output "database_network_acl_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -256,12 +256,6 @@ variable "create_elasticache_subnet_route_table" {
   default     = false
 }
 
-variable "create_tgwattach_subnet_route_table" {
-  description = "Controls if separate route table for TGW Attachement should be created"
-  type        = bool
-  default     = false
-}
-
 variable "create_database_subnet_group" {
   description = "Controls if database subnet group should be created (n.b. database_subnets must also be set)"
   type        = bool
@@ -292,14 +286,8 @@ variable "create_database_nat_gateway_route" {
   default     = false
 }
 
-variable "create_tgwattach_internet_gateway_route" {
-  description = "Controls if an internet gateway route for public TGW Attachement access should be created"
-  type        = bool
-  default     = false
-}
-
-variable "create_tgwattach_nat_gateway_route" {
-  description = "Controls if a nat gateway route should be created to give internet access to the TGW Attachement subnets"
+variable "tgwattach_associate_private_route_table" {
+  description = "Controls if the private route talbe should be attached to give internet access to the TGW Attachement subnets"
   type        = bool
   default     = false
 }
@@ -502,12 +490,6 @@ variable "private_route_table_tags" {
   default     = {}
 }
 
-variable "tgwattach_route_table_tags" {
-  description = "Additional tags for the TGW Attachement route tables"
-  type        = map(string)
-  default     = {}
-}
-
 variable "database_route_table_tags" {
   description = "Additional tags for the database route tables"
   type        = map(string)
@@ -618,12 +600,6 @@ variable "outpost_acl_tags" {
 
 variable "intra_acl_tags" {
   description = "Additional tags for the intra subnets network ACL"
-  type        = map(string)
-  default     = {}
-}
-
-variable "tgwattach_acl_tags" {
-  description = "Additional tags for the TGW Attachement subnets network ACL"
   type        = map(string)
   default     = {}
 }
@@ -798,12 +774,6 @@ variable "outpost_dedicated_network_acl" {
 
 variable "intra_dedicated_network_acl" {
   description = "Whether to use dedicated network ACL (not default) and custom rules for intra subnets"
-  type        = bool
-  default     = false
-}
-
-variable "tgwattach_dedicated_network_acl" {
-  description = "Whether to use dedicated network ACL (not default) and custom rules for TGW Attachement subnets"
   type        = bool
   default     = false
 }
@@ -988,38 +958,6 @@ variable "intra_inbound_acl_rules" {
 
 variable "intra_outbound_acl_rules" {
   description = "Intra subnets outbound network ACLs"
-  type        = list(map(string))
-
-  default = [
-    {
-      rule_number = 100
-      rule_action = "allow"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_block  = "0.0.0.0/0"
-    },
-  ]
-}
-
-variable "tgwattach_inbound_acl_rules" {
-  description = "TGW Attachement subnets inbound network ACLs"
-  type        = list(map(string))
-
-  default = [
-    {
-      rule_number = 100
-      rule_action = "allow"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_block  = "0.0.0.0/0"
-    },
-  ]
-}
-
-variable "tgwattach_outbound_acl_rules" {
-  description = "TGW Attachement subnets outbound network ACLs"
   type        = list(map(string))
 
   default = [

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "intra_subnet_ipv6_prefixes" {
   default     = []
 }
 
+variable "tgwattach_subnet_ipv6_prefixes" {
+  description = "Assigns IPv6 TGW Attachement subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
+  type        = list(string)
+  default     = []
+}
+
 variable "assign_ipv6_address_on_creation" {
   description = "Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
   type        = bool
@@ -112,6 +118,12 @@ variable "intra_subnet_assign_ipv6_address_on_creation" {
   default     = null
 }
 
+variable "tgwattach_subnet_assign_ipv6_address_on_creation" {
+  description = "Assign IPv6 address on TGW Attachement subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map_public_ip_on_launch"
+  type        = bool
+  default     = null
+}
+
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)
@@ -146,6 +158,12 @@ variable "intra_subnet_suffix" {
   description = "Suffix to append to intra subnets name"
   type        = string
   default     = "intra"
+}
+
+variable "tgwattach_subnet_suffix" {
+  description = "Suffix to append to TGW Attachement subnets name"
+  type        = string
+  default     = "tgwattach"
 }
 
 variable "database_subnet_suffix" {
@@ -208,6 +226,12 @@ variable "intra_subnets" {
   default     = []
 }
 
+variable "tgwattach_subnets" {
+  description = "A list of TGW Attachement subnets"
+  type        = list(string)
+  default     = []
+}
+
 variable "create_database_subnet_route_table" {
   description = "Controls if separate route table for database should be created"
   type        = bool
@@ -228,6 +252,12 @@ variable "enable_public_redshift" {
 
 variable "create_elasticache_subnet_route_table" {
   description = "Controls if separate route table for elasticache should be created"
+  type        = bool
+  default     = false
+}
+
+variable "create_tgwattach_subnet_route_table" {
+  description = "Controls if separate route table for TGW Attachement should be created"
   type        = bool
   default     = false
 }
@@ -258,6 +288,18 @@ variable "create_database_internet_gateway_route" {
 
 variable "create_database_nat_gateway_route" {
   description = "Controls if a nat gateway route should be created to give internet access to the database subnets"
+  type        = bool
+  default     = false
+}
+
+variable "create_tgwattach_internet_gateway_route" {
+  description = "Controls if an internet gateway route for public TGW Attachement access should be created"
+  type        = bool
+  default     = false
+}
+
+variable "create_tgwattach_nat_gateway_route" {
+  description = "Controls if a nat gateway route should be created to give internet access to the TGW Attachement subnets"
   type        = bool
   default     = false
 }
@@ -460,6 +502,12 @@ variable "private_route_table_tags" {
   default     = {}
 }
 
+variable "tgwattach_route_table_tags" {
+  description = "Additional tags for the TGW Attachement route tables"
+  type        = map(string)
+  default     = {}
+}
+
 variable "database_route_table_tags" {
   description = "Additional tags for the database route tables"
   type        = map(string)
@@ -544,6 +592,12 @@ variable "intra_subnet_tags" {
   default     = {}
 }
 
+variable "tgwattach_subnet_tags" {
+  description = "Additional tags for the TGW Attachement subnets"
+  type        = map(string)
+  default     = {}
+}
+
 variable "public_acl_tags" {
   description = "Additional tags for the public subnets network ACL"
   type        = map(string)
@@ -564,6 +618,12 @@ variable "outpost_acl_tags" {
 
 variable "intra_acl_tags" {
   description = "Additional tags for the intra subnets network ACL"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tgwattach_acl_tags" {
+  description = "Additional tags for the TGW Attachement subnets network ACL"
   type        = map(string)
   default     = {}
 }
@@ -738,6 +798,12 @@ variable "outpost_dedicated_network_acl" {
 
 variable "intra_dedicated_network_acl" {
   description = "Whether to use dedicated network ACL (not default) and custom rules for intra subnets"
+  type        = bool
+  default     = false
+}
+
+variable "tgwattach_dedicated_network_acl" {
+  description = "Whether to use dedicated network ACL (not default) and custom rules for TGW Attachement subnets"
   type        = bool
   default     = false
 }
@@ -922,6 +988,38 @@ variable "intra_inbound_acl_rules" {
 
 variable "intra_outbound_acl_rules" {
   description = "Intra subnets outbound network ACLs"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "tgwattach_inbound_acl_rules" {
+  description = "TGW Attachement subnets inbound network ACLs"
+  type        = list(map(string))
+
+  default = [
+    {
+      rule_number = 100
+      rule_action = "allow"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_block  = "0.0.0.0/0"
+    },
+  ]
+}
+
+variable "tgwattach_outbound_acl_rules" {
+  description = "TGW Attachement subnets outbound network ACLs"
   type        = list(map(string))
 
   default = [


### PR DESCRIPTION
## Description
Add a new subnet type : tgwattach. The tgwattach subnet are usually small subnet range with no route table associated with unless you set the parameter  `tgwattach_associate_private_route_table` to true to benefit from the default route to NAT Gateway in case of an outbound VPC.

## Motivation and Context
Following AWS best practices for Transit Gateway attachement: https://docs.aws.amazon.com/vpc/latest/tgw/tgw-best-design-practices.html:
*Use a separate subnet for each transit gateway VPC attachment. For each subnet, use a small CIDR, for example /28, so that you have more addresses for EC2 resources*

These attachement subnets does not need ACLs neither route table, unless the VPC to be attached is an outbound VPC. In this case a route to NAT Gateway must be set. This is done by associating the `private` route table to those subnets with the parameter `tgwattach_associate_private_route_table` (set it to `true`or `false`)

(if ACL is required, it is possible to enhance the module and add ACLs for the tgwattach subnets)

## Breaking Changes
No breaking change noticed.

## How Has This Been Tested?
I tested the changes with a hub and spoke architecture, using a transit Gateway, three `application VPCs` (no internet gateway and NAT Gateway) and an outbound VPC (with IGW and NAT GW)
The new module is compatible with the Transit Gateway module. Attachement is performed thanks to the `tgwattach_subnets` IDs output.
