### PR TITLE
feat: Add support for ipv6_ipam_pool_id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -118,18 +118,6 @@ variable "ipv6_ipam_pool_id" {
   default     = null
 }
 
-variable "ipv6_cidr_block" {
-  description = "The IPv6 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv6_netmask_length. This parameter is required if ipv6_netmask_length is not set and he IPAM pool does not have allocation_default_netmask set."
-  type        = string
-  default     = null
-}
-
-variable "ipv6_netmask_length" {
-  description = "The netmask length of the IPv6 CIDR you want to allocate to this VPC. Requires specifying a ipv6_ipam_pool_id. This parameter is optional if the IPAM pool has allocation_default_netmask set, otherwise it or cidr_block are required"
-  type        = number
-  default     = null
-}
-
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,24 @@ variable "intra_subnet_assign_ipv6_address_on_creation" {
   default     = null
 }
 
+variable "ipv6_ipam_pool_id" {
+  description = "IPAM Pool ID for a IPv6 Pool"
+  type        = string
+  default     = null
+}
+
+variable "ipv6_cidr_block" {
+  description = "The IPv6 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using ipv6_netmask_length. This parameter is required if ipv6_netmask_length is not set and he IPAM pool does not have allocation_default_netmask set."
+  type        = string
+  default     = null
+}
+
+variable "ipv6_netmask_length" {
+  description = "The netmask length of the IPv6 CIDR you want to allocate to this VPC. Requires specifying a ipv6_ipam_pool_id. This parameter is optional if the IPAM pool has allocation_default_netmask set, otherwise it or cidr_block are required"
+  type        = number
+  default     = null
+}
+
 variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)


### PR DESCRIPTION
## Description
This change allows using an existing IPAM IPv6 Pool in a VPC

## Motivation and Context
We have a client that uses their own centralized Pools of IPv6 IPAM network blocks.  They assign us a block and provide a pool id.  The current VPC module didn't make use of the `ipv6_ipam_pool_id` argument to the `aws_vpc` resource.  This argument is mutually exclusive of the `assign_generated_ipv6_cidr_block` argument, so we also need to make that argument optional by assigning `null` to it if the `ipv6_ipam_pool_id` value is set.

This solves a very specific use case, but it makes the code more flexible to allow for this scenario.

## Breaking Changes
None that I can see.

## How Has This Been Tested?
- [ X ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I ran the following in each of the example directories -- using terraform 0.13.7 from the "master" branch:
```
    terraform init
    terraform plan -out terraform.tfplan
    terraform apply terraform.tfplan
```
Then checked out the "feature/ipv6_ipam_pool_id" branch and ran:
```
    terraform plan -out terraform.tfplan`
```
And confirmed that there are "No Changes".

I wasn't able to run the test in `examples/outpost` or `examples/vpc-flow-logs` -- neither would get a valid plan in the `master` branch.

I have run this in our own terraform with an `ipv6_ipam_pool_id`.
