### PR TITLE
feat: Support for multiple public route tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ No modules.
 | <a name="input_create_flow_log_cloudwatch_iam_role"></a> [create\_flow\_log\_cloudwatch\_iam\_role](#input\_create\_flow\_log\_cloudwatch\_iam\_role) | Whether to create IAM role for VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_create_flow_log_cloudwatch_log_group"></a> [create\_flow\_log\_cloudwatch\_log\_group](#input\_create\_flow\_log\_cloudwatch\_log\_group) | Whether to create CloudWatch log group for VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_create_igw"></a> [create\_igw](#input\_create\_igw) | Controls if an Internet Gateway is created for public subnets and the related routes that connect them | `bool` | `true` | no |
+| <a name="input_create_multiple_public_route_tables"></a> [create\_multiple\_public\_route\_tables](#input\_create\_multiple\_public\_route\_tables) | Creating multiple public route tables | `bool` | `false` | no |
 | <a name="input_create_redshift_subnet_group"></a> [create\_redshift\_subnet\_group](#input\_create\_redshift\_subnet\_group) | Controls if redshift subnet group should be created | `bool` | `true` | no |
 | <a name="input_create_redshift_subnet_route_table"></a> [create\_redshift\_subnet\_route\_table](#input\_create\_redshift\_subnet\_route\_table) | Controls if separate route table for redshift should be created | `bool` | `false` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Controls if VPC should be created (it affects almost all resources) | `bool` | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -250,6 +250,12 @@ variable "public_route_table_tags" {
   default     = {}
 }
 
+variable "create_multiple_public_route_tables" {
+  description = "Creating multiple public route tables"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Public Network ACLs
 ################################################################################


### PR DESCRIPTION
## Description
Support for multiple route tables when creating public subnets

## Motivation and Context
Guarantee that the used route table for public subnets on creation is different when a boolean variable is set to true.
Motivation from issue https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1020 
## Breaking Changes
No breaking changes, as the variable is optional and defaulted to 'false'. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Used the examples/simple/* directory as a start. Changed the `private_subnets` array for `public_subnets` and verified that the behavior described by the requester is happening. Included the variable `create_multiple_public_route_tables` and set to true. Verified in multiple runs of apply and destroy that the created route table is different for each new public subnet. 

Changes to examples/simple/ have not been reflected on the push. I also did not want to copy-paste the contents of 'simple' for this use case, for a more clean, less complex state of the examples folder. Please let me know if you prefer the example to be included. 
