### PR TITLE
fix: Name key of vpc tags is overriding Name key cgw

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1155,9 +1155,9 @@ resource "aws_customer_gateway" "this" {
   type        = "ipsec.1"
 
   tags = merge(
-    { Name = "${var.name}-${each.key}" },
     var.tags,
     var.customer_gateway_tags,
+  { Name = "${var.name}-${each.key}" },
   )
 }
 


### PR DESCRIPTION
If you specify Name key in vpc tags, then Name key of vpc tags is overriding Name key of cgw

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
