### PR TITLE
chore: Updated example to enable TLS Inbound for Session Manager

### DIFF
--- a/examples/complete-vpc/main.tf
+++ b/examples/complete-vpc/main.tf
@@ -114,6 +114,7 @@ module "vpc_endpoints" {
       service             = "ssmmessages"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
+      security_group_ids  = [aws_security_group.vpc_tls.id]
     },
     lambda = {
       service             = "lambda"
@@ -141,6 +142,7 @@ module "vpc_endpoints" {
       service             = "ec2messages"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
+      security_group_ids  = [aws_security_group.vpc_tls.id]
     },
     ecr_api = {
       service             = "ecr.api"


### PR DESCRIPTION
Enable TLS inbound for Session Manager

## Description
I use Session Manager quite extensively as it avoids the need for managing SSH Key pairs. The complete example had all of the endpoints but was missing the security group definitions for a couple, so I added them here.

## Motivation and Context
Enable testers to spin up EC2 instances without the need for SSH Key Pairs

## Breaking Changes
None

## How Has This Been Tested?
I've validated that this works in 2 separate AWS accounts.
