### PR TITLE
feat: Add multiple intra route tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -817,7 +817,6 @@ resource "aws_subnet" "intra" {
 }
 
 resource "aws_route_table" "intra" {
-#  count = local.create_intra_subnets ? 1 : 0
   count = local.create_intra_subnets && local.max_subnet_length > 0 ? local.len_intra_subnets : 0
 
   vpc_id = local.vpc_id


### PR DESCRIPTION
## Description
This adds multiple intra route tables per the number of intra subnets deployed.

## Motivation and Context
This resolves an issue where multiple intra route tables are required such as when using them in a multiple availability zone inspection vpc.  Each intra subnet needs to forward to the particular network firewall endpoint which is in the local availability zone

## Breaking Changes
There are no breaking changes as this only creates the same number of route tables as intra subnets.  

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I have tested by running the seperate-route-tables example in this branch and outputs return everything as expected to include the multiple route table ids.
- [x] I have executed `pre-commit run -a` on my pull request

