### PR TITLE
feat: Add subnet specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ No modules.
 | <a name="input_database_subnet_group_tags"></a> [database\_subnet\_group\_tags](#input\_database\_subnet\_group\_tags) | Additional tags for the database subnet group | `map(string)` | `{}` | no |
 | <a name="input_database_subnet_ipv6_prefixes"></a> [database\_subnet\_ipv6\_prefixes](#input\_database\_subnet\_ipv6\_prefixes) | Assigns IPv6 database subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_database_subnet_names"></a> [database\_subnet\_names](#input\_database\_subnet\_names) | Explicit values to use in the Name tag on database subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_database_subnet_specific_tags"></a> [database\_subnet\_specific\_tags](#input\_database\_subnet\_specific\_tags) | Additional tags for each database subnet | `list(map(string))` | `[]` | no |
 | <a name="input_database_subnet_suffix"></a> [database\_subnet\_suffix](#input\_database\_subnet\_suffix) | Suffix to append to database subnets name | `string` | `"db"` | no |
 | <a name="input_database_subnet_tags"></a> [database\_subnet\_tags](#input\_database\_subnet\_tags) | Additional tags for the database subnets | `map(string)` | `{}` | no |
 | <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | A list of database subnets | `list(string)` | `[]` | no |
@@ -417,6 +418,7 @@ No modules.
 | <a name="input_elasticache_subnet_group_tags"></a> [elasticache\_subnet\_group\_tags](#input\_elasticache\_subnet\_group\_tags) | Additional tags for the elasticache subnet group | `map(string)` | `{}` | no |
 | <a name="input_elasticache_subnet_ipv6_prefixes"></a> [elasticache\_subnet\_ipv6\_prefixes](#input\_elasticache\_subnet\_ipv6\_prefixes) | Assigns IPv6 elasticache subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_elasticache_subnet_names"></a> [elasticache\_subnet\_names](#input\_elasticache\_subnet\_names) | Explicit values to use in the Name tag on elasticache subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_elasticache_subnet_specific_tags"></a> [elasticache\_subnet\_specific\_tags](#input\_elasticache\_subnet\_specific\_tags) | Additional tags for each elasticache subnet | `list(map(string))` | `[]` | no |
 | <a name="input_elasticache_subnet_suffix"></a> [elasticache\_subnet\_suffix](#input\_elasticache\_subnet\_suffix) | Suffix to append to elasticache subnets name | `string` | `"elasticache"` | no |
 | <a name="input_elasticache_subnet_tags"></a> [elasticache\_subnet\_tags](#input\_elasticache\_subnet\_tags) | Additional tags for the elasticache subnets | `map(string)` | `{}` | no |
 | <a name="input_elasticache_subnets"></a> [elasticache\_subnets](#input\_elasticache\_subnets) | A list of elasticache subnets | `list(string)` | `[]` | no |
@@ -455,6 +457,7 @@ No modules.
 | <a name="input_intra_subnet_assign_ipv6_address_on_creation"></a> [intra\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_intra\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on intra subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | <a name="input_intra_subnet_ipv6_prefixes"></a> [intra\_subnet\_ipv6\_prefixes](#input\_intra\_subnet\_ipv6\_prefixes) | Assigns IPv6 intra subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_intra_subnet_names"></a> [intra\_subnet\_names](#input\_intra\_subnet\_names) | Explicit values to use in the Name tag on intra subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_intra_subnet_specific_tags"></a> [intra\_subnet\_specific\_tags](#input\_intra\_subnet\_specific\_tags) | Additional tags for each intra subnet | `list(map(string))` | `[]` | no |
 | <a name="input_intra_subnet_suffix"></a> [intra\_subnet\_suffix](#input\_intra\_subnet\_suffix) | Suffix to append to intra subnets name | `string` | `"intra"` | no |
 | <a name="input_intra_subnet_tags"></a> [intra\_subnet\_tags](#input\_intra\_subnet\_tags) | Additional tags for the intra subnets | `map(string)` | `{}` | no |
 | <a name="input_intra_subnets"></a> [intra\_subnets](#input\_intra\_subnets) | A list of intra subnets | `list(string)` | `[]` | no |
@@ -482,6 +485,7 @@ No modules.
 | <a name="input_outpost_subnet_assign_ipv6_address_on_creation"></a> [outpost\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_outpost\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on outpost subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | <a name="input_outpost_subnet_ipv6_prefixes"></a> [outpost\_subnet\_ipv6\_prefixes](#input\_outpost\_subnet\_ipv6\_prefixes) | Assigns IPv6 outpost subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_outpost_subnet_names"></a> [outpost\_subnet\_names](#input\_outpost\_subnet\_names) | Explicit values to use in the Name tag on outpost subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_outpost_subnet_specific_tags"></a> [outpost\_subnet\_specific\_tags](#input\_outpost\_subnet\_specific\_tags) | Additional tags for each outpost subnet | `list(map(string))` | `[]` | no |
 | <a name="input_outpost_subnet_suffix"></a> [outpost\_subnet\_suffix](#input\_outpost\_subnet\_suffix) | Suffix to append to outpost subnets name | `string` | `"outpost"` | no |
 | <a name="input_outpost_subnet_tags"></a> [outpost\_subnet\_tags](#input\_outpost\_subnet\_tags) | Additional tags for the outpost subnets | `map(string)` | `{}` | no |
 | <a name="input_outpost_subnets"></a> [outpost\_subnets](#input\_outpost\_subnets) | A list of outpost subnets inside the VPC | `list(string)` | `[]` | no |
@@ -493,6 +497,7 @@ No modules.
 | <a name="input_private_subnet_assign_ipv6_address_on_creation"></a> [private\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_private\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on private subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | <a name="input_private_subnet_ipv6_prefixes"></a> [private\_subnet\_ipv6\_prefixes](#input\_private\_subnet\_ipv6\_prefixes) | Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_names"></a> [private\_subnet\_names](#input\_private\_subnet\_names) | Explicit values to use in the Name tag on private subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_private_subnet_specific_tags"></a> [private\_subnet\_specific\_tags](#input\_private\_subnet\_specific\_tags) | Additional tags for each private subnet | `list(map(string))` | `[]` | no |
 | <a name="input_private_subnet_suffix"></a> [private\_subnet\_suffix](#input\_private\_subnet\_suffix) | Suffix to append to private subnets name | `string` | `"private"` | no |
 | <a name="input_private_subnet_tags"></a> [private\_subnet\_tags](#input\_private\_subnet\_tags) | Additional tags for the private subnets | `map(string)` | `{}` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
@@ -507,6 +512,7 @@ No modules.
 | <a name="input_public_subnet_assign_ipv6_address_on_creation"></a> [public\_subnet\_assign\_ipv6\_address\_on\_creation](#input\_public\_subnet\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on public subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `null` | no |
 | <a name="input_public_subnet_ipv6_prefixes"></a> [public\_subnet\_ipv6\_prefixes](#input\_public\_subnet\_ipv6\_prefixes) | Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_names"></a> [public\_subnet\_names](#input\_public\_subnet\_names) | Explicit values to use in the Name tag on public subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_public_subnet_specific_tags"></a> [public\_subnet\_specific\_tags](#input\_public\_subnet\_specific\_tags) | Additional tags for each public subnet | `list(map(string))` | `[]` | no |
 | <a name="input_public_subnet_suffix"></a> [public\_subnet\_suffix](#input\_public\_subnet\_suffix) | Suffix to append to public subnets name | `string` | `"public"` | no |
 | <a name="input_public_subnet_tags"></a> [public\_subnet\_tags](#input\_public\_subnet\_tags) | Additional tags for the public subnets | `map(string)` | `{}` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
@@ -521,6 +527,7 @@ No modules.
 | <a name="input_redshift_subnet_group_tags"></a> [redshift\_subnet\_group\_tags](#input\_redshift\_subnet\_group\_tags) | Additional tags for the redshift subnet group | `map(string)` | `{}` | no |
 | <a name="input_redshift_subnet_ipv6_prefixes"></a> [redshift\_subnet\_ipv6\_prefixes](#input\_redshift\_subnet\_ipv6\_prefixes) | Assigns IPv6 redshift subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_redshift_subnet_names"></a> [redshift\_subnet\_names](#input\_redshift\_subnet\_names) | Explicit values to use in the Name tag on redshift subnets. If empty, Name tags are generated. | `list(string)` | `[]` | no |
+| <a name="input_redshift_subnet_specific_tags"></a> [redshift\_subnet\_specific\_tags](#input\_redshift\_subnet\_specific\_tags) | Additional tags for each redshift subnet | `list(map(string))` | `[]` | no |
 | <a name="input_redshift_subnet_suffix"></a> [redshift\_subnet\_suffix](#input\_redshift\_subnet\_suffix) | Suffix to append to redshift subnets name | `string` | `"redshift"` | no |
 | <a name="input_redshift_subnet_tags"></a> [redshift\_subnet\_tags](#input\_redshift\_subnet\_tags) | Additional tags for the redshift subnets | `map(string)` | `{}` | no |
 | <a name="input_redshift_subnets"></a> [redshift\_subnets](#input\_redshift\_subnets) | A list of redshift subnets | `list(string)` | `[]` | no |

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -34,6 +34,12 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
+  private_subnet_specific_tags = [
+    {},
+    {"karpenter.sh/discovery/my-cluster-1": "owned"},
+    {"karpenter.sh/discovery/my-cluster-2": "owned"},
+  ]
+
   public_subnet_tags = {
     Name = "overridden-name-public"
   }

--- a/main.tf
+++ b/main.tf
@@ -377,6 +377,7 @@ resource "aws_subnet" "public" {
     },
     var.tags,
     var.public_subnet_tags,
+    length(var.public_subnet_specific_tags) > 0 ? var.public_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -404,6 +405,7 @@ resource "aws_subnet" "private" {
     },
     var.tags,
     var.private_subnet_tags,
+    length(var.private_subnet_specific_tags) > 0 ? var.private_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -432,6 +434,7 @@ resource "aws_subnet" "outpost" {
     },
     var.tags,
     var.outpost_subnet_tags,
+    length(var.outpost_subnet_specific_tags) > 0 ? var.outpost_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -459,6 +462,7 @@ resource "aws_subnet" "database" {
     },
     var.tags,
     var.database_subnet_tags,
+    length(var.database_subnet_specific_tags) > 0 ? var.database_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -502,6 +506,7 @@ resource "aws_subnet" "redshift" {
     },
     var.tags,
     var.redshift_subnet_tags,
+    length(var.redshift_subnet_specific_tags) > 0 ? var.redshift_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -543,6 +548,7 @@ resource "aws_subnet" "elasticache" {
     },
     var.tags,
     var.elasticache_subnet_tags,
+    length(var.elasticache_subnet_specific_tags) > 0 ? var.elasticache_subnet_specific_tags[count.index] : {},
   )
 }
 
@@ -584,6 +590,7 @@ resource "aws_subnet" "intra" {
     },
     var.tags,
     var.intra_subnet_tags,
+    length(var.intra_subnet_specific_tags) > 0 ? var.intra_subnet_specific_tags[count.index] : {},
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,48 @@ variable "elasticache_subnet_suffix" {
   default     = "elasticache"
 }
 
+variable "public_subnet_specific_tags" {
+  description = "Additional tags for each public subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "private_subnet_specific_tags" {
+  description = "Additional tags for each private subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "outpost_subnet_specific_tags" {
+  description = "Additional tags for each outpost subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "database_subnet_specific_tags" {
+  description = "Additional tags for each database subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "redshift_subnet_specific_tags" {
+  description = "Additional tags for each redshift subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "elasticache_subnet_specific_tags" {
+  description = "Additional tags for each elasticache subnet"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "intra_subnet_specific_tags" {
+  description = "Additional tags for each intra subnet"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
   type        = list(string)


### PR DESCRIPTION
## Description
This adds the following inputs:
- `public_subnet_specific_tags`
- `private_subnet_specific_tags`
- `outpost_subnet_specific_tags`
- `database_subnet_specific_tags`
- `redshift_subnet_specific_tags`
- `elasticache_subnet_specific_tags`
- `intra_subnet_specific_tags`

## Motivation and Context
- See https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/866

## Breaking Changes
No breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
