### PR TITLE
fix: Remove references to the create_vpc variable from unrelated reso…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 variable "create_vpc" {
-  description = "Controls if VPC should be created (it affects almost all resources)"
+  description = "Controls if VPC should be created"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
…urces such as subnets, route tables, and NAT gateways. If 'create_vpc' variable value is false then you have to provide vpc_id.

## Description
If i set create_vpc variable value to false then it doesn't create other resources like: Subnet, Route Table, NAT Gateway.

## Motivation and Context
Currently, Setting the create_vpc variable value to "false" ensures that the creation of additional resources such as subnets, route tables, and NAT gateways is avoided. This change is required to provide more flexibility and control over resource provisioning. It allows for a more customized deployment process, particularly in scenarios where you may already have existing resources or you want to manage these specific resources separately. By making this change, you can prevent the unnecessary creation of these resources when they are not needed, which can save resources, reduce complexity, and better align with your specific requirements.

## Breaking Changes
No, It should not break existing cluster because i have changed creation conditions

## How Has This Been Tested?
- [X ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<img width="1700" alt="image" src="https://github.com/terraform-aws-modules/terraform-aws-vpc/assets/72162406/6bc725bc-4fb6-4f50-91cf-fd2f4349947a">
