### PR TITLE
feat: Use default `cidr` value from RFC 1918 (#839)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "name" {
 variable "cidr" {
   description = "(Optional) The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length` & `ipv4_ipam_pool_id`"
   type        = string
-  default     = "0.0.0.0/0"
+  default     = "10.0.0.0/16"
 }
 
 variable "enable_ipv6" {


### PR DESCRIPTION
## Description
We should use default value from RFC 1918 to simplify module usage without specifying additionally `cidr`


## Motivation and Context
This is related to the [Default CIDR for module should be from RFC 1918 #839](839)


## Breaking Changes
No breaking changes


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
