### PR TITLE
fix: The number of intra subnets should not influence the number of NAT gateways provisioned

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ locals {
   max_subnet_length = max(
     local.len_private_subnets,
     local.len_public_subnets,
-    local.len_intra_subnets,
     local.len_elasticache_subnets,
     local.len_database_subnets,
     local.len_redshift_subnets,


### PR DESCRIPTION
## Description
"The module does not take into account the number of intra_subnets, since the latter are designed to have no Internet access via NAT Gateway."
the concept is right, the number of intra subnets should not determine the number of nat gateways. However it currently does. Today I tried to create a vpc with :
3 intra subnets, 
2 public subnets, 
2 private subnets. 
As a result, I had 3 nat gateways (because i choose configuration nat gateway per subnet) so i had:
nat-gateway-a located in public network A
nat-gateway-b located in public network B
nat-gateway-c located in public network A (second nat gateway in the same subnet).

## Motivation and Context
makes the module work in accordance with the assumptions, documentation and logic. Keeping an unnecessary nat gateway with a public ip is just an extra cost, and 2 nat gateways in the same subnet can be confusing

## Breaking Changes
No

## How Has This Been Tested?
Yeap, on latest version 5.1.1 i removed line and everything works fine according to assumptions.