### PR TITLE
feat: Add new variable to enable vpc metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ No modules.
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block. | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
+| <a name="input_enable_nau_metrics"></a> [enable\_nau\_metrics](#input\_enable\_nau\_metrics) | Should be true to enable Network Address Usage metrics for the VPC. | `bool` | `null` | no |
 | <a name="input_enable_public_redshift"></a> [enable\_public\_redshift](#input\_enable\_public\_redshift) | Controls if redshift should have public routing table | `bool` | `false` | no |
 | <a name="input_enable_vpn_gateway"></a> [enable\_vpn\_gateway](#input\_enable\_vpn\_gateway) | Should be true if you want to create a new VPN Gateway resource and attach it to the VPC | `bool` | `false` | no |
 | <a name="input_external_nat_ip_ids"></a> [external\_nat\_ip\_ids](#input\_external\_nat\_ip\_ids) | List of EIP IDs to be assigned to the NAT Gateways (used in combination with reuse\_nat\_ips) | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -29,11 +29,12 @@ resource "aws_vpc" "this" {
   ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
   ipv6_netmask_length              = var.ipv6_netmask_length
 
-  instance_tenancy               = var.instance_tenancy
-  enable_dns_hostnames           = var.enable_dns_hostnames
-  enable_dns_support             = var.enable_dns_support
-  enable_classiclink             = null # https://github.com/hashicorp/terraform/issues/31730
-  enable_classiclink_dns_support = null # https://github.com/hashicorp/terraform/issues/31730
+  instance_tenancy                     = var.instance_tenancy
+  enable_dns_hostnames                 = var.enable_dns_hostnames
+  enable_dns_support                   = var.enable_dns_support
+  enable_classiclink                   = null # https://github.com/hashicorp/terraform/issues/31730
+  enable_classiclink_dns_support       = null # https://github.com/hashicorp/terraform/issues/31730
+  enable_network_address_usage_metrics = var.enable_nau_metrics
 
   tags = merge(
     { "Name" = var.name },

--- a/variables.tf
+++ b/variables.tf
@@ -336,6 +336,12 @@ variable "enable_classiclink_dns_support" {
   default     = null
 }
 
+variable "enable_nau_metrics" {
+  description = "Should be true to enable Network Address Usage metrics for the VPC."
+  type        = bool
+  default     = null
+}
+
 variable "enable_nat_gateway" {
   description = "Should be true if you want to provision NAT Gateways for each of your private networks"
   type        = bool


### PR DESCRIPTION
## Description
Add variable to enable VPC [metrics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc#enable_network_address_usage_metrics) collection

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Outputs

```bash
module.vpc.aws_vpc.this[0]: Refreshing state... [id=vpc-5484784564125488]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.vpc.aws_vpc.this[0] will be updated in-place
  ~ resource "aws_vpc" "this" {
      ~ enable_network_address_usage_metrics = false -> true
        id                                   = "vpc-5484784564125488"
        tags                                 = {
            "Environment"  = "sandbox"
            "Name"         = "sandbox"
        }
        # (16 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Warning: Resource targeting is in effect

You are creating a plan with the -target option, which means that the result
of this plan may not represent all of the changes requested by the current
configuration.
		
The -target option is not for routine use, and is provided only for
exceptional situations such as recovering from errors or mistakes, or when
Terraform specifically suggests to use it as part of an error message.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.vpc.aws_vpc.this[0]: Modifying... [id=vpc-5484784564125488]
module.vpc.aws_vpc.this[0]: Still modifying... [id=vpc-5484784564125488, 10s elapsed]
module.vpc.aws_vpc.this[0]: Modifications complete after 15s [id=vpc-5484784564125488]

Warning: Applied changes may be incomplete

The plan was created with the -target option in effect, so some changes
requested in the configuration may have been ignored and the output values may
not be fully updated. Run the following command to verify that no other
changes are pending:
    terraform plan
	
Note that the -target option is not suitable for routine use, and is provided
only for exceptional situations such as recovering from errors or mistakes, or
when Terraform specifically suggests to use it as part of an error message.


Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
Releasing state lock. This may take a few moments...
```
