### PR TITLE
fix: Correct typo in complete example for source VPC endpoint policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -207,7 +207,7 @@ data "aws_iam_policy_document" "dynamodb_endpoint_policy" {
 
     condition {
       test     = "StringNotEquals"
-      variable = "aws:sourceVpce"
+      variable = "aws:sourceVpc"
 
       values = [module.vpc.vpc_id]
     }


### PR DESCRIPTION
## Description
The complete example has a default DynamoDB policy that references a source VPC endpoint but sets the value to the VPC ID. This is incorrect and it should be a source VPC condition referencing a VPC ID or a source VPC endpoint condition referencing a VPC endpoint.

In keeping with the current value, I have updated the condition to reference a source VPC as a source VPC endpoint doesn't make much sense here.

## Motivation and Context
Correctness

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
