### PR TITLE
Add  flow_log_log_group_name_prefix  as a output 

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ No modules.
 | <a name="output_elasticache_subnets"></a> [elasticache\_subnets](#output\_elasticache\_subnets) | List of IDs of elasticache subnets |
 | <a name="output_elasticache_subnets_cidr_blocks"></a> [elasticache\_subnets\_cidr\_blocks](#output\_elasticache\_subnets\_cidr\_blocks) | List of cidr\_blocks of elasticache subnets |
 | <a name="output_elasticache_subnets_ipv6_cidr_blocks"></a> [elasticache\_subnets\_ipv6\_cidr\_blocks](#output\_elasticache\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of elasticache subnets in an IPv6 enabled VPC |
+| <a name="output_flow_log_log_group_name_prefix"></a> [flow\_log\_log\_group\_name\_prefix](#output\_flow\_log\_log\_group\_name\_prefix) | The name prefix of the CloudWatch Log Group created for the VPC flow logs. |
 | <a name="output_igw_arn"></a> [igw\_arn](#output\_igw\_arn) | The ARN of the Internet Gateway |
 | <a name="output_igw_id"></a> [igw\_id](#output\_igw\_id) | The ID of the Internet Gateway |
 | <a name="output_intra_network_acl_arn"></a> [intra\_network\_acl\_arn](#output\_intra\_network\_acl\_arn) | ARN of the intra network ACL |

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -7,7 +7,7 @@ locals {
 
   s3_bucket_name            = "vpc-flow-logs-to-s3-${random_pet.this.id}"
   cloudwatch_log_group_name = "vpc-flow-logs-to-cloudwatch-${random_pet.this.id}"
-  cloudwatch_flow_log_group_name = "${module.vpc_with_flow_logs_cloudwatch_logs.flow_log_log_group_name_prefix}/${module.vpc_with_flow_logs_cloudwatch_logs.name}"
+  cloudwatch_flow_log_group_name = "${module.vpc_with_flow_logs_cloudwatch_logs_default.flow_log_log_group_name_prefix}${module.vpc_with_flow_logs_cloudwatch_logs_default.vpc_id}"
 }
 
 ################################################################################
@@ -112,7 +112,7 @@ resource "aws_cloudwatch_log_metric_filter" "flow_log_reject" {
   }
 
    depends_on = [
-    module.vpc_with_flow_logs_cloudwatch_logs
+    module.vpc_with_flow_logs_cloudwatch_logs_default
   ]
 }
 

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -110,6 +110,10 @@ resource "aws_cloudwatch_log_metric_filter" "flow_log_reject" {
     namespace = "FLOW_LOG"
     value     = "1"
   }
+
+   depends_on = [
+    module.vpc_with_flow_logs_cloudwatch_logs
+  ]
 }
 
 # S3 Bucket

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -7,6 +7,7 @@ locals {
 
   s3_bucket_name            = "vpc-flow-logs-to-s3-${random_pet.this.id}"
   cloudwatch_log_group_name = "vpc-flow-logs-to-cloudwatch-${random_pet.this.id}"
+  cloudwatch_flow_log_group_name = "${module.vpc_with_flow_logs_cloudwatch_logs.flow_log_log_group_name_prefix}/${module.vpc_with_flow_logs_cloudwatch_logs.name}"
 }
 
 ################################################################################
@@ -97,6 +98,18 @@ module "vpc_with_flow_logs_cloudwatch_logs" {
 
 resource "random_pet" "this" {
   length = 2
+}
+
+resource "aws_cloudwatch_log_metric_filter" "flow_log_reject" {
+  name           = "Flow-Log-Reject"
+  pattern        = "REJECT"
+  log_group_name = locals.cloudwatch_flow_log_group_name
+
+  metric_transformation {
+    name      = "REJECT"
+    namespace = "FLOW_LOG"
+    value     = "1"
+  }
 }
 
 # S3 Bucket

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -103,7 +103,7 @@ resource "random_pet" "this" {
 resource "aws_cloudwatch_log_metric_filter" "flow_log_reject" {
   name           = "Flow-Log-Reject"
   pattern        = "REJECT"
-  log_group_name = locals.cloudwatch_flow_log_group_name
+  log_group_name = local.cloudwatch_flow_log_group_name
 
   metric_transformation {
     name      = "REJECT"

--- a/outputs.tf
+++ b/outputs.tf
@@ -534,6 +534,11 @@ output "vpc_flow_log_cloudwatch_iam_role_arn" {
   value       = local.flow_log_iam_role_arn
 }
 
+output "flow_log_log_group_name_prefix" {
+  description = "The name prefix of the CloudWatch Log Group created for the VPC flow logs."
+  value       = var.flow_log_cloudwatch_log_group_name_prefix
+}
+
 # Static values (arguments)
 output "azs" {
   description = "A list of availability zones specified as argument to this module"


### PR DESCRIPTION
## Description

Adds `flow_log_log_group_name_prefix` as a output from the module.

## Motivation and Context

See: [#790](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/790)

## Breaking Changes

No.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

This is my first open source commit so take it easy on me!