### PR TITLE
docs: Correct link address for `simple` example

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,6 +1,6 @@
 # Complete VPC
 
-Configuration in this directory creates set of VPC resources which may be sufficient for staging or production environment (look into [simple-vpc](../simple-vpc) for more simplified setup).
+Configuration in this directory creates set of VPC resources which may be sufficient for staging or production environment (look into [simple](../simple) for more simplified setup).
 
 There are public, private, database, ElastiCache, intra (private w/o Internet access) subnets, and NAT Gateways created in each availability zone.
 


### PR DESCRIPTION
## Description
Maybe the folder name or link address isn't right, I really don't know. Either way this is the right link address.


## Motivation and Context
It helps people find the files needed to run the example.

## How Has This Been Tested?
- [x]  It's a simple typo fix.