### PR TITLE
fix: WIP: Separate IGW creation from VPC attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,13 +127,17 @@ resource "aws_vpc_dhcp_options_association" "this" {
 resource "aws_internet_gateway" "this" {
   count = local.create_vpc && var.create_igw && length(var.public_subnets) > 0 ? 1 : 0
 
-  vpc_id = local.vpc_id
-
   tags = merge(
     { "Name" = var.name },
     var.tags,
     var.igw_tags,
   )
+}
+
+resource "aws_internet_gateway_attachment" "this" {
+  count               = local.create_vpc && var.create_igw && length(var.public_subnets) > 0 ? 1 : 0
+  internet_gateway_id = aws_internet_gateway.this[0].id
+  vpc_id              = local.vpc_id
 }
 
 resource "aws_egress_only_internet_gateway" "this" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.73"
+      version = ">= 4.3.0"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR separates creation of the internet gateway (IGW) from attachment to the VPC.

By doing this, an implicit dependency is avoided, allowing `terraform destroy` on a VPC+IGW created by this module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #883 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
The new resource `aws_internet_gateway_attachment` requires version 4.3.0 of the Terraform provider for AWS.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
