### PR TITLE
feat: Update CIDR variable data type to list(string)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "name" {
 
 variable "cidr" {
   description = "(Optional) The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length` & `ipv4_ipam_pool_id`"
-  type        = string
+  type        = list(string)
   default     = "0.0.0.0/0"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "name" {
 variable "cidr" {
   description = "(Optional) The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length` & `ipv4_ipam_pool_id`"
   type        = list(string)
-  default     = "0.0.0.0/0"
+  default     = ["0.0.0.0/0"]
 }
 
 variable "enable_ipv6" {


### PR DESCRIPTION
Update the CIDR variable data type to list(string) to support attachment of additional CIDR blocks to current VPC

## Description
Update the CIDR variable data type to list(string) to support attachment of additional CIDR blocks to current VPC

## Motivation and Context
I wish to deploy a duplicate eks cluster in  the same VPC and currently it gives me issues related to insufficient IP addresses available .As per AWS docs [Here ](https://docs.aws.amazon.com/vpc/latest/userguide/how-it-works.html#vpc-ip-addressing), the VPC size could have atleast 5 CIDR from /16 to /28

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> Ideally It should not as it only accepts more CID blocks and not the vice versa
<!-- If so, please provide an explanation why it is necessary. -->N/A

## How Has This Been Tested?
- [ ] I have tested these changes manually on my aws console by attaching vpc cidrs , but I want to now do it via terraform