### PR TITLE
feat: Add support for `dns_options` on VPC endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ Full contributing [guidelines are covered here](.github/contributing.md).
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -102,8 +102,12 @@ module "vpc_endpoints" {
 
   endpoints = {
     s3 = {
-      service = "s3"
-      tags    = { Name = "s3-vpc-endpoint" }
+      service             = "s3"
+      private_dns_enabled = true
+      dns_options = {
+        private_dns_only_for_inbound_resolver_endpoint = false
+      }
+      tags = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {
       service         = "dynamodb"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/ipam/README.md
+++ b/examples/ipam/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/ipam/versions.tf
+++ b/examples/ipam/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/ipv6-dualstack/README.md
+++ b/examples/ipv6-dualstack/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/ipv6-dualstack/versions.tf
+++ b/examples/ipv6-dualstack/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/ipv6-only/README.md
+++ b/examples/ipv6-only/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/ipv6-only/versions.tf
+++ b/examples/ipv6-only/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -25,13 +25,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/issues/versions.tf
+++ b/examples/issues/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/manage-default-vpc/README.md
+++ b/examples/manage-default-vpc/README.md
@@ -22,7 +22,7 @@ Run `terraform destroy` when you don't need these resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 

--- a/examples/manage-default-vpc/versions.tf
+++ b/examples/manage-default-vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/network-acls/README.md
+++ b/examples/network-acls/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/network-acls/versions.tf
+++ b/examples/network-acls/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/outpost/README.md
+++ b/examples/outpost/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/outpost/versions.tf
+++ b/examples/outpost/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/secondary-cidr-blocks/README.md
+++ b/examples/secondary-cidr-blocks/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/secondary-cidr-blocks/versions.tf
+++ b/examples/secondary-cidr-blocks/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/separate-route-tables/README.md
+++ b/examples/separate-route-tables/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/separate-route-tables/versions.tf
+++ b/examples/separate-route-tables/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -26,13 +26,13 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/vpc-flow-logs/versions.tf
+++ b/examples/vpc-flow-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
 
     random = {

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -56,13 +56,13 @@ module "endpoints" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
 
 ## Modules
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -34,9 +34,9 @@ resource "aws_vpc_endpoint" "this" {
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
   dynamic "dns_options" {
-    for_each = try(each.value.private_dns_enabled,false) ? [try(each.value.dns_options, {})] : []
+    for_each = try(each.value.private_dns_enabled, false) ? [try(each.value.dns_options, {})] : []
     content {
-      dns_record_ip_type = try(each.value.dns_options.dns_record_ip_type,null)
+      dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
       private_dns_only_for_inbound_resolver_endpoint = try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false)
     }
   }

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -34,10 +34,10 @@ resource "aws_vpc_endpoint" "this" {
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
   dynamic "dns_options" {
-    for_each = try(each.value.private_dns_enabled, false) ? [try(each.value.dns_options, {})] : []
+    for_each = lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : []
     content {
       dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
-      private_dns_only_for_inbound_resolver_endpoint = try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false)
+      private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_enabled, false) ? try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false) : null
     }
   }
   tags = merge(var.tags, try(each.value.tags, {}))

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -33,13 +33,16 @@ resource "aws_vpc_endpoint" "this" {
   route_table_ids     = try(each.value.service_type, "Interface") == "Gateway" ? lookup(each.value, "route_table_ids", null) : null
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
+
   dynamic "dns_options" {
-    for_each = try(each.value.service_type, "Interface") == "Interface" ? lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : [{}] : []
+    for_each = try([each.value.dns_options], [])
+
     content {
       dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
-      private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_enabled, false) ? try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false) : null
+      private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_only_for_inbound_resolver_endpoint, null)
     }
   }
+
   tags = merge(var.tags, try(each.value.tags, {}))
 
   timeouts {

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -34,7 +34,7 @@ resource "aws_vpc_endpoint" "this" {
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
   dynamic "dns_options" {
-    for_each = lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : []
+    for_each = try(each.value.service_type, "Interface") == "Interface" ? lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : [] : []
     content {
       dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
       private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_enabled, false) ? try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false) : null

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -34,7 +34,7 @@ resource "aws_vpc_endpoint" "this" {
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
   dynamic "dns_options" {
-    for_each = try(each.value.service_type, "Interface") == "Interface" ? lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : [] : []
+    for_each = try(each.value.service_type, "Interface") == "Interface" ? lookup(each.value, "dns_options", null) != null ? [each.value.dns_options] : [{}] : []
     content {
       dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
       private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_enabled, false) ? try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false) : null

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -33,7 +33,13 @@ resource "aws_vpc_endpoint" "this" {
   route_table_ids     = try(each.value.service_type, "Interface") == "Gateway" ? lookup(each.value, "route_table_ids", null) : null
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
-
+  dynamic "dns_options" {
+    for_each = try(each.value.private_dns_enabled,false) ? [try(each.value.dns_options, {})] : []
+    content {
+      dns_record_ip_type = try(each.value.dns_options.dns_record_ip_type,null)
+      private_dns_only_for_inbound_resolver_endpoint = try(each.value.dns_options.private_dns_only_for_inbound_resolver_endpoint, false)
+    }
+  }
   tags = merge(var.tags, try(each.value.tags, {}))
 
   timeouts {

--- a/modules/vpc-endpoints/versions.tf
+++ b/modules/vpc-endpoints/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.20"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
add dns_options block to use it in cases of endpoints that support gateway and interface 

## Motivation and Context
- Resolves #982

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
there is no user input change, if the array is not existend or private_dns_enabled is false it will not trigger a change
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
tested locally
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
