### PR TITLE
fix: Use length() instead of try(coalescelist()) in output of database_route_table_ids

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -403,7 +403,7 @@ resource "aws_route_table" "database" {
 }
 
 resource "aws_route_table_association" "database" {
-  count = local.create_database_subnets ? local.len_database_subnets : 0
+  count = local.create_database_subnets && (length(aws_route_table.database[*].id) > 0 || length(aws_route_table.private[*].id) > 0) ? local.len_database_subnets : 0
 
   subnet_id = element(aws_subnet.database[*].id, count.index)
   route_table_id = element(

--- a/outputs.tf
+++ b/outputs.tf
@@ -279,7 +279,7 @@ output "database_subnet_group_name" {
 
 output "database_route_table_ids" {
   description = "List of IDs of database route tables"
-  value       = try(coalescelist(aws_route_table.database[*].id, local.private_route_table_ids), [])
+  value       = length(aws_route_table.database[*].id) > 0 ? aws_route_table.database[*].id : (length(aws_route_table.private[*].id) > 0 ? aws_route_table.private[*].id : [])
 }
 
 output "database_internet_gateway_route_id" {


### PR DESCRIPTION
## Description
Value of `database_route_table_ids` is not available during terraform plan and when tried to use the out in subsequent resources or modules, they fail because of it. 

## Motivation and Context
This change allows us to pass/use `database_route_table_ids` on first attempt instead of creating VPC first and use the output for creating the rest of the resources

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
- Tested with our current code base.
```
module "common_vpc" {
  count   = var.create_vpc ? 1 : 0
  source  = "terraform-aws-modules/vpc/aws"
  version = "4.0.2"

  name                 = local.vpc_name
  cidr                 = var.vpc_cidr
  azs                  = data.aws_availability_zones.available.names
  enable_dns_hostnames = true
  enable_nat_gateway = true
  single_nat_gateway = true
  create_database_subnet_route_table = true

  database_subnets = [
    cidrsubnet(var.vpc_cidr, var.common_vpc_subnet_newbits, 0),
    cidrsubnet(var.vpc_cidr, var.common_vpc_subnet_newbits, 1),
    cidrsubnet(var.vpc_cidr, var.common_vpc_subnet_newbits, 2)
  ]

  private_subnets = [
    cidrsubnet(var.vpc_cidr, var.common_vpc_subnet_newbits, 3)
  ]
  
  public_subnets = [
    cidrsubnet(var.vpc_cidr, var.common_vpc_subnet_newbits, 4)
  ]

  database_subnet_assign_ipv6_address_on_creation = false
  map_public_ip_on_launch                         = false
}

resource "aws_vpc_peering_connection" "requester_cross_account" {

  peer_owner_id = "7645838754" #fake
  peer_vpc_id   = "vpc-7465735w45sd" #fake
  vpc_id        = "vpc-35768fjdg" #fake
  peer_region   = "eu-west-2"
  auto_accept   = false

}
resource "aws_route" "requester_multi_account" {
  for_each = { for index, id in module.common_vpc[0].database_route_table_ids : index => id }

  route_table_id            = each.value
  destination_cidr_block    = "10.0.0.0/16"
  vpc_peering_connection_id = aws_vpc_peering_connection.requester_cross_account.id
}
```
This Produces error
```
module.common_vpc[0].database_route_table_ids will be known only after apply
│ 
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full
│ set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only
│ in the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a
│ second time to fully converge.
```

Plan succeeds after the change:
```
# aws_route.requester_multi_account["0"] will be created
  + resource "aws_route" "requester_multi_account" {
      + destination_cidr_block    = "10.0.0.0/16"
      + id                        = (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      + origin                    = (known after apply)
      + route_table_id            = (known after apply)
      + state                     = (known after apply)
      + vpc_peering_connection_id = (known after apply)
    }
```
