### PR TITLE
fix: Move cgw_id and cgw_arns to output map

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_azs"></a> [azs](#output\_azs) | A list of availability zones specified as argument to this module |
-| <a name="output_cgw_arns"></a> [cgw\_arns](#output\_cgw\_arns) | List of ARNs of Customer Gateway |
-| <a name="output_cgw_ids"></a> [cgw\_ids](#output\_cgw\_ids) | List of IDs of Customer Gateway |
+| <a name="output_cgw_arns"></a> [cgw\_arns](#output\_cgw\_arns) | Map of ARNs of Customer Gateway |
+| <a name="output_cgw_ids"></a> [cgw\_ids](#output\_cgw\_ids) | List of ARNs of Customer Gateway |
 | <a name="output_database_internet_gateway_route_id"></a> [database\_internet\_gateway\_route\_id](#output\_database\_internet\_gateway\_route\_id) | ID of the database internet gateway route |
 | <a name="output_database_ipv6_egress_route_id"></a> [database\_ipv6\_egress\_route\_id](#output\_database\_ipv6\_egress\_route\_id) | ID of the database IPv6 egress route |
 | <a name="output_database_nat_gateway_route_ids"></a> [database\_nat\_gateway\_route\_ids](#output\_database\_nat\_gateway\_route\_ids) | List of IDs of the database nat gateway route |
@@ -507,7 +507,7 @@ No modules.
 | <a name="output_default_vpc_instance_tenancy"></a> [default\_vpc\_instance\_tenancy](#output\_default\_vpc\_instance\_tenancy) | Tenancy of instances spin up within Default VPC |
 | <a name="output_default_vpc_main_route_table_id"></a> [default\_vpc\_main\_route\_table\_id](#output\_default\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with the Default VPC |
 | <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | The ID of the DHCP options |
-| <a name="output_egress_only_internet_gateway_id"></a> [egress\_only\_internet\_gateway\_id](#output\_egress\_only\_internet\_gateway\_id) | The ID of the egress only Internet Gateway |
+| <a name="output_egress_only_internet_gateway_id"></a> [egress\_only\_internet\_gateway\_id](#output\_egress\_only\_internet\_gateway\_id) | List of IDs of Customer Gateway |
 | <a name="output_elasticache_network_acl_arn"></a> [elasticache\_network\_acl\_arn](#output\_elasticache\_network\_acl\_arn) | ARN of the elasticache network ACL |
 | <a name="output_elasticache_network_acl_id"></a> [elasticache\_network\_acl\_id](#output\_elasticache\_network\_acl\_id) | ID of the elasticache network ACL |
 | <a name="output_elasticache_route_table_association_ids"></a> [elasticache\_route\_table\_association\_ids](#output\_elasticache\_route\_table\_association\_ids) | List of IDs of the elasticache route table association |
@@ -568,7 +568,7 @@ No modules.
 | <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of redshift subnets |
 | <a name="output_redshift_subnets_cidr_blocks"></a> [redshift\_subnets\_cidr\_blocks](#output\_redshift\_subnets\_cidr\_blocks) | List of cidr\_blocks of redshift subnets |
 | <a name="output_redshift_subnets_ipv6_cidr_blocks"></a> [redshift\_subnets\_ipv6\_cidr\_blocks](#output\_redshift\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of redshift subnets in an IPv6 enabled VPC |
-| <a name="output_this_customer_gateway"></a> [this\_customer\_gateway](#output\_this\_customer\_gateway) | Map of Customer Gateway attributes |
+| <a name="output_this_customer_gateway"></a> [this\_customer\_gateway](#output\_this\_customer\_gateway) | Map of attribute maps for all customer gateways created |
 | <a name="output_vgw_arn"></a> [vgw\_arn](#output\_vgw\_arn) | The ARN of the VPN Gateway |
 | <a name="output_vgw_id"></a> [vgw\_id](#output\_vgw\_id) | The ID of the VPN Gateway |
 | <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | The ARN of the VPC |

--- a/outputs.tf
+++ b/outputs.tf
@@ -364,22 +364,22 @@ output "igw_arn" {
 }
 
 output "egress_only_internet_gateway_id" {
-  description = "The ID of the egress only Internet Gateway"
+  description = "List of IDs of Customer Gateway"
   value       = try(aws_egress_only_internet_gateway.this[0].id, "")
 }
 
 output "cgw_ids" {
-  description = "List of IDs of Customer Gateway"
+  description = "List of ARNs of Customer Gateway"
   value       = [for k, v in aws_customer_gateway.this : v.id]
 }
 
 output "cgw_arns" {
-  description = "List of ARNs of Customer Gateway"
+  description = "Map of ARNs of Customer Gateway"
   value       = [for k, v in aws_customer_gateway.this : v.arn]
 }
 
 output "this_customer_gateway" {
-  description = "Map of Customer Gateway attributes"
+  description = "Map of attribute maps for all customer gateways created"
   value       = aws_customer_gateway.this
 }
 


### PR DESCRIPTION
## Description
In the outputs for this module, I have changed cgw_ids and cgw_arns to be maps instead of lists. This is due to issue - 
[765](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/765#issue-1165166357) Where the user explains you pass in a map and a list is output. The `customer_gateways` input, if changed will cause issues with the ordering of the cgw_ids and cgw_arns a map would resolve the issue with ordering changes.

## Motivation and Context
Solving the following issue - 
[765](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/765#issue-1165166357) 

## Breaking Changes
This will mean everyone who uses this module will need to adapt how they refer to the following outputs
- cgw_ids
- cgw_arns

## How Has This Been Tested?
locally with commit hooks and planning the simple-vpc
- [x] I have executed `pre-commit run -a` on my pull request