### PR TITLE
feat: Add public and private tags per az

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ No modules.
 | <a name="input_private_subnet_names"></a> [private\_subnet\_names](#input\_private\_subnet\_names) | Explicit values to use in the Name tag on private subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_suffix"></a> [private\_subnet\_suffix](#input\_private\_subnet\_suffix) | Suffix to append to private subnets name | `string` | `"private"` | no |
 | <a name="input_private_subnet_tags"></a> [private\_subnet\_tags](#input\_private\_subnet\_tags) | Additional tags for the private subnets | `map(string)` | `{}` | no |
+| <a name="input_private_subnet_tags_per_az"></a> [private\_subnet\_tags\_per\_az](#input\_private\_subnet\_tags\_per\_az) | Additional tags for the private subnets where the primary key is the AZ | `map(map(string))` | `{}` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_propagate_intra_route_tables_vgw"></a> [propagate\_intra\_route\_tables\_vgw](#input\_propagate\_intra\_route\_tables\_vgw) | Should be true if you want route table propagation | `bool` | `false` | no |
 | <a name="input_propagate_private_route_tables_vgw"></a> [propagate\_private\_route\_tables\_vgw](#input\_propagate\_private\_route\_tables\_vgw) | Should be true if you want route table propagation | `bool` | `false` | no |
@@ -509,6 +510,7 @@ No modules.
 | <a name="input_public_subnet_names"></a> [public\_subnet\_names](#input\_public\_subnet\_names) | Explicit values to use in the Name tag on public subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_suffix"></a> [public\_subnet\_suffix](#input\_public\_subnet\_suffix) | Suffix to append to public subnets name | `string` | `"public"` | no |
 | <a name="input_public_subnet_tags"></a> [public\_subnet\_tags](#input\_public\_subnet\_tags) | Additional tags for the public subnets | `map(string)` | `{}` | no |
+| <a name="input_public_subnet_tags_per_az"></a> [public\_subnet\_tags\_per\_az](#input\_public\_subnet\_tags\_per\_az) | Additional tags for the public subnets where the primary key is the AZ | `map(map(string))` | `{}` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_redshift_acl_tags"></a> [redshift\_acl\_tags](#input\_redshift\_acl\_tags) | Additional tags for the redshift subnets network ACL | `map(string)` | `{}` | no |

--- a/examples/simple-vpc/main.tf
+++ b/examples/simple-vpc/main.tf
@@ -36,6 +36,12 @@ module "vpc" {
     Name = "overridden-name-public"
   }
 
+  public_subnet_tags_per_az = {
+    "${local.region}a" = {
+      "availability-zone" = "${local.region}a"
+    }
+  }
+
   tags = local.tags
 
   vpc_tags = {

--- a/main.tf
+++ b/main.tf
@@ -377,6 +377,7 @@ resource "aws_subnet" "public" {
     },
     var.tags,
     var.public_subnet_tags,
+    lookup(var.public_subnet_tags_per_az, element(var.azs, count.index), {})
   )
 }
 
@@ -404,6 +405,7 @@ resource "aws_subnet" "private" {
     },
     var.tags,
     var.private_subnet_tags,
+    lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {})
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -486,9 +486,21 @@ variable "public_subnet_tags" {
   default     = {}
 }
 
+variable "public_subnet_tags_per_az" {
+  description = "Additional tags for the public subnets where the primary key is the AZ"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "private_subnet_tags" {
   description = "Additional tags for the private subnets"
   type        = map(string)
+  default     = {}
+}
+
+variable "private_subnet_tags_per_az" {
+  description = "Additional tags for the private subnets where the primary key is the AZ"
+  type        = map(map(string))
   default     = {}
 }
 


### PR DESCRIPTION
## Description
Add public and private tags per az

## Motivation and Context
I want to set up kubernetes controllers that can use a specific subnet by tag. I could use name but our names have a lot of information in them. I would much rather be able to tag a subnet by AZ with certain tags like the AZ itself or the cluster I'm trying to target for this AZ.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

```sh
cd examples/simple-vpc
terraform init
terraform plan
```

```hcl
  # module.vpc.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + tags                                           = {
          + "Example"           = "ex-simple-vpc"
          + "GithubOrg"         = "terraform-aws-modules"
          + "GithubRepo"        = "terraform-aws-vpc"
          + "Name"              = "overridden-name-public"
          + "availability-zone" = "eu-west-1a"
        }
      + tags_all                                       = {
          + "Example"           = "ex-simple-vpc"
          + "GithubOrg"         = "terraform-aws-modules"
          + "GithubRepo"        = "terraform-aws-vpc"
          + "Name"              = "overridden-name-public"
          + "availability-zone" = "eu-west-1a"
        }
    }

  # module.vpc.aws_subnet.public[1] will be created
  + resource "aws_subnet" "public" {
      + tags                                           = {
          + "Example"           = "ex-simple-vpc"
          + "GithubOrg"         = "terraform-aws-modules"
          + "GithubRepo"        = "terraform-aws-vpc"
          + "Name"              = "overridden-name-public"
        }
      + tags_all                                       = {
          + "Example"           = "ex-simple-vpc"
          + "GithubOrg"         = "terraform-aws-modules"
          + "GithubRepo"        = "terraform-aws-vpc"
          + "Name"              = "overridden-name-public"
        }
    }
```
