### PR TITLE
Fix cidr_block set to null if use_ipam_pool set to true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
 resource "aws_vpc" "this" {
   count = local.create_vpc ? 1 : 0
 
-  cidr_block          = var.use_ipam_pool ? null : var.cidr
+  cidr_block          = var.use_ipam_pool && var.ipv4_netmask_length != null ? null : var.cidr
   ipv4_ipam_pool_id   = var.ipv4_ipam_pool_id
   ipv4_netmask_length = var.ipv4_netmask_length
 


### PR DESCRIPTION
## Description
*cidr_block* parameter is set to `null` when *use_ipam_pool* varaiable is set to true. Thus, only *ipv4_netmask_length* is available when you want to use IPAM. However, it is possible to chose the CIDR rather than the netmask length as the [example](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/examples/ipam-vpc/main.tf) shows at line 44. 

## Motivation and Context
Want to be able to use IPAM with CIDR selection, not only with netmask length selection.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [x] Test with *cidr* provisioned as [example](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/examples/ipam-vpc/main.tf) shows at line 44
- [x] Test with *ipv4_netmask_length* provisioned as [example](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/examples/ipam-vpc/main.tf) shows at line 24
- [x] Test with *use_ipam_pool* set to *false*
- [ ] I have executed `pre-commit run -a` on my pull request

