### PR TITLE
feat: Add support for `ipv6_ipam_pool_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
-| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `true` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `null` | no |
 | <a name="input_assign_ipv6_address_on_creation"></a> [assign\_ipv6\_address\_on\_creation](#input\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
@@ -406,7 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
-| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for an IPv6 pool. | `string` | `null` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
-| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for an IPv6 pool. | `string` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
-| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `""` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
-| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `null` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `true` | no |
 | <a name="input_assign_ipv6_address_on_creation"></a> [assign\_ipv6\_address\_on\_creation](#input\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
@@ -406,7 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
-| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for an IPv6 pool. | `string` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `null` | no |
 | <a name="input_assign_ipv6_address_on_creation"></a> [assign\_ipv6\_address\_on\_creation](#input\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
@@ -405,6 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
-| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `null` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `false` | no |
 | <a name="input_assign_ipv6_address_on_creation"></a> [assign\_ipv6\_address\_on\_creation](#input\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
-| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `""` | no |
+| <a name="input_ipv6_ipam_pool_id"></a> [ipv6\_ipam\_pool\_id](#input\_ipv6\_ipam\_pool\_id) | IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`. | `string` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,16 +11,6 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
-
-  # The arguments `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`
-  # conflict.  If `var.ipv6_ipam_pool_id` has a value, force
-  # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
-  # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
-  # then use the value of `var.create_vpc`.
-  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : coalesce(
-    var.assign_generated_ipv6_cidr_block,
-    var.create_vpc,
-  )
 }
 
 ################################################################################
@@ -36,7 +26,7 @@ resource "aws_vpc" "this" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = local.assign_generated_ipv6_cidr_block
+  assign_generated_ipv6_cidr_block = var.enable_ipv6 && var.assign_generated_ipv6_cidr_block ? true : null
   ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -11,16 +11,6 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
-
-  # The arguments `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`
-  # conflict.  If `var.ipv6_ipam_pool_id` has a value, force
-  # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
-  # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
-  # then use the value of `var.create_vpc`.
-  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : coalesce(
-    var.assign_generated_ipv6_cidr_block,
-    var.create_vpc,
-  )
 }
 
 ################################################################################
@@ -36,7 +26,7 @@ resource "aws_vpc" "this" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = local.assign_generated_ipv6_cidr_block
+  assign_generated_ipv6_cidr_block = var.enable_ipv6 && var.assign_generated_ipv6_cidr_block
   ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ locals {
   # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
   # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
   # then use the value of `var.create_vpc`.
-  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : (
+  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != "" ? null : (
     var.assign_generated_ipv6_cidr_block != null
     && var.assign_generated_ipv6_cidr_block
     || var.create_vpc

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,17 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
+
+  # The arguments `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`
+  # conflict.  If `var.ipv6_ipam_pool_id` has a value, force
+  # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
+  # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
+  # then use the value of `var.create_vpc`.
+  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : (
+    var.assign_generated_ipv6_cidr_block != null
+    && var.assign_generated_ipv6_cidr_block
+    || var.create_vpc
+  )
 }
 
 ################################################################################
@@ -26,7 +37,8 @@ resource "aws_vpc" "this" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = var.enable_ipv6
+  assign_generated_ipv6_cidr_block = local.assign_generated_ipv6_cidr_block
+  ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
 
   tags = merge(
     { "Name" = var.name },

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,16 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
+
+  # The arguments `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`
+  # conflict.  If `var.ipv6_ipam_pool_id` has a value, force
+  # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
+  # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
+  # then use the value of `var.create_vpc`.
+  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : coalesce(
+    var.assign_generated_ipv6_cidr_block,
+    var.create_vpc,
+  )
 }
 
 ################################################################################
@@ -26,7 +36,7 @@ resource "aws_vpc" "this" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = var.enable_ipv6 && var.assign_generated_ipv6_cidr_block
+  assign_generated_ipv6_cidr_block = local.assign_generated_ipv6_cidr_block
   ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,9 @@ locals {
   # `assign_generated_ipv6_cidr_block` to be `null`. Otherwise, if
   # `var.assign_generated_ipv6_cidr_block` has a value, use it; if it is `null`,
   # then use the value of `var.create_vpc`.
-  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != "" ? null : (
-    var.assign_generated_ipv6_cidr_block != null
-    && var.assign_generated_ipv6_cidr_block
-    || var.create_vpc
+  assign_generated_ipv6_cidr_block = var.ipv6_ipam_pool_id != null ? null : coalesce(
+    var.assign_generated_ipv6_cidr_block,
+    var.create_vpc,
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "assign_generated_ipv6_cidr_block" {
 variable "ipv6_ipam_pool_id" {
   description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "private_subnet_ipv6_prefixes" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "assign_generated_ipv6_cidr_block" {
 }
 
 variable "ipv6_ipam_pool_id" {
-  description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
+  description = "IPAM Pool ID for an IPv6 pool."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "assign_generated_ipv6_cidr_block" {
 variable "ipv6_ipam_pool_id" {
   description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "private_subnet_ipv6_prefixes" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,11 +25,11 @@ variable "enable_ipv6" {
 variable "assign_generated_ipv6_cidr_block" {
   description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC."
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "ipv6_ipam_pool_id" {
-  description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
+  description = "IPAM Pool ID for an IPv6 pool."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "enable_ipv6" {
 variable "assign_generated_ipv6_cidr_block" {
   description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC."
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "ipv6_ipam_pool_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,11 +25,11 @@ variable "enable_ipv6" {
 variable "assign_generated_ipv6_cidr_block" {
   description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "ipv6_ipam_pool_id" {
-  description = "IPAM Pool ID for an IPv6 pool."
+  description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,18 @@ variable "enable_ipv6" {
   default     = false
 }
 
+variable "assign_generated_ipv6_cidr_block" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC."
+  type        = bool
+  default     = null
+}
+
+variable "ipv6_ipam_pool_id" {
+  description = "IPAM Pool ID for a IPv6 pool. Overrides `assign_generated_ipv6_cidr_block`."
+  type        = string
+  default     = null
+}
+
 variable "private_subnet_ipv6_prefixes" {
   description = "Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   type        = list(string)


### PR DESCRIPTION
## Description
Add support for passing `ipv6_ipam_pool_id` and `assign_generated_ipv6_cidr_block` arguments to the `aws_vpc` resource.

## Motivation and Context
I have a VPC where I need to pass the `ipv6_ipam_pool_id` and I couldn't do that without adding this feature.

## Breaking Changes
None, the module works the same as it does today.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s); I did not update any of the examples to test the new feature because BYOIPv6 is difficult to setup / test in a development environment.
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects; existing examples work as they did before if you don't pass in the new argument: `ipv6_ipam_pool_id`
- [x] I used the module for my own VPC and used the new argument `ipv6_ipam_pool_id` and it worked as expected.
- [x] I have executed `pre-commit run -a` on my pull request