### PR TITLE
fix: update number of route tables in intra subnets to match num AZs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -818,12 +818,17 @@ resource "aws_subnet" "intra" {
 }
 
 resource "aws_route_table" "intra" {
-  count = local.create_intra_subnets && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
+  count = local.create_intra_subnets ? local.len_intra_subnets : 0
 
   vpc_id = local.vpc_id
 
   tags = merge(
-    { "Name" = "${var.name}-${var.intra_subnet_suffix}" },
+    {
+      "Name" = var.single_nat_gateway ? "${var.name}-${var.intra_subnet_suffix}" : format(
+        "${var.name}-${var.intra_subnet_suffix}-%s",
+        element(var.azs, count.index),
+      )
+    },
     var.tags,
     var.intra_route_table_tags,
   )

--- a/main.tf
+++ b/main.tf
@@ -818,7 +818,7 @@ resource "aws_subnet" "intra" {
 }
 
 resource "aws_route_table" "intra" {
-  count = local.create_intra_subnets ? 1 : 0
+  count = local.create_intra_subnets && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
 
   vpc_id = local.vpc_id
 
@@ -832,8 +832,11 @@ resource "aws_route_table" "intra" {
 resource "aws_route_table_association" "intra" {
   count = local.create_intra_subnets ? local.len_intra_subnets : 0
 
-  subnet_id      = element(aws_subnet.intra[*].id, count.index)
-  route_table_id = element(aws_route_table.intra[*].id, 0)
+  subnet_id = element(aws_subnet.intra[*].id, count.index)
+  route_table_id = element(
+    aws_route_table.intra[*].id,
+    var.single_nat_gateway ? 0 : count.index,
+  )
 }
 
 ################################################################################


### PR DESCRIPTION

## Description
Create one route table and associated route table association per subnet for intra subnets

## Motivation and Context
We need to deploy lambdas  in a VPC that has both private subnet and intra subnet tiers. Our use case is some lambdas will need to be able to connect to the internet via NATGWs, but some lambdas won't need any outbound internet access. For lambdas that will be deployed in the intra subnets, they will be in multiple AZs and the current pattern of only having one route table shared amongst all subnets is not compatible with patterns like having VPC endpoints / private link endpoints deployed in all subnets.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No, outputs for `intra_subnets_route_table_ids` and `intra_subnets_route_table_association_ids` will now potentially have more than 1 output.

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->

Running complete and separate-route-tables examples show that 3 route tables are now being created.

![Screenshot 2023-06-07 at 2 31 17 PM](https://github.com/terraform-aws-modules/terraform-aws-vpc/assets/28816022/81b8fdd3-7aea-4d5b-9109-756b99e15e69)

- [ x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
