### PR TITLE
feat: Change to allow create variable within specific vpc objects

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -121,7 +121,7 @@ module "vpc_endpoints" {
       subnet_ids          = module.vpc.private_subnets
     },
     ecs_telemetry = {
-      create = false
+      create              = false
       service             = "ecs-telemetry"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -89,7 +89,6 @@ module "vpc_endpoints" {
 
   endpoints = {
     s3 = {
-      create = false
       service = "s3"
       tags    = { Name = "s3-vpc-endpoint" }
     },
@@ -122,6 +121,7 @@ module "vpc_endpoints" {
       subnet_ids          = module.vpc.private_subnets
     },
     ecs_telemetry = {
+      create = false
       service             = "ecs-telemetry"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -89,6 +89,7 @@ module "vpc_endpoints" {
 
   endpoints = {
     s3 = {
+      create = false
       service = "s3"
       tags    = { Name = "s3-vpc-endpoint" }
     },

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -24,21 +24,21 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 1.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_vpc_with_flow_logs_cloudwatch_logs"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs) | ../../ | n/a |
 | <a name="module_vpc_with_flow_logs_cloudwatch_logs_default"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs\_default](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs\_default) | ../../ | n/a |
 | <a name="module_vpc_with_flow_logs_s3_bucket"></a> [vpc\_with\_flow\_logs\_s3\_bucket](#module\_vpc\_with\_flow\_logs\_s3\_bucket) | ../../ | n/a |

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -24,7 +24,7 @@ module "vpc_with_flow_logs_s3_bucket" {
 
   enable_flow_log           = true
   flow_log_destination_type = "s3"
-  flow_log_destination_arn  = module.s3_bucket.this_s3_bucket_arn
+  flow_log_destination_arn  = module.s3_bucket.s3_bucket_arn
 
   vpc_flow_log_tags = {
     Name = "vpc-flow-logs-s3-bucket"
@@ -42,7 +42,7 @@ module "vpc_with_flow_logs_s3_bucket_parquet" {
 
   enable_flow_log           = true
   flow_log_destination_type = "s3"
-  flow_log_destination_arn  = module.s3_bucket.this_s3_bucket_arn
+  flow_log_destination_arn  = module.s3_bucket.s3_bucket_arn
   flow_log_file_format      = "parquet"
 
   vpc_flow_log_tags = {
@@ -102,7 +102,7 @@ resource "random_pet" "this" {
 # S3 Bucket
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 1.0"
+  version = "~> 3.0"
 
   bucket        = local.s3_bucket_name
   policy        = data.aws_iam_policy_document.flow_log_s3.json

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.63"
+      version = ">= 3.75"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = ">= 2"
+      version = ">= 2.0"
     }
   }
 }

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -15,7 +15,7 @@ data "aws_vpc_endpoint_service" "this" {
 }
 
 resource "aws_vpc_endpoint" "this" {
-  for_each = { for k, v in var.endpoints : k => v if var.create && try(v.create, true)}
+  for_each = { for k, v in var.endpoints : k => v if var.create && try(v.create, true) }
 
   vpc_id            = var.vpc_id
   service_name      = data.aws_vpc_endpoint_service.this[each.key].service_name

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -15,7 +15,7 @@ data "aws_vpc_endpoint_service" "this" {
 }
 
 resource "aws_vpc_endpoint" "this" {
-  for_each = { for k, v in var.endpoints : k => v if var.create }
+  for_each = { for k, v in var.endpoints : k => v if var.create && v.create}
 
   vpc_id            = var.vpc_id
   service_name      = data.aws_vpc_endpoint_service.this[each.key].service_name

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -15,7 +15,7 @@ data "aws_vpc_endpoint_service" "this" {
 }
 
 resource "aws_vpc_endpoint" "this" {
-  for_each = { for k, v in var.endpoints : k => v if var.create && v.create}
+  for_each = { for k, v in var.endpoints : k => v if var.create && try(v.create, true)}
 
   vpc_id            = var.vpc_id
   service_name      = data.aws_vpc_endpoint_service.this[each.key].service_name


### PR DESCRIPTION

## Description
This change is to allow for create to work within each vpc endpoint object. If the create is outside of a vpc endpoint then that will take priorty over the specific vpc endpoints create.

## Motivation and Context
This will make the script alot more flexible and fine grain. As you can go down to object level to specify which objects should be created or not. Making a lot more use cases possible.


## Breaking Changes
The only thing that was introduced that would be debtable is try but it seems try has been there for a long time so seem like it is backwards compatible. 

## How Has This Been Tested?
Yes I have an example project which I tested this on. I tested with multiple use cases to make sure.
This change will also default create to true with object level vpc endpoints just like it has been. Meaning create is still optional for object level and resource level create.