### PR TITLE
fix: Compact CIDR block outputs to avoid empty diffs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,7 +60,7 @@ output "vpc_ipv6_cidr_block" {
 
 output "vpc_secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks of the VPC"
-  value       = aws_vpc_ipv4_cidr_block_association.this[*].cidr_block
+  value       = compact(aws_vpc_ipv4_cidr_block_association.this[*].cidr_block)
 }
 
 output "vpc_owner_id" {
@@ -80,12 +80,12 @@ output "private_subnet_arns" {
 
 output "private_subnets_cidr_blocks" {
   description = "List of cidr_blocks of private subnets"
-  value       = aws_subnet.private[*].cidr_block
+  value       = compact(aws_subnet.private[*].cidr_block)
 }
 
 output "private_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.private[*].ipv6_cidr_block
+  value       = compact(aws_subnet.private[*].ipv6_cidr_block)
 }
 
 output "public_subnets" {
@@ -100,12 +100,12 @@ output "public_subnet_arns" {
 
 output "public_subnets_cidr_blocks" {
   description = "List of cidr_blocks of public subnets"
-  value       = aws_subnet.public[*].cidr_block
+  value       = compact(aws_subnet.public[*].cidr_block)
 }
 
 output "public_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.public[*].ipv6_cidr_block
+  value       = compact(aws_subnet.public[*].ipv6_cidr_block)
 }
 
 output "outpost_subnets" {
@@ -120,12 +120,12 @@ output "outpost_subnet_arns" {
 
 output "outpost_subnets_cidr_blocks" {
   description = "List of cidr_blocks of outpost subnets"
-  value       = aws_subnet.outpost[*].cidr_block
+  value       = compact(aws_subnet.outpost[*].cidr_block)
 }
 
 output "outpost_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of outpost subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.outpost[*].ipv6_cidr_block
+  value       = compact(aws_subnet.outpost[*].ipv6_cidr_block)
 }
 
 output "database_subnets" {
@@ -140,12 +140,12 @@ output "database_subnet_arns" {
 
 output "database_subnets_cidr_blocks" {
   description = "List of cidr_blocks of database subnets"
-  value       = aws_subnet.database[*].cidr_block
+  value       = compact(aws_subnet.database[*].cidr_block)
 }
 
 output "database_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of database subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.database[*].ipv6_cidr_block
+  value       = compact(aws_subnet.database[*].ipv6_cidr_block)
 }
 
 output "database_subnet_group" {
@@ -170,12 +170,12 @@ output "redshift_subnet_arns" {
 
 output "redshift_subnets_cidr_blocks" {
   description = "List of cidr_blocks of redshift subnets"
-  value       = aws_subnet.redshift[*].cidr_block
+  value       = compact(aws_subnet.redshift[*].cidr_block)
 }
 
 output "redshift_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of redshift subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.redshift[*].ipv6_cidr_block
+  value       = compact(aws_subnet.redshift[*].ipv6_cidr_block)
 }
 
 output "redshift_subnet_group" {
@@ -195,12 +195,12 @@ output "elasticache_subnet_arns" {
 
 output "elasticache_subnets_cidr_blocks" {
   description = "List of cidr_blocks of elasticache subnets"
-  value       = aws_subnet.elasticache[*].cidr_block
+  value       = compact(aws_subnet.elasticache[*].cidr_block)
 }
 
 output "elasticache_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of elasticache subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.elasticache[*].ipv6_cidr_block
+  value       = compact(aws_subnet.elasticache[*].ipv6_cidr_block)
 }
 
 output "intra_subnets" {
@@ -215,12 +215,12 @@ output "intra_subnet_arns" {
 
 output "intra_subnets_cidr_blocks" {
   description = "List of cidr_blocks of intra subnets"
-  value       = aws_subnet.intra[*].cidr_block
+  value       = compact(aws_subnet.intra[*].cidr_block)
 }
 
 output "intra_subnets_ipv6_cidr_blocks" {
   description = "List of IPv6 cidr_blocks of intra subnets in an IPv6 enabled VPC"
-  value       = aws_subnet.intra[*].ipv6_cidr_block
+  value       = compact(aws_subnet.intra[*].ipv6_cidr_block)
 }
 
 output "elasticache_subnet_group" {


### PR DESCRIPTION
## Description
- Compact CIDR block outputs to avoid empty diffs

## Motivation and Context
- Closes #743 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
