### PR TITLE
Add a constraint to the AWS provider for version 3 releases

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.73"
+      version = ">= 4.35, < 5.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description
Add an upper bound version constraint the to versions file for V3. This PR is against main, but this needs be a change against the v3 commit of the repo. https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v3.19.0

## Motivation and Context
The new version of the AWS provider v5.0.0 breaks the functionally of the v3 module. This presents a break of functionality in our deployed systems that we can not reasonably upgrade to VPC v4 at this time.

## Breaking Changes
This PR addresses a breaking change, and allows users who have pinned to version 3 to continue using it until they can upgrade to version 4.
