### PR TITLE
feat: Support pre-IPAM BYOIPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the virtual private gateway is created with the current default Amazon ASN. | `string` | `"64512"` | no |
+| <a name="input_assign_generated_ipv6_cidr_block"></a> [assign\_generated\_ipv6\_cidr\_block](#input\_assign\_generated\_ipv6\_cidr\_block) | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. | `bool` | `null` | no |
 | <a name="input_assign_ipv6_address_on_creation"></a> [assign\_ipv6\_address\_on\_creation](#input\_assign\_ipv6\_address\_on\_creation) | Assign IPv6 address on subnet, must be disabled to change IPv6 CIDRs. This is the IPv6 equivalent of map\_public\_ip\_on\_launch | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | (Optional) The IPv4 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv4_netmask_length` & `ipv4_ipam_pool_id` | `string` | `"0.0.0.0/0"` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,8 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
+
+  assign_generated_ipv6_cidr_block = coalesce(var.assign_generated_ipv6_cidr_block, true)
 }
 
 ################################################################################
@@ -24,7 +26,7 @@ resource "aws_vpc" "this" {
   ipv4_ipam_pool_id   = var.ipv4_ipam_pool_id
   ipv4_netmask_length = var.ipv4_netmask_length
 
-  assign_generated_ipv6_cidr_block = var.enable_ipv6 && !var.use_ipam_pool ? true : null
+  assign_generated_ipv6_cidr_block = var.enable_ipv6 && !var.use_ipam_pool && local.assign_generated_ipv6_cidr_block ? true : null
   ipv6_cidr_block                  = var.ipv6_cidr
   ipv6_ipam_pool_id                = var.ipv6_ipam_pool_id
   ipv6_netmask_length              = var.ipv6_netmask_length

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "enable_ipv6" {
   default     = false
 }
 
+variable "assign_generated_ipv6_cidr_block" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC."
+  type        = bool
+  default     = null
+}
+
 variable "private_subnet_ipv6_prefixes" {
   description = "Assigns IPv6 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   type        = list(string)


### PR DESCRIPTION
## Description

Before IPAM, users were still able to BYOIPv6. This change allows these users to use this module.

## Motivation and Context

We used AWS BYOIPv6 before the AWS IPAM feature so we have to pass `ipv6_ipam_pool_id` AND pass `null` to `assign_generated_ipv6_cidr_block`. Currently the code for `assign_generated_ipv6_cidr_block` is:

```
  assign_generated_ipv6_cidr_block = var.enable_ipv6 && !var.use_ipam_pool ? true : null
```

so there is no way for us to pass `assign_generated_ipv6_cidr_block = null` without setting `use_ipam_pool` which has it's own implications since:

```
  cidr_block          = var.use_ipam_pool ? null : var.cidr
```

## Breaking Changes

No, I double checked that this shouldn't break anything or change existing behavior.

## How Has This Been Tested?

### I have updated at least one of the `examples/*` to demonstrate and validate my change(s)

I haven't done this because the developer (or CI/CD) needs to have BYOIPv6 setup.

### I have tested and validated these changes using one or more of the provided `examples/*` projects

I haven't done this because the developer (or CI/CD) needs to have BYOIPv6 setup.

Instead, I have done some manual testing...

#### Existing code

```
assign_generated_ipv6_cidr_block = var.enable_ipv6 && !var.use_ipam_pool ? true : null
```

#### Tests

##### Existing functionality

The input, `assign_generated_ipv6_cidr_block`, is only true when `enable_ipv6` is `true` and `use_ipam_pool` is `false`; otherwise it's `null`. This is expected since we only want AWS to generate an IPv6 CIDR when IPv6 is enabled and we aren't using an IPAM pool.

##### `enable_ipv6 = true` && `use_ipam_pool = true`

```CONSOLE
> true && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = true` && `use_ipam_pool = false`

```CONSOLE
> true && !false ? true : null
true
```

##### `enable_ipv6 = false` && `use_ipam_pool = true`

```CONSOLE
> false && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = false` && `use_ipam_pool = false`

```CONSOLE
> false && !false ? true : null
tobool(null)
```

##### Ensure we don't break existing functionality

Functionality is the same. If the user doesn't pass `assign_generated_ipv6_cidr_block`, then the only time we ask AWS to generate an IPv6 CIDR is when IPv6 is enabled and we aren't using an IPAM pool.

##### `enable_ipv6 = true` && `use_ipam_pool = true` && `assign_generated_ipv6_cidr_block = null`

```CONSOLE
> true && coalesce(null, true) && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = true` && `use_ipam_pool = false` && `assign_generated_ipv6_cidr_block = null`

```CONSOLE
> true && coalesce(null, true) && !false ? true : null
true
```

##### `enable_ipv6 = false` && `use_ipam_pool = true` && `assign_generated_ipv6_cidr_block = null`

```CONSOLE
> false && coalesce(null, true) && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = false` && `use_ipam_pool = false` && `assign_generated_ipv6_cidr_block = null`

```CONSOLE
> false && coalesce(null, true) && !false ? true : null
tobool(null)
```

##### Ensure that if `assign_generated_ipv6_cidr_block = false`, we never ask AWS to generate an IPv6 CIDR block

If `assign_generated_ipv6_cidr_block = false`, we never ask AWS to generate an IPv6 CIDR block.

##### `enable_ipv6 = true` && `use_ipam_pool = true` && `assign_generated_ipv6_cidr_block = false`

```CONSOLE
> true && coalesce(false, true) && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = true` && `use_ipam_pool = false` && `assign_generated_ipv6_cidr_block = false`

```CONSOLE
> true && coalesce(false, true) && !false ? true : null
tobool(null)
```

##### `enable_ipv6 = false` && `use_ipam_pool = true` && `assign_generated_ipv6_cidr_block = false`

```CONSOLE
> false && coalesce(false, true) && !true ? true : null
tobool(null)
```

##### `enable_ipv6 = false` && `use_ipam_pool = false` && `assign_generated_ipv6_cidr_block = false`

```CONSOLE
> false && coalesce(false, true) && !false ? true : null
tobool(null)
```

##### Ensure that if `assign_generated_ipv6_cidr_block = true`, things are handled as they are today

We can be certain that since things were the same when `assign_generated_ipv6_cidr_block` was `null` (and the default value was `true`, that when `assign_generated_ipv6_cidr_block = true`, things are handled as they are today; we would only ask AWS to generate an IPv6 CIDR if IPv6 is enabled, and we aren't using an IPAM pool.

#### What about when `ipv6_ipam_pool_id` is not `null`?

The only time there is a conflict is when `ipv6_ipam_pool_id` is not `null` (and `assign_generated_ipv6_cidr_block` evaluates to `true`).

If a user passes `ipv6_ipam_pool_id`, and leaves `assign_generated_ipv6_cidr_block` as `null`, then the only time `assign_generated_ipv6_cidr_block` is not `null` is when `enable_ipv6` is `true` and `use_ipam_pool` is `false`. In this case, it works the same as today and the user should set `use_ipam_pool` to `true` since they are passing a value for `assign_generated_ipv6_cidr_block`.

If a user passes `ipv6_ipam_pool_id`, and sets `assign_generated_ipv6_cidr_block` to `true`, then the only time `assign_generated_ipv6_cidr_block` is not `null` is when `enable_ipv6` is `true` and `use_ipam_pool` is `false`. In this case, the user messed up 2x, they should NOT have set `assign_generated_ipv6_cidr_block` to `true` AND they SHOULD have set `use_ipam_pool` to `true`; fixing either mistake will resolve the conflict.

## I have executed `pre-commit run -a` on my pull request

```
nicholas7DYYW:terraform-aws-vpc hnicholas$ git status
On branch support-legacy-ipam
Your branch is up to date with 'origin/support-legacy-ipam'.

nothing to commit, working tree clean
```

```
hnicholas7DYYW:terraform-aws-vpc hnicholas$ pre-commit run -a
Terraform fmt............................................................Passed
Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```
