### PR TITLE
docs: In the example, S3 endpoint should be a gateway, not interface

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -94,8 +94,10 @@ module "vpc_endpoints" {
 
   endpoints = {
     s3 = {
-      service = "s3"
-      tags    = { Name = "s3-vpc-endpoint" }
+      service         = "s3"
+      service_type    = "Gateway"
+      route_table_ids = flatten([module.vpc.intra_route_table_ids, module.vpc.private_route_table_ids, module.vpc.public_route_table_ids])
+      tags            = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {
       service         = "dynamodb"

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -17,7 +17,7 @@ module "endpoints" {
     s3 = {
       # gateway endpoint
       service             = "s3"
-      route_table_ids = ["rt-12322456", "rt-43433343", "rt-11223344"]
+      route_table_ids     = ["rt-12322456", "rt-43433343", "rt-11223344"]
       tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -15,8 +15,9 @@ module "endpoints" {
 
   endpoints = {
     s3 = {
-      # interface endpoint
+      # gateway endpoint
       service             = "s3"
+      route_table_ids = ["rt-12322456", "rt-43433343", "rt-11223344"]
       tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {


### PR DESCRIPTION
## Description
The documentation implies that the S3 endpoint is an interface, but it's actually a gateway
https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I spent some time debugging an issue where my ECS Fargate task wasn't able to pull images from S3, and this was the issue.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
