### PR TITLE
feat: add output to get dns_entry list

### DIFF
--- a/modules/vpc-endpoints/outputs.tf
+++ b/modules/vpc-endpoints/outputs.tf
@@ -16,3 +16,8 @@ output "security_group_id" {
   description = "ID of the security group"
   value       = try(aws_security_group.this[0].id, null)
 }
+
+output "dns_names" {
+  description = "DNS names of vpc endpoint for ingress"
+  value = try({for k, v in aws_vpc_endpoint.this : k => v.dns_entry}, null)
+}


### PR DESCRIPTION
…' VPC Endpoint

## Description
add output to get dns_names of aws_vpc_endpoint resource
## Motivation and Context
To facilitate the selection of DNS names of the VPC Endpoint

## Breaking Changes
No

## How Has This Been Tested?
It has been tested in on-premise infra and resource.tf file use this output and achieve my goal.
e.g
```
  module "records_test" {
  source = "./modules/aws-route53/modules/records"
  depends_on = [ module.zone_ingress_test ]

  zone_id = module.zone_ingress_test.route53_zone_zone_id[var.domain_ingress_test]

  records = [
    {
      name           = "*.apps.internal"
      type           = "CNAME"
      ttl            = 300
      # records        = [module.ingress_endpoints.dns_names[0]["dns_name"]]
      records        = [module.ingress_endpoints.dns_names["ingress_endpoint"][0]["dns_name"]]
      }
  ]
}
```