### PR TITLE
fix: Add missing private subnets to max subnet length local

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -29,10 +29,7 @@ module "vpc" {
   cidr = local.vpc_cidr
 
   azs             = local.azs
-  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
-  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 4)]
-
-  enable_nat_gateway = false
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ locals {
   max_subnet_length = max(
     local.len_private_subnets,
     local.len_public_subnets,
+    local.len_intra_subnets,
     local.len_elasticache_subnets,
     local.len_database_subnets,
     local.len_redshift_subnets,

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
   len_outpost_subnets     = max(length(var.outpost_subnets), length(var.outpost_subnet_ipv6_prefixes))
 
   max_subnet_length = max(
+    local.len_private_subnets,
     local.len_public_subnets,
     local.len_elasticache_subnets,
     local.len_database_subnets,


### PR DESCRIPTION
## Description
- Add missing private subnets to max subnet length local

## Motivation and Context
- Allows creating private only subnets

Error from current implementation:
![image](https://user-images.githubusercontent.com/10913471/230655727-e414ce5c-e6d3-46ca-9da0-2ce5f6fb634a.png)

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
