### PR TITLE
docs: Add undocumented variable `service_type`

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -22,6 +22,7 @@ module "endpoints" {
     dynamodb = {
       # gateway endpoint
       service         = "dynamodb"
+      service_type    = "Gateway"
       route_table_ids = ["rt-12322456", "rt-43433343", "rt-11223344"]
       tags            = { Name = "dynamodb-vpc-endpoint" }
     },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Hey!
When creating a VPC endpoint of type gateway, in the [docs](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest/submodules/vpc-endpoints)  it is documented that it is only needed to specify the route tables for the endpoint and it will be automatically set the endpoint of gateway. 
Unfortunately this isn't true and based on the terraform code itself a key called `service_type` need to be set as well 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will add a more clear docs on how to create a gateway endpoint

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
Basically ran it against my own AWS account and phased the issue.
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
