### PR TITLE
feat: Add support for IPAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ No modules.
 | <a name="input_database_subnet_suffix"></a> [database\_subnet\_suffix](#input\_database\_subnet\_suffix) | Suffix to append to database subnets name | `string` | `"db"` | no |
 | <a name="input_database_subnet_tags"></a> [database\_subnet\_tags](#input\_database\_subnet\_tags) | Additional tags for the database subnets | `map(string)` | `{}` | no |
 | <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | A list of database subnets | `list(string)` | `[]` | no |
+| <a name="input_database_subnets_indexes"></a> [database\_subnets\_indexes](#input\_database\_subnets\_indexes) | A list of indexes for the database subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_default_network_acl_egress"></a> [default\_network\_acl\_egress](#input\_default\_network\_acl\_egress) | List of maps of egress rules to set on the Default Network ACL | `list(map(string))` | <pre>[<br>  {<br>    "action": "allow",<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_no": 100,<br>    "to_port": 0<br>  },<br>  {<br>    "action": "allow",<br>    "from_port": 0,<br>    "ipv6_cidr_block": "::/0",<br>    "protocol": "-1",<br>    "rule_no": 101,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | <a name="input_default_network_acl_ingress"></a> [default\_network\_acl\_ingress](#input\_default\_network\_acl\_ingress) | List of maps of ingress rules to set on the Default Network ACL | `list(map(string))` | <pre>[<br>  {<br>    "action": "allow",<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_no": 100,<br>    "to_port": 0<br>  },<br>  {<br>    "action": "allow",<br>    "from_port": 0,<br>    "ipv6_cidr_block": "::/0",<br>    "protocol": "-1",<br>    "rule_no": 101,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | <a name="input_default_network_acl_name"></a> [default\_network\_acl\_name](#input\_default\_network\_acl\_name) | Name to be used on the Default Network ACL | `string` | `null` | no |
@@ -369,6 +370,7 @@ No modules.
 | <a name="input_elasticache_subnet_suffix"></a> [elasticache\_subnet\_suffix](#input\_elasticache\_subnet\_suffix) | Suffix to append to elasticache subnets name | `string` | `"elasticache"` | no |
 | <a name="input_elasticache_subnet_tags"></a> [elasticache\_subnet\_tags](#input\_elasticache\_subnet\_tags) | Additional tags for the elasticache subnets | `map(string)` | `{}` | no |
 | <a name="input_elasticache_subnets"></a> [elasticache\_subnets](#input\_elasticache\_subnets) | A list of elasticache subnets | `list(string)` | `[]` | no |
+| <a name="input_elasticache_subnets_indexes"></a> [elasticache\_subnets\_indexes](#input\_elasticache\_subnets\_indexes) | A list of indexes for the elasticache subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_enable_classiclink"></a> [enable\_classiclink](#input\_enable\_classiclink) | [DEPRECATED](https://github.com/hashicorp/terraform/issues/31730) Should be true to enable ClassicLink for the VPC. Only valid in regions and accounts that support EC2 Classic. | `bool` | `null` | no |
 | <a name="input_enable_classiclink_dns_support"></a> [enable\_classiclink\_dns\_support](#input\_enable\_classiclink\_dns\_support) | [DEPRECATED](https://github.com/hashicorp/terraform/issues/31730) Should be true to enable ClassicLink DNS Support for the VPC. Only valid in regions and accounts that support EC2 Classic. | `bool` | `null` | no |
 | <a name="input_enable_dhcp_options"></a> [enable\_dhcp\_options](#input\_enable\_dhcp\_options) | Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type | `bool` | `false` | no |
@@ -405,6 +407,9 @@ No modules.
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
+| <a name="input_intra_subnets_indexes"></a> [intra\_subnets\_indexes](#input\_intra\_subnets\_indexes) | A list of indexes for the intra subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
+| <a name="input_ipv4_ipam_pool_id"></a> [ipv4\_ipam\_pool\_id](#input\_ipv4\_ipam\_pool\_id) | The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. | `string` | `""` | no |
+| <a name="input_ipv4_netmask_length"></a> [ipv4\_netmask\_length](#input\_ipv4\_netmask\_length) | The netmask length of the IPv4 CIDR you want to allocate to this VPC. Only used when IPAM is enabled. | `number` | `null` | no |
 | <a name="input_manage_default_network_acl"></a> [manage\_default\_network\_acl](#input\_manage\_default\_network\_acl) | Should be true to adopt and manage Default Network ACL | `bool` | `false` | no |
 | <a name="input_manage_default_route_table"></a> [manage\_default\_route\_table](#input\_manage\_default\_route\_table) | Should be true to manage default route table | `bool` | `false` | no |
 | <a name="input_manage_default_security_group"></a> [manage\_default\_security\_group](#input\_manage\_default\_security\_group) | Should be true to adopt and manage default security group | `bool` | `false` | no |
@@ -426,6 +431,7 @@ No modules.
 | <a name="input_outpost_subnet_suffix"></a> [outpost\_subnet\_suffix](#input\_outpost\_subnet\_suffix) | Suffix to append to outpost subnets name | `string` | `"outpost"` | no |
 | <a name="input_outpost_subnet_tags"></a> [outpost\_subnet\_tags](#input\_outpost\_subnet\_tags) | Additional tags for the outpost subnets | `map(string)` | `{}` | no |
 | <a name="input_outpost_subnets"></a> [outpost\_subnets](#input\_outpost\_subnets) | A list of outpost subnets inside the VPC | `list(string)` | `[]` | no |
+| <a name="input_outpost_subnets_indexes"></a> [outpost\_subnets\_indexes](#input\_outpost\_subnets\_indexes) | A list of indexes for the outpost subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_private_acl_tags"></a> [private\_acl\_tags](#input\_private\_acl\_tags) | Additional tags for the private subnets network ACL | `map(string)` | `{}` | no |
 | <a name="input_private_dedicated_network_acl"></a> [private\_dedicated\_network\_acl](#input\_private\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for private subnets | `bool` | `false` | no |
 | <a name="input_private_inbound_acl_rules"></a> [private\_inbound\_acl\_rules](#input\_private\_inbound\_acl\_rules) | Private subnets inbound network ACLs | `list(map(string))` | <pre>[<br>  {<br>    "cidr_block": "0.0.0.0/0",<br>    "from_port": 0,<br>    "protocol": "-1",<br>    "rule_action": "allow",<br>    "rule_number": 100,<br>    "to_port": 0<br>  }<br>]</pre> | no |
@@ -436,6 +442,7 @@ No modules.
 | <a name="input_private_subnet_suffix"></a> [private\_subnet\_suffix](#input\_private\_subnet\_suffix) | Suffix to append to private subnets name | `string` | `"private"` | no |
 | <a name="input_private_subnet_tags"></a> [private\_subnet\_tags](#input\_private\_subnet\_tags) | Additional tags for the private subnets | `map(string)` | `{}` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
+| <a name="input_private_subnets_indexes"></a> [private\_subnets\_indexes](#input\_private\_subnets\_indexes) | A list of indexes for the private subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_propagate_intra_route_tables_vgw"></a> [propagate\_intra\_route\_tables\_vgw](#input\_propagate\_intra\_route\_tables\_vgw) | Should be true if you want route table propagation | `bool` | `false` | no |
 | <a name="input_propagate_private_route_tables_vgw"></a> [propagate\_private\_route\_tables\_vgw](#input\_propagate\_private\_route\_tables\_vgw) | Should be true if you want route table propagation | `bool` | `false` | no |
 | <a name="input_propagate_public_route_tables_vgw"></a> [propagate\_public\_route\_tables\_vgw](#input\_propagate\_public\_route\_tables\_vgw) | Should be true if you want route table propagation | `bool` | `false` | no |
@@ -449,6 +456,7 @@ No modules.
 | <a name="input_public_subnet_suffix"></a> [public\_subnet\_suffix](#input\_public\_subnet\_suffix) | Suffix to append to public subnets name | `string` | `"public"` | no |
 | <a name="input_public_subnet_tags"></a> [public\_subnet\_tags](#input\_public\_subnet\_tags) | Additional tags for the public subnets | `map(string)` | `{}` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
+| <a name="input_public_subnets_indexes"></a> [public\_subnets\_indexes](#input\_public\_subnets\_indexes) | A list of indexes for the public subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_redshift_acl_tags"></a> [redshift\_acl\_tags](#input\_redshift\_acl\_tags) | Additional tags for the redshift subnets network ACL | `map(string)` | `{}` | no |
 | <a name="input_redshift_dedicated_network_acl"></a> [redshift\_dedicated\_network\_acl](#input\_redshift\_dedicated\_network\_acl) | Whether to use dedicated network ACL (not default) and custom rules for redshift subnets | `bool` | `false` | no |
@@ -462,6 +470,7 @@ No modules.
 | <a name="input_redshift_subnet_suffix"></a> [redshift\_subnet\_suffix](#input\_redshift\_subnet\_suffix) | Suffix to append to redshift subnets name | `string` | `"redshift"` | no |
 | <a name="input_redshift_subnet_tags"></a> [redshift\_subnet\_tags](#input\_redshift\_subnet\_tags) | Additional tags for the redshift subnets | `map(string)` | `{}` | no |
 | <a name="input_redshift_subnets"></a> [redshift\_subnets](#input\_redshift\_subnets) | A list of redshift subnets | `list(string)` | `[]` | no |
+| <a name="input_redshift_subnets_indexes"></a> [redshift\_subnets\_indexes](#input\_redshift\_subnets\_indexes) | A list of indexes for the redshift subnets. Only used when IPAM is enabled. | `list(number)` | `[]` | no |
 | <a name="input_reuse_nat_ips"></a> [reuse\_nat\_ips](#input\_reuse\_nat\_ips) | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |

--- a/examples/ipam/README.md
+++ b/examples/ipam/README.md
@@ -1,0 +1,159 @@
+# IPAM VPC
+
+Configuration in this directory creates a set of VPC resources that integrated with AWS IPAM for dynamic allocation of IP addresses.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_vpc_ipam.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam) | resource |
+| [aws_vpc_ipam_pool.top_level](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool) | resource |
+| [aws_vpc_ipam_pool_cidr.top_level](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool_cidr) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cgw_arns"></a> [cgw\_arns](#output\_cgw\_arns) | List of ARNs of Customer Gateway |
+| <a name="output_cgw_ids"></a> [cgw\_ids](#output\_cgw\_ids) | List of IDs of Customer Gateway |
+| <a name="output_database_internet_gateway_route_id"></a> [database\_internet\_gateway\_route\_id](#output\_database\_internet\_gateway\_route\_id) | ID of the database internet gateway route |
+| <a name="output_database_ipv6_egress_route_id"></a> [database\_ipv6\_egress\_route\_id](#output\_database\_ipv6\_egress\_route\_id) | ID of the database IPv6 egress route |
+| <a name="output_database_nat_gateway_route_ids"></a> [database\_nat\_gateway\_route\_ids](#output\_database\_nat\_gateway\_route\_ids) | List of IDs of the database nat gateway route |
+| <a name="output_database_network_acl_arn"></a> [database\_network\_acl\_arn](#output\_database\_network\_acl\_arn) | ARN of the database network ACL |
+| <a name="output_database_network_acl_id"></a> [database\_network\_acl\_id](#output\_database\_network\_acl\_id) | ID of the database network ACL |
+| <a name="output_database_route_table_association_ids"></a> [database\_route\_table\_association\_ids](#output\_database\_route\_table\_association\_ids) | List of IDs of the database route table association |
+| <a name="output_database_route_table_ids"></a> [database\_route\_table\_ids](#output\_database\_route\_table\_ids) | List of IDs of database route tables |
+| <a name="output_database_subnet_arns"></a> [database\_subnet\_arns](#output\_database\_subnet\_arns) | List of ARNs of database subnets |
+| <a name="output_database_subnet_group"></a> [database\_subnet\_group](#output\_database\_subnet\_group) | ID of database subnet group |
+| <a name="output_database_subnet_group_name"></a> [database\_subnet\_group\_name](#output\_database\_subnet\_group\_name) | Name of database subnet group |
+| <a name="output_database_subnets"></a> [database\_subnets](#output\_database\_subnets) | List of IDs of database subnets |
+| <a name="output_database_subnets_cidr_blocks"></a> [database\_subnets\_cidr\_blocks](#output\_database\_subnets\_cidr\_blocks) | List of cidr\_blocks of database subnets |
+| <a name="output_database_subnets_ipv6_cidr_blocks"></a> [database\_subnets\_ipv6\_cidr\_blocks](#output\_database\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of database subnets in an IPv6 enabled VPC |
+| <a name="output_default_network_acl_id"></a> [default\_network\_acl\_id](#output\_default\_network\_acl\_id) | The ID of the default network ACL |
+| <a name="output_default_route_table_id"></a> [default\_route\_table\_id](#output\_default\_route\_table\_id) | The ID of the default route table |
+| <a name="output_default_security_group_id"></a> [default\_security\_group\_id](#output\_default\_security\_group\_id) | The ID of the security group created by default on VPC creation |
+| <a name="output_default_vpc_arn"></a> [default\_vpc\_arn](#output\_default\_vpc\_arn) | The ARN of the Default VPC |
+| <a name="output_default_vpc_cidr_block"></a> [default\_vpc\_cidr\_block](#output\_default\_vpc\_cidr\_block) | The CIDR block of the Default VPC |
+| <a name="output_default_vpc_default_network_acl_id"></a> [default\_vpc\_default\_network\_acl\_id](#output\_default\_vpc\_default\_network\_acl\_id) | The ID of the default network ACL of the Default VPC |
+| <a name="output_default_vpc_default_route_table_id"></a> [default\_vpc\_default\_route\_table\_id](#output\_default\_vpc\_default\_route\_table\_id) | The ID of the default route table of the Default VPC |
+| <a name="output_default_vpc_default_security_group_id"></a> [default\_vpc\_default\_security\_group\_id](#output\_default\_vpc\_default\_security\_group\_id) | The ID of the security group created by default on Default VPC creation |
+| <a name="output_default_vpc_enable_dns_hostnames"></a> [default\_vpc\_enable\_dns\_hostnames](#output\_default\_vpc\_enable\_dns\_hostnames) | Whether or not the Default VPC has DNS hostname support |
+| <a name="output_default_vpc_enable_dns_support"></a> [default\_vpc\_enable\_dns\_support](#output\_default\_vpc\_enable\_dns\_support) | Whether or not the Default VPC has DNS support |
+| <a name="output_default_vpc_id"></a> [default\_vpc\_id](#output\_default\_vpc\_id) | The ID of the Default VPC |
+| <a name="output_default_vpc_instance_tenancy"></a> [default\_vpc\_instance\_tenancy](#output\_default\_vpc\_instance\_tenancy) | Tenancy of instances spin up within Default VPC |
+| <a name="output_default_vpc_main_route_table_id"></a> [default\_vpc\_main\_route\_table\_id](#output\_default\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with the Default VPC |
+| <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | The ID of the DHCP options |
+| <a name="output_egress_only_internet_gateway_id"></a> [egress\_only\_internet\_gateway\_id](#output\_egress\_only\_internet\_gateway\_id) | The ID of the egress only Internet Gateway |
+| <a name="output_elasticache_network_acl_arn"></a> [elasticache\_network\_acl\_arn](#output\_elasticache\_network\_acl\_arn) | ARN of the elasticache network ACL |
+| <a name="output_elasticache_network_acl_id"></a> [elasticache\_network\_acl\_id](#output\_elasticache\_network\_acl\_id) | ID of the elasticache network ACL |
+| <a name="output_elasticache_route_table_association_ids"></a> [elasticache\_route\_table\_association\_ids](#output\_elasticache\_route\_table\_association\_ids) | List of IDs of the elasticache route table association |
+| <a name="output_elasticache_route_table_ids"></a> [elasticache\_route\_table\_ids](#output\_elasticache\_route\_table\_ids) | List of IDs of elasticache route tables |
+| <a name="output_elasticache_subnet_arns"></a> [elasticache\_subnet\_arns](#output\_elasticache\_subnet\_arns) | List of ARNs of elasticache subnets |
+| <a name="output_elasticache_subnet_group"></a> [elasticache\_subnet\_group](#output\_elasticache\_subnet\_group) | ID of elasticache subnet group |
+| <a name="output_elasticache_subnet_group_name"></a> [elasticache\_subnet\_group\_name](#output\_elasticache\_subnet\_group\_name) | Name of elasticache subnet group |
+| <a name="output_elasticache_subnets"></a> [elasticache\_subnets](#output\_elasticache\_subnets) | List of IDs of elasticache subnets |
+| <a name="output_elasticache_subnets_cidr_blocks"></a> [elasticache\_subnets\_cidr\_blocks](#output\_elasticache\_subnets\_cidr\_blocks) | List of cidr\_blocks of elasticache subnets |
+| <a name="output_elasticache_subnets_ipv6_cidr_blocks"></a> [elasticache\_subnets\_ipv6\_cidr\_blocks](#output\_elasticache\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of elasticache subnets in an IPv6 enabled VPC |
+| <a name="output_igw_arn"></a> [igw\_arn](#output\_igw\_arn) | The ARN of the Internet Gateway |
+| <a name="output_igw_id"></a> [igw\_id](#output\_igw\_id) | The ID of the Internet Gateway |
+| <a name="output_intra_network_acl_arn"></a> [intra\_network\_acl\_arn](#output\_intra\_network\_acl\_arn) | ARN of the intra network ACL |
+| <a name="output_intra_network_acl_id"></a> [intra\_network\_acl\_id](#output\_intra\_network\_acl\_id) | ID of the intra network ACL |
+| <a name="output_intra_route_table_association_ids"></a> [intra\_route\_table\_association\_ids](#output\_intra\_route\_table\_association\_ids) | List of IDs of the intra route table association |
+| <a name="output_intra_route_table_ids"></a> [intra\_route\_table\_ids](#output\_intra\_route\_table\_ids) | List of IDs of intra route tables |
+| <a name="output_intra_subnet_arns"></a> [intra\_subnet\_arns](#output\_intra\_subnet\_arns) | List of ARNs of intra subnets |
+| <a name="output_intra_subnets"></a> [intra\_subnets](#output\_intra\_subnets) | List of IDs of intra subnets |
+| <a name="output_intra_subnets_cidr_blocks"></a> [intra\_subnets\_cidr\_blocks](#output\_intra\_subnets\_cidr\_blocks) | List of cidr\_blocks of intra subnets |
+| <a name="output_intra_subnets_ipv6_cidr_blocks"></a> [intra\_subnets\_ipv6\_cidr\_blocks](#output\_intra\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of intra subnets in an IPv6 enabled VPC |
+| <a name="output_nat_ids"></a> [nat\_ids](#output\_nat\_ids) | List of allocation ID of Elastic IPs created for AWS NAT Gateway |
+| <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
+| <a name="output_natgw_ids"></a> [natgw\_ids](#output\_natgw\_ids) | List of NAT Gateway IDs |
+| <a name="output_outpost_network_acl_arn"></a> [outpost\_network\_acl\_arn](#output\_outpost\_network\_acl\_arn) | ARN of the outpost network ACL |
+| <a name="output_outpost_network_acl_id"></a> [outpost\_network\_acl\_id](#output\_outpost\_network\_acl\_id) | ID of the outpost network ACL |
+| <a name="output_outpost_subnet_arns"></a> [outpost\_subnet\_arns](#output\_outpost\_subnet\_arns) | List of ARNs of outpost subnets |
+| <a name="output_outpost_subnets"></a> [outpost\_subnets](#output\_outpost\_subnets) | List of IDs of outpost subnets |
+| <a name="output_outpost_subnets_cidr_blocks"></a> [outpost\_subnets\_cidr\_blocks](#output\_outpost\_subnets\_cidr\_blocks) | List of cidr\_blocks of outpost subnets |
+| <a name="output_outpost_subnets_ipv6_cidr_blocks"></a> [outpost\_subnets\_ipv6\_cidr\_blocks](#output\_outpost\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of outpost subnets in an IPv6 enabled VPC |
+| <a name="output_private_ipv6_egress_route_ids"></a> [private\_ipv6\_egress\_route\_ids](#output\_private\_ipv6\_egress\_route\_ids) | List of IDs of the ipv6 egress route |
+| <a name="output_private_nat_gateway_route_ids"></a> [private\_nat\_gateway\_route\_ids](#output\_private\_nat\_gateway\_route\_ids) | List of IDs of the private nat gateway route |
+| <a name="output_private_network_acl_arn"></a> [private\_network\_acl\_arn](#output\_private\_network\_acl\_arn) | ARN of the private network ACL |
+| <a name="output_private_network_acl_id"></a> [private\_network\_acl\_id](#output\_private\_network\_acl\_id) | ID of the private network ACL |
+| <a name="output_private_route_table_association_ids"></a> [private\_route\_table\_association\_ids](#output\_private\_route\_table\_association\_ids) | List of IDs of the private route table association |
+| <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | List of IDs of private route tables |
+| <a name="output_private_subnet_arns"></a> [private\_subnet\_arns](#output\_private\_subnet\_arns) | List of ARNs of private subnets |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
+| <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets |
+| <a name="output_private_subnets_ipv6_cidr_blocks"></a> [private\_subnets\_ipv6\_cidr\_blocks](#output\_private\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of private subnets in an IPv6 enabled VPC |
+| <a name="output_public_internet_gateway_ipv6_route_id"></a> [public\_internet\_gateway\_ipv6\_route\_id](#output\_public\_internet\_gateway\_ipv6\_route\_id) | ID of the IPv6 internet gateway route |
+| <a name="output_public_internet_gateway_route_id"></a> [public\_internet\_gateway\_route\_id](#output\_public\_internet\_gateway\_route\_id) | ID of the internet gateway route |
+| <a name="output_public_network_acl_arn"></a> [public\_network\_acl\_arn](#output\_public\_network\_acl\_arn) | ARN of the public network ACL |
+| <a name="output_public_network_acl_id"></a> [public\_network\_acl\_id](#output\_public\_network\_acl\_id) | ID of the public network ACL |
+| <a name="output_public_route_table_association_ids"></a> [public\_route\_table\_association\_ids](#output\_public\_route\_table\_association\_ids) | List of IDs of the public route table association |
+| <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | List of IDs of public route tables |
+| <a name="output_public_subnet_arns"></a> [public\_subnet\_arns](#output\_public\_subnet\_arns) | List of ARNs of public subnets |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
+| <a name="output_public_subnets_cidr_blocks"></a> [public\_subnets\_cidr\_blocks](#output\_public\_subnets\_cidr\_blocks) | List of cidr\_blocks of public subnets |
+| <a name="output_public_subnets_ipv6_cidr_blocks"></a> [public\_subnets\_ipv6\_cidr\_blocks](#output\_public\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of public subnets in an IPv6 enabled VPC |
+| <a name="output_redshift_network_acl_arn"></a> [redshift\_network\_acl\_arn](#output\_redshift\_network\_acl\_arn) | ARN of the redshift network ACL |
+| <a name="output_redshift_network_acl_id"></a> [redshift\_network\_acl\_id](#output\_redshift\_network\_acl\_id) | ID of the redshift network ACL |
+| <a name="output_redshift_public_route_table_association_ids"></a> [redshift\_public\_route\_table\_association\_ids](#output\_redshift\_public\_route\_table\_association\_ids) | List of IDs of the public redshidt route table association |
+| <a name="output_redshift_route_table_association_ids"></a> [redshift\_route\_table\_association\_ids](#output\_redshift\_route\_table\_association\_ids) | List of IDs of the redshift route table association |
+| <a name="output_redshift_route_table_ids"></a> [redshift\_route\_table\_ids](#output\_redshift\_route\_table\_ids) | List of IDs of redshift route tables |
+| <a name="output_redshift_subnet_arns"></a> [redshift\_subnet\_arns](#output\_redshift\_subnet\_arns) | List of ARNs of redshift subnets |
+| <a name="output_redshift_subnet_group"></a> [redshift\_subnet\_group](#output\_redshift\_subnet\_group) | ID of redshift subnet group |
+| <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of redshift subnets |
+| <a name="output_redshift_subnets_cidr_blocks"></a> [redshift\_subnets\_cidr\_blocks](#output\_redshift\_subnets\_cidr\_blocks) | List of cidr\_blocks of redshift subnets |
+| <a name="output_redshift_subnets_ipv6_cidr_blocks"></a> [redshift\_subnets\_ipv6\_cidr\_blocks](#output\_redshift\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of redshift subnets in an IPv6 enabled VPC |
+| <a name="output_this_customer_gateway"></a> [this\_customer\_gateway](#output\_this\_customer\_gateway) | Map of Customer Gateway attributes |
+| <a name="output_vgw_arn"></a> [vgw\_arn](#output\_vgw\_arn) | The ARN of the VPN Gateway |
+| <a name="output_vgw_id"></a> [vgw\_id](#output\_vgw\_id) | The ID of the VPN Gateway |
+| <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | The ARN of the VPC |
+| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
+| <a name="output_vpc_enable_dns_hostnames"></a> [vpc\_enable\_dns\_hostnames](#output\_vpc\_enable\_dns\_hostnames) | Whether or not the VPC has DNS hostname support |
+| <a name="output_vpc_enable_dns_support"></a> [vpc\_enable\_dns\_support](#output\_vpc\_enable\_dns\_support) | Whether or not the VPC has DNS support |
+| <a name="output_vpc_flow_log_cloudwatch_iam_role_arn"></a> [vpc\_flow\_log\_cloudwatch\_iam\_role\_arn](#output\_vpc\_flow\_log\_cloudwatch\_iam\_role\_arn) | The ARN of the IAM role used when pushing logs to Cloudwatch log group |
+| <a name="output_vpc_flow_log_destination_arn"></a> [vpc\_flow\_log\_destination\_arn](#output\_vpc\_flow\_log\_destination\_arn) | The ARN of the destination for VPC Flow Logs |
+| <a name="output_vpc_flow_log_destination_type"></a> [vpc\_flow\_log\_destination\_type](#output\_vpc\_flow\_log\_destination\_type) | The type of the destination for VPC Flow Logs |
+| <a name="output_vpc_flow_log_id"></a> [vpc\_flow\_log\_id](#output\_vpc\_flow\_log\_id) | The ID of the Flow Log resource |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
+| <a name="output_vpc_instance_tenancy"></a> [vpc\_instance\_tenancy](#output\_vpc\_instance\_tenancy) | Tenancy of instances spin up within VPC |
+| <a name="output_vpc_ipv6_association_id"></a> [vpc\_ipv6\_association\_id](#output\_vpc\_ipv6\_association\_id) | The association ID for the IPv6 CIDR block |
+| <a name="output_vpc_ipv6_cidr_block"></a> [vpc\_ipv6\_cidr\_block](#output\_vpc\_ipv6\_cidr\_block) | The IPv6 CIDR block |
+| <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC |
+| <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC |
+| <a name="output_vpc_secondary_cidr_blocks"></a> [vpc\_secondary\_cidr\_blocks](#output\_vpc\_secondary\_cidr\_blocks) | List of secondary CIDR blocks of the VPC |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/ipam/main.tf
+++ b/examples/ipam/main.tf
@@ -1,0 +1,76 @@
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  region = "eu-west-1"
+}
+
+################################################################################
+# VPC Module
+################################################################################
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_ipam" "main" {
+  description = "My IPAM"
+  operating_regions {
+    region_name = data.aws_region.current.name
+  }
+
+  tags = {
+    Test = "Main"
+  }
+}
+
+resource "aws_vpc_ipam_pool" "top_level" {
+  description    = "top-level-pool"
+  address_family = "ipv4"
+  ipam_scope_id  = aws_vpc_ipam.main.private_default_scope_id
+
+  locale = data.aws_region.current.name
+}
+
+resource "aws_vpc_ipam_pool_cidr" "top_level" {
+  ipam_pool_id = aws_vpc_ipam_pool.top_level.id
+  cidr         = "10.0.0.0/8"
+}
+
+
+module "vpc" {
+  source = "../../"
+
+  name = "ipam-example"
+
+  cidr                = null
+  ipv4_ipam_pool_id   = aws_vpc_ipam_pool.top_level.id
+  ipv4_netmask_length = 16
+
+  azs                     = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets         = ["24", "24", "24"]
+  private_subnets_indexes = [0, 1, 2]
+
+  database_subnets         = ["24", "24"]
+  database_subnets_indexes = [3, 7]
+
+  public_subnets         = ["24", "24", "24"]
+  public_subnets_indexes = [4, 5, 6]
+
+  enable_ipv6 = false
+
+  enable_nat_gateway = false
+  single_nat_gateway = true
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+
+  vpc_tags = {
+    Name = "vpc-name"
+  }
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.top_level
+  ]
+}

--- a/examples/ipam/outputs.tf
+++ b/examples/ipam/outputs.tf
@@ -1,0 +1,535 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_arn" {
+  description = "The ARN of the VPC"
+  value       = module.vpc.vpc_arn
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "default_security_group_id" {
+  description = "The ID of the security group created by default on VPC creation"
+  value       = module.vpc.default_security_group_id
+}
+
+output "default_network_acl_id" {
+  description = "The ID of the default network ACL"
+  value       = module.vpc.default_network_acl_id
+}
+
+output "default_route_table_id" {
+  description = "The ID of the default route table"
+  value       = module.vpc.default_route_table_id
+}
+
+output "vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within VPC"
+  value       = module.vpc.vpc_instance_tenancy
+}
+
+output "vpc_enable_dns_support" {
+  description = "Whether or not the VPC has DNS support"
+  value       = module.vpc.vpc_enable_dns_support
+}
+
+output "vpc_enable_dns_hostnames" {
+  description = "Whether or not the VPC has DNS hostname support"
+  value       = module.vpc.vpc_enable_dns_hostnames
+}
+
+output "vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with this VPC"
+  value       = module.vpc.vpc_main_route_table_id
+}
+
+output "vpc_ipv6_association_id" {
+  description = "The association ID for the IPv6 CIDR block"
+  value       = module.vpc.vpc_ipv6_association_id
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = module.vpc.vpc_ipv6_cidr_block
+}
+
+output "vpc_secondary_cidr_blocks" {
+  description = "List of secondary CIDR blocks of the VPC"
+  value       = module.vpc.vpc_secondary_cidr_blocks
+}
+
+output "vpc_owner_id" {
+  description = "The ID of the AWS account that owns the VPC"
+  value       = module.vpc.vpc_owner_id
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "private_subnet_arns" {
+  description = "List of ARNs of private subnets"
+  value       = module.vpc.private_subnet_arns
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of private subnets"
+  value       = module.vpc.private_subnets_cidr_blocks
+}
+
+output "private_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
+  value       = module.vpc.private_subnets_ipv6_cidr_blocks
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "public_subnet_arns" {
+  description = "List of ARNs of public subnets"
+  value       = module.vpc.public_subnet_arns
+}
+
+output "public_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of public subnets"
+  value       = module.vpc.public_subnets_cidr_blocks
+}
+
+output "public_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
+  value       = module.vpc.public_subnets_ipv6_cidr_blocks
+}
+
+output "outpost_subnets" {
+  description = "List of IDs of outpost subnets"
+  value       = module.vpc.outpost_subnets
+}
+
+output "outpost_subnet_arns" {
+  description = "List of ARNs of outpost subnets"
+  value       = module.vpc.outpost_subnet_arns
+}
+
+output "outpost_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of outpost subnets"
+  value       = module.vpc.outpost_subnets_cidr_blocks
+}
+
+output "outpost_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of outpost subnets in an IPv6 enabled VPC"
+  value       = module.vpc.outpost_subnets_ipv6_cidr_blocks
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = module.vpc.database_subnets
+}
+
+output "database_subnet_arns" {
+  description = "List of ARNs of database subnets"
+  value       = module.vpc.database_subnet_arns
+}
+
+output "database_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of database subnets"
+  value       = module.vpc.database_subnets_cidr_blocks
+}
+
+output "database_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of database subnets in an IPv6 enabled VPC"
+  value       = module.vpc.database_subnets_ipv6_cidr_blocks
+}
+
+output "database_subnet_group" {
+  description = "ID of database subnet group"
+  value       = module.vpc.database_subnet_group
+}
+
+output "database_subnet_group_name" {
+  description = "Name of database subnet group"
+  value       = module.vpc.database_subnet_group_name
+}
+
+output "redshift_subnets" {
+  description = "List of IDs of redshift subnets"
+  value       = module.vpc.redshift_subnets
+}
+
+output "redshift_subnet_arns" {
+  description = "List of ARNs of redshift subnets"
+  value       = module.vpc.redshift_subnet_arns
+}
+
+output "redshift_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of redshift subnets"
+  value       = module.vpc.redshift_subnets_cidr_blocks
+}
+
+output "redshift_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of redshift subnets in an IPv6 enabled VPC"
+  value       = module.vpc.redshift_subnets_ipv6_cidr_blocks
+}
+
+output "redshift_subnet_group" {
+  description = "ID of redshift subnet group"
+  value       = module.vpc.redshift_subnet_group
+}
+
+output "elasticache_subnets" {
+  description = "List of IDs of elasticache subnets"
+  value       = module.vpc.elasticache_subnets
+}
+
+output "elasticache_subnet_arns" {
+  description = "List of ARNs of elasticache subnets"
+  value       = module.vpc.elasticache_subnet_arns
+}
+
+output "elasticache_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of elasticache subnets"
+  value       = module.vpc.elasticache_subnets_cidr_blocks
+}
+
+output "elasticache_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of elasticache subnets in an IPv6 enabled VPC"
+  value       = module.vpc.elasticache_subnets_ipv6_cidr_blocks
+}
+
+output "intra_subnets" {
+  description = "List of IDs of intra subnets"
+  value       = module.vpc.intra_subnets
+}
+
+output "intra_subnet_arns" {
+  description = "List of ARNs of intra subnets"
+  value       = module.vpc.intra_subnet_arns
+}
+
+output "intra_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of intra subnets"
+  value       = module.vpc.intra_subnets_cidr_blocks
+}
+
+output "intra_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of intra subnets in an IPv6 enabled VPC"
+  value       = module.vpc.intra_subnets_ipv6_cidr_blocks
+}
+
+output "elasticache_subnet_group" {
+  description = "ID of elasticache subnet group"
+  value       = module.vpc.elasticache_subnet_group
+}
+
+output "elasticache_subnet_group_name" {
+  description = "Name of elasticache subnet group"
+  value       = module.vpc.elasticache_subnet_group_name
+}
+
+output "public_route_table_ids" {
+  description = "List of IDs of public route tables"
+  value       = module.vpc.public_route_table_ids
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = module.vpc.private_route_table_ids
+}
+
+output "database_route_table_ids" {
+  description = "List of IDs of database route tables"
+  value       = module.vpc.database_route_table_ids
+}
+
+output "redshift_route_table_ids" {
+  description = "List of IDs of redshift route tables"
+  value       = module.vpc.redshift_route_table_ids
+}
+
+output "elasticache_route_table_ids" {
+  description = "List of IDs of elasticache route tables"
+  value       = module.vpc.elasticache_route_table_ids
+}
+
+output "intra_route_table_ids" {
+  description = "List of IDs of intra route tables"
+  value       = module.vpc.intra_route_table_ids
+}
+
+output "public_internet_gateway_route_id" {
+  description = "ID of the internet gateway route"
+  value       = module.vpc.public_internet_gateway_route_id
+}
+
+output "public_internet_gateway_ipv6_route_id" {
+  description = "ID of the IPv6 internet gateway route"
+  value       = module.vpc.public_internet_gateway_ipv6_route_id
+}
+
+output "database_internet_gateway_route_id" {
+  description = "ID of the database internet gateway route"
+  value       = module.vpc.database_internet_gateway_route_id
+}
+
+output "database_nat_gateway_route_ids" {
+  description = "List of IDs of the database nat gateway route"
+  value       = module.vpc.database_nat_gateway_route_ids
+}
+
+output "database_ipv6_egress_route_id" {
+  description = "ID of the database IPv6 egress route"
+  value       = module.vpc.database_ipv6_egress_route_id
+}
+
+output "private_nat_gateway_route_ids" {
+  description = "List of IDs of the private nat gateway route"
+  value       = module.vpc.private_nat_gateway_route_ids
+}
+
+output "private_ipv6_egress_route_ids" {
+  description = "List of IDs of the ipv6 egress route"
+  value       = module.vpc.private_ipv6_egress_route_ids
+}
+
+output "private_route_table_association_ids" {
+  description = "List of IDs of the private route table association"
+  value       = module.vpc.private_route_table_association_ids
+}
+
+output "database_route_table_association_ids" {
+  description = "List of IDs of the database route table association"
+  value       = module.vpc.database_route_table_association_ids
+}
+
+output "redshift_route_table_association_ids" {
+  description = "List of IDs of the redshift route table association"
+  value       = module.vpc.redshift_route_table_association_ids
+}
+
+output "redshift_public_route_table_association_ids" {
+  description = "List of IDs of the public redshidt route table association"
+  value       = module.vpc.redshift_public_route_table_association_ids
+}
+
+output "elasticache_route_table_association_ids" {
+  description = "List of IDs of the elasticache route table association"
+  value       = module.vpc.elasticache_route_table_association_ids
+}
+
+output "intra_route_table_association_ids" {
+  description = "List of IDs of the intra route table association"
+  value       = module.vpc.intra_route_table_association_ids
+}
+
+output "public_route_table_association_ids" {
+  description = "List of IDs of the public route table association"
+  value       = module.vpc.public_route_table_association_ids
+}
+
+output "dhcp_options_id" {
+  description = "The ID of the DHCP options"
+  value       = module.vpc.dhcp_options_id
+}
+
+output "nat_ids" {
+  description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
+  value       = module.vpc.nat_ids
+}
+
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = module.vpc.nat_public_ips
+}
+
+output "natgw_ids" {
+  description = "List of NAT Gateway IDs"
+  value       = module.vpc.natgw_ids
+}
+
+output "igw_id" {
+  description = "The ID of the Internet Gateway"
+  value       = module.vpc.igw_id
+}
+
+output "igw_arn" {
+  description = "The ARN of the Internet Gateway"
+  value       = module.vpc.igw_arn
+}
+
+output "egress_only_internet_gateway_id" {
+  description = "The ID of the egress only Internet Gateway"
+  value       = module.vpc.egress_only_internet_gateway_id
+}
+
+output "cgw_ids" {
+  description = "List of IDs of Customer Gateway"
+  value       = module.vpc.cgw_ids
+}
+
+output "cgw_arns" {
+  description = "List of ARNs of Customer Gateway"
+  value       = module.vpc.cgw_arns
+}
+
+output "this_customer_gateway" {
+  description = "Map of Customer Gateway attributes"
+  value       = module.vpc.this_customer_gateway
+}
+
+output "vgw_id" {
+  description = "The ID of the VPN Gateway"
+  value       = module.vpc.vgw_id
+}
+
+output "vgw_arn" {
+  description = "The ARN of the VPN Gateway"
+  value       = module.vpc.vgw_arn
+}
+
+output "default_vpc_id" {
+  description = "The ID of the Default VPC"
+  value       = module.vpc.default_vpc_id
+}
+
+output "default_vpc_arn" {
+  description = "The ARN of the Default VPC"
+  value       = module.vpc.default_vpc_arn
+}
+
+output "default_vpc_cidr_block" {
+  description = "The CIDR block of the Default VPC"
+  value       = module.vpc.default_vpc_cidr_block
+}
+
+output "default_vpc_default_security_group_id" {
+  description = "The ID of the security group created by default on Default VPC creation"
+  value       = module.vpc.default_vpc_default_security_group_id
+}
+
+output "default_vpc_default_network_acl_id" {
+  description = "The ID of the default network ACL of the Default VPC"
+  value       = module.vpc.default_vpc_default_network_acl_id
+}
+
+output "default_vpc_default_route_table_id" {
+  description = "The ID of the default route table of the Default VPC"
+  value       = module.vpc.default_vpc_default_route_table_id
+}
+
+output "default_vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within Default VPC"
+  value       = module.vpc.default_vpc_instance_tenancy
+}
+
+output "default_vpc_enable_dns_support" {
+  description = "Whether or not the Default VPC has DNS support"
+  value       = module.vpc.default_vpc_enable_dns_support
+}
+
+output "default_vpc_enable_dns_hostnames" {
+  description = "Whether or not the Default VPC has DNS hostname support"
+  value       = module.vpc.default_vpc_enable_dns_hostnames
+}
+
+output "default_vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with the Default VPC"
+  value       = module.vpc.default_vpc_main_route_table_id
+}
+
+output "public_network_acl_id" {
+  description = "ID of the public network ACL"
+  value       = module.vpc.public_network_acl_id
+}
+
+output "public_network_acl_arn" {
+  description = "ARN of the public network ACL"
+  value       = module.vpc.public_network_acl_arn
+}
+
+output "private_network_acl_id" {
+  description = "ID of the private network ACL"
+  value       = module.vpc.private_network_acl_id
+}
+
+output "private_network_acl_arn" {
+  description = "ARN of the private network ACL"
+  value       = module.vpc.private_network_acl_arn
+}
+
+output "outpost_network_acl_id" {
+  description = "ID of the outpost network ACL"
+  value       = module.vpc.outpost_network_acl_id
+}
+
+output "outpost_network_acl_arn" {
+  description = "ARN of the outpost network ACL"
+  value       = module.vpc.outpost_network_acl_arn
+}
+
+output "intra_network_acl_id" {
+  description = "ID of the intra network ACL"
+  value       = module.vpc.intra_network_acl_id
+}
+
+output "intra_network_acl_arn" {
+  description = "ARN of the intra network ACL"
+  value       = module.vpc.intra_network_acl_arn
+}
+
+output "database_network_acl_id" {
+  description = "ID of the database network ACL"
+  value       = module.vpc.database_network_acl_id
+}
+
+output "database_network_acl_arn" {
+  description = "ARN of the database network ACL"
+  value       = module.vpc.database_network_acl_arn
+}
+
+output "redshift_network_acl_id" {
+  description = "ID of the redshift network ACL"
+  value       = module.vpc.redshift_network_acl_id
+}
+
+output "redshift_network_acl_arn" {
+  description = "ARN of the redshift network ACL"
+  value       = module.vpc.redshift_network_acl_arn
+}
+
+output "elasticache_network_acl_id" {
+  description = "ID of the elasticache network ACL"
+  value       = module.vpc.elasticache_network_acl_id
+}
+
+output "elasticache_network_acl_arn" {
+  description = "ARN of the elasticache network ACL"
+  value       = module.vpc.elasticache_network_acl_arn
+}
+
+# VPC flow log
+output "vpc_flow_log_id" {
+  description = "The ID of the Flow Log resource"
+  value       = module.vpc.vpc_flow_log_id
+}
+
+output "vpc_flow_log_destination_arn" {
+  description = "The ARN of the destination for VPC Flow Logs"
+  value       = module.vpc.vpc_flow_log_destination_arn
+}
+
+output "vpc_flow_log_destination_type" {
+  description = "The type of the destination for VPC Flow Logs"
+  value       = module.vpc.vpc_flow_log_destination_type
+}
+
+output "vpc_flow_log_cloudwatch_iam_role_arn" {
+  description = "The ARN of the IAM role used when pushing logs to Cloudwatch log group"
+  value       = module.vpc.vpc_flow_log_cloudwatch_iam_role_arn
+}

--- a/examples/ipam/versions.tf
+++ b/examples/ipam/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.63"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,48 @@ variable "intra_subnets" {
   default     = []
 }
 
+variable "public_subnets_indexes" {
+  description = "A list of indexes for the public subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "private_subnets_indexes" {
+  description = "A list of indexes for the private subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "outpost_subnets_indexes" {
+  description = "A list of indexes for the outpost subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "database_subnets_indexes" {
+  description = "A list of indexes for the database subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "redshift_subnets_indexes" {
+  description = "A list of indexes for the redshift subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "elasticache_subnets_indexes" {
+  description = "A list of indexes for the elasticache subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
+variable "intra_subnets_indexes" {
+  description = "A list of indexes for the intra subnets. Only used when IPAM is enabled."
+  type        = list(number)
+  default     = []
+}
+
 variable "create_database_subnet_route_table" {
   description = "Controls if separate route table for database should be created"
   type        = bool
@@ -1188,6 +1230,18 @@ variable "flow_log_per_hour_partition" {
   description = "(Optional) Indicates whether to partition the flow log per hour. This reduces the cost and response time for queries."
   type        = bool
   default     = false
+}
+
+variable "ipv4_ipam_pool_id" {
+  description = "The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR."
+  type        = string
+  default     = ""
+}
+
+variable "ipv4_netmask_length" {
+  description = "The netmask length of the IPv4 CIDR you want to allocate to this VPC. Only used when IPAM is enabled."
+  type        = number
+  default     = null
 }
 
 variable "putin_khuylo" {


### PR DESCRIPTION
## Description
Add supports for IPAM and dynamic allocation of IP addresses

## Motivation and Context
Amazon VPC IP Address Manager (IPAM) is a VPC feature that makes it easier to plan, track, and monitor IP addresses. This pull request adds support for it, which allows for dynamic IP allocations.

## Breaking Changes
Proposed changes don't break the backward compatibility.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I have delpoyed module in AWS using the example that is added in the PR with a different configuration, I performed several updates and then destroyed the module. Additionally, I have deployed other examples to check if backward compatibility is maintained.
