### PR TITLE
feat: allows vpc to have a nat gateway even with no private subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1040,7 +1040,7 @@ resource "aws_nat_gateway" "this" {
 }
 
 resource "aws_route" "private_nat_gateway" {
-  count = var.create_vpc && var.enable_nat_gateway ? local.nat_gateway_count : 0
+  count = var.create_vpc && var.enable_nat_gateway && length(var.private_subnets) > 0 ? local.nat_gateway_count : 0
 
   route_table_id         = element(aws_route_table.private[*].id, count.index)
   destination_cidr_block = var.nat_gateway_destination_cidr_block


### PR DESCRIPTION
## Description
Allows Vpc to have a nate gateway even with no private subnets

## Motivation and Context
Error with below nat_gateway configs with no private subnet

  enable_nat_gateway = true 
  single_nat_gateway = true 
  one_nat_gateway_per_az = false

│ Error: Error in function call
│ 
│   on .terraform/modules/openvpn_vpc/main.tf line 905, in resource "aws_route" "private_nat_gateway":
│  905:   route_table_id         = element(aws_route_table.private.*.id, count.index)
│     ├────────────────
│     │ aws_route_table.private is empty tuple
│     │ count.index is 0
│ 
│ Call to function "element" failed: cannot use element function with an empty list.

## Breaking Changes
None

## How Has This Been Tested?
terraform apply with mentioned configs is running
