### PR TITLE
fix: Allow `security_group_ids` to take `null` values

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -26,7 +26,7 @@ resource "aws_vpc_endpoint" "this" {
   vpc_endpoint_type = lookup(each.value, "service_type", "Interface")
   auto_accept       = lookup(each.value, "auto_accept", null)
 
-  security_group_ids  = lookup(each.value, "service_type", "Interface") == "Interface" ? distinct(concat(var.security_group_ids, lookup(each.value, "security_group_ids", []))) : null
+  security_group_ids  = lookup(each.value, "service_type", "Interface") == "Interface" ? length(distinct(concat(var.security_group_ids, lookup(each.value, "security_group_ids", [])))) > 0 ? distinct(concat(var.security_group_ids, lookup(each.value, "security_group_ids", []))) : null : null
   subnet_ids          = lookup(each.value, "service_type", "Interface") == "Interface" ? distinct(concat(var.subnet_ids, lookup(each.value, "subnet_ids", []))) : null
   route_table_ids     = lookup(each.value, "service_type", "Interface") == "Gateway" ? lookup(each.value, "route_table_ids", null) : null
   policy              = lookup(each.value, "policy", null)


### PR DESCRIPTION
## Description
Allow the `security_group_ids` argument to `aws_vpc_endpoint` to take `null` values when the endpoint is of Interface type

## Motivation and Context
When defining a VPC endpoint of type Interface, if no `security_group_ids` are defined either as defaults or in the individual endpoint definition, the value passed to the `aws_vpc_endpoint` resource is an empty list.

This PR modifies that behaviour so that if no `security_group_ids` are defined, the `aws_vpc_endpoint` receives a `null` value instead of an empty list. Semantically, it makes no difference and it causes the default security group to be associated with the endpoint. However, functionally, a `null` value enables the use of `aws_vpc_endpoint_security_group_association` resources without triggering changes on the `aws_vpc_endpoint` resource.

## How Has This Been Tested?
I have tested this changes against an environment where the side effects that this change addresses were occuring
