### PR TITLE
feat: Use argument service_name for VPC endpoints if possible

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -98,7 +98,6 @@ module "vpc_endpoints" {
       tags    = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {
-      service         = "dynamodb"
       service_type    = "Gateway"
       service_name    = "com.amazonaws.${local.region}.dynamodb"
       route_table_ids = flatten([module.vpc.intra_route_table_ids, module.vpc.private_route_table_ids, module.vpc.public_route_table_ids])

--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -100,6 +100,7 @@ module "vpc_endpoints" {
     dynamodb = {
       service         = "dynamodb"
       service_type    = "Gateway"
+      service_name    = "com.amazonaws.${local.region}.dynamodb"
       route_table_ids = flatten([module.vpc.intra_route_table_ids, module.vpc.private_route_table_ids, module.vpc.public_route_table_ids])
       policy          = data.aws_iam_policy_document.dynamodb_endpoint_policy.json
       tags            = { Name = "dynamodb-vpc-endpoint" }

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "aws_vpc_endpoint_service" "this" {
-  for_each = local.endpoints
+  for_each = { for k, v in local.endpoints : k => v if lookup(v, "service_name", null) == null }
 
   service      = lookup(each.value, "service", null)
   service_name = lookup(each.value, "service_name", null)
@@ -22,7 +22,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = data.aws_vpc_endpoint_service.this[each.key].service_name
+  service_name      = lookup(each.value, "service_name", null) != null ? lookup(each.value, "service_name", null) : data.aws_vpc_endpoint_service.this[each.key].service_name
   vpc_endpoint_type = lookup(each.value, "service_type", "Interface")
   auto_accept       = lookup(each.value, "auto_accept", null)
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "aws_vpc_endpoint_service" "this" {
-  for_each = { for k, v in local.endpoints : k => v if lookup(v, "service_name", null) == null }
+  for_each = local.endpoints
 
   service      = lookup(each.value, "service", null)
   service_name = lookup(each.value, "service_name", null)
@@ -22,7 +22,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = lookup(each.value, "service_name", null) != null ? lookup(each.value, "service_name", null) : data.aws_vpc_endpoint_service.this[each.key].service_name
+  service_name      = try(each.value.service_name, data.aws_vpc_endpoint_service.this[each.key].service_name)
   vpc_endpoint_type = lookup(each.value, "service_type", "Interface")
   auto_accept       = lookup(each.value, "auto_accept", null)
 


### PR DESCRIPTION
## Description

`service_name` argument for `endpoints` which allows to hardcode value then no data source is used.

Very often Terraform re-reads data source for aws_vpc_endpoint_service then recreates aws_vpc_endpoint and recreation fails because endpoint already exists.

To break this unnecessary cycle I would prefer to hardcode `service_name` and do not use data source at all. I can't even tell what kind of changes provokes recreation of VPC endpoints: it seems to me very random and not directly related to the endpoints. I'm pretty sure once it was recreated after I changed just a tag for VPC and/or subnet.

<!--- Describe your changes in detail -->

## Motivation and Context

To prevent unecessary recreation of endpoins like:

```
  # module.vpce.aws_vpc_endpoint.this["s3"] must be replaced
+/- resource "aws_vpc_endpoint" "this" {
      ~ arn                   = "arn:aws:ec2:us-east-2:123456789012:vpc-endpoint/vpce-xxxxxxxxxxxxxx" -> (known after apply)
      ~ cidr_blocks           = [
        ] -> (known after apply)
      ~ dns_entry             = [] -> (known after apply)
      ~ id                    = "vpce-xxxxxxxxxxxxxx" -> (known after apply)
      + ip_address_type       = (known after apply)
      ~ network_interface_ids = [] -> (known after apply)
      ~ owner_id              = "123456789012" -> (known after apply)
      ~ policy                = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "*"
                      - Effect    = "Allow"
                      - Principal = "*"
                      - Resource  = "*"
                    },
                ]
              - Version   = "2008-10-17"
            }
        ) -> (known after apply)
      ~ prefix_list_id        = "pl-xxxxxxxxxx" -> (known after apply)
      ~ requester_managed     = false -> (known after apply)
      ~ security_group_ids    = [] -> (known after apply)
      ~ service_name          = "com.amazonaws.us-east-2.s3" -> (known after apply) # forces replacement
      ~ state                 = "available" -> (known after apply)
      ~ subnet_ids            = [] -> (known after apply)
        tags                  = {
            "Name"   = "app-cluster-testing-use2-s3"
            "Object" = "module.vpce"
            "Reach"  = "private"
        }
        # (5 unchanged attributes hidden)

      + dns_options {
          + dns_record_ip_type = (known after apply)
        }

        # (1 unchanged block hidden)
    }

  # module.vpce.data.aws_vpc_endpoint_service.this["s3"] will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_vpc_endpoint_service" "this" {
      + acceptance_required           = (known after apply)
      + arn                           = (known after apply)
      + availability_zones            = (known after apply)
      + base_endpoint_dns_names       = (known after apply)
      + id                            = (known after apply)
      + manages_vpc_endpoints         = (known after apply)
      + owner                         = (known after apply)
      + private_dns_name              = (known after apply)
      + service                       = "s3"
      + service_id                    = (known after apply)
      + service_name                  = (known after apply)
      + service_type                  = (known after apply)
      + supported_ip_address_types    = (known after apply)
      + tags                          = (known after apply)
      + vpc_endpoint_policy_supported = (known after apply)

      + filter {
          + name   = "service-type"
          + values = [
              + "Gateway",
            ]
        }

      + timeouts {
          + read = (known after apply)
        }
    }
```

## Breaking Changes

No breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
