### PR TITLE
fix: Fix for default security group loop

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -73,6 +73,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_vpc_endpoint_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 
 ## Inputs


### PR DESCRIPTION
## Description
This change introduces a data source to look up the default security group of the vpc that the endpoint will be deployed into. The default security group is then explicitly associated with the endpoint if no other security groups are passed into the module, or found by the lookup function. This resolves the issue of terraform wanting to make changes on every apply, as described in the linked issue below.

## Motivation and Context
This is to fix what's described in https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/803

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

The vpc in the complete example was deployed prior to making my change. Terraform apply was run again after making my change, and terraform detected no changes to make.

Locally, I also deployed the simple-vpc example with the below endpoint configuration added to it

```
module "vpc_endpoints" {
  source = "../../modules/vpc-endpoints"

  vpc_id = module.vpc.vpc_id

  endpoints = {
    s3 = {
      service = "s3"
      tags    = { Name = "s3-vpc-endpoint" }
    }
  }

  tags = {
    Owner       = "user"
    Environment = "dev"
  }
}
```

I ran terraform apply again and was able to reproduce the problem described in the linked issue. After adding my change and running a terraform apply, no changes were detected, which is the expected behaviour.

- [x] I have executed `pre-commit run -a` on my pull request

