### PR TITLE
fix: Correct VPC endpoint private DNS resolver `for_each` key

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -38,8 +38,8 @@ resource "aws_vpc_endpoint" "this" {
     for_each = try([each.value.dns_options], [])
 
     content {
-      dns_record_ip_type                             = try(each.value.dns_options.dns_record_ip_type, null)
-      private_dns_only_for_inbound_resolver_endpoint = try(each.value.private_dns_only_for_inbound_resolver_endpoint, null)
+      dns_record_ip_type                             = try(dns_options.value.dns_options.dns_record_ip_type, null)
+      private_dns_only_for_inbound_resolver_endpoint = try(dns_options.value.private_dns_only_for_inbound_resolver_endpoint, null)
     }
   }
 


### PR DESCRIPTION
## Description
- Correct VPC endpoint private DNS resolver `for_each` key

## Motivation and Context
- Resolves #1028

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
