### PR TITLE
docs: allow HTTPS from VPC to ssmmessages and ec2messages endpoints

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -109,6 +109,7 @@ module "vpc_endpoints" {
       service             = "ssmmessages"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
+      security_group_ids  = [aws_security_group.vpc_tls.id]
     },
     lambda = {
       service             = "lambda"
@@ -135,6 +136,7 @@ module "vpc_endpoints" {
       service             = "ec2messages"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
+      security_group_ids  = [aws_security_group.vpc_tls.id]
     },
     ecr_api = {
       service             = "ecr.api"


### PR DESCRIPTION
## Description
Updated `examples/complete-vpc/main.tf` to allow HTTPS from VPC to ssmmessages and ec2messages endpoints

## Motivation and Context

Enabling endpoints exactly as described in `examples/complete-vpc/main.tf` breaks SSM communication.

As per 

- https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html
- https://aws.amazon.com/premiumsupport/knowledge-center/ec2-systems-manager-vpc-endpoints/     

HTTPS (port 443) outbound traffic to the following endpoints must be allowed

   ssm.region.amazonaws.com
   ssmmessages.region.amazonaws.com
   ec2messages.region.amazonaws.com

## Breaking Changes
N.A.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

