### PR TITLE
feat: Add validation to limit secondary_cidr_blocks to max 4 entries

### DIFF
--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -9,7 +9,7 @@ locals {
   region = "eu-west-1"
 
   vpc_cidr              = "10.0.0.0/16"
-  secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16"]
+  secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
   azs                   = slice(data.aws_availability_zones.available.names, 0, 3)
 
   tags = {

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -9,7 +9,7 @@ locals {
   region = "eu-west-1"
 
   vpc_cidr              = "10.0.0.0/16"
-  secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
+  secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16"]
   azs                   = slice(data.aws_availability_zones.available.names, 0, 3)
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,10 @@ variable "secondary_cidr_blocks" {
   description = "List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool"
   type        = list(string)
   default     = []
+  validation {
+    condition     = length(var.secondary_cidr_blocks) <= 4
+    error_message = "The number of secondary CIDR blocks cannot exceed 4."
+  }
 }
 
 variable "instance_tenancy" {


### PR DESCRIPTION
## Description
Add validation to limit secondary_cidr_blocks to max 4 entries

## Motivation and Context
- Introduce a validation block within the variable 'secondary_cidr_blocks'
- Ensure the list of CIDR blocks does not exceed 4 entries
- Provide a clear error message for configurations exceeding the limit

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
