### PR TITLE
fix: Dns_options for vpc-endpoints

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -34,13 +34,9 @@ resource "aws_vpc_endpoint" "this" {
   policy              = try(each.value.policy, null)
   private_dns_enabled = try(each.value.service_type, "Interface") == "Interface" ? try(each.value.private_dns_enabled, null) : null
 
-  dynamic "dns_options" {
-    for_each = try([each.value.dns_options], [])
-
-    content {
-      dns_record_ip_type                             = try(dns_options.value.dns_options.dns_record_ip_type, null)
-      private_dns_only_for_inbound_resolver_endpoint = try(dns_options.value.private_dns_only_for_inbound_resolver_endpoint, null)
-    }
+  dns_options {
+    dns_record_ip_type                             = try(each.value.dns_options["dns_record_ip_type"], null)
+    private_dns_only_for_inbound_resolver_endpoint = try(each.value.dns_options["private_dns_only_for_inbound_resolver_endpoint"], null)
   }
 
   tags = merge(var.tags, try(each.value.tags, {}))


### PR DESCRIPTION
## Description

While trying to setup an S3 VPC endpoint I found I could not set `dns_options.private_dns_only_for_inbound_resolver_endpoint` even though this was apparently resolved by https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1029

To see what was going on under the hood, I removed the `try` wrapping `private_dns_only_for_inbound_resolver_endpoint` and got this error:

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Unsupported attribute
│
│   on .terraform/modules/endpoints/modules/vpc-endpoints/main.tf line 42, in resource "aws_vpc_endpoint" "this":
│   42:       private_dns_only_for_inbound_resolver_endpoint = dns_options.value.private_dns_only_for_inbound_resolver_endpoint
│     ├────────────────
│     │ dns_options.value is false
│
│ Can't access attributes on a primitive-typed value (bool).
```

So this whole thing is already off. Idk why `dns_options.value` is a bool, all I know is it has something to do with the `dynamic` block being used here.

I noticed the `dynamic` block is not needed. You're only allowed one `dns_options` block for the `aws_vpc_endpoint` resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint#dns_options

So I removed the `dynamic` block and updated the value lookups to `each.value.dns_options[]` which now works.

For an S3 service, with
`dns_options.private_dns_only_for_inbound_resolver_endpoint` set to `false`, this is the plan it generated:

```
+ resource "aws_vpc_endpoint" "this" {
   + arn                   = (known after apply)
   + cidr_blocks           = (known after apply)
   + dns_entry             = (known after apply)
   + id                    = (known after apply)
   + ip_address_type       = (known after apply)
   + network_interface_ids = (known after apply)
   + owner_id              = (known after apply)
   + policy                = jsonencode(
         {
           + Statement = [
               + {
                   + Action    = "*"
                   + Condition = {
                       + StringNotEquals = {
                           + "aws:SourceVpc" = "vpc-0518b6428b706516d"
                         }
                     }
                   + Effect    = "Deny"
                   + Principal = "*"
                   + Resource  = "*"
                 },
             ]
           + Version   = "2012-10-17"
         }
     )
   + prefix_list_id        = (known after apply)
   + private_dns_enabled   = true
   + requester_managed     = (known after apply)
   + route_table_ids       = (known after apply)
   + security_group_ids    = [
       + "sg-050ed3bb7b46fd681",
     ]
   + service_name          = "com.amazonaws.us-east-1.s3"
   + state                 = (known after apply)
   + subnet_ids            = [
       + "subnet-0af61b529ffb7940b",
       + "subnet-0dd27b92ffe0d02cd",
     ]
   + tags                  = {
       + "Name" = "s3"
     }
   + tags_all              = {
       + "Name" = "s3"
     }
   + vpc_endpoint_type     = "Interface"
   + vpc_id                = "vpc-0518b6428b706516d"

   + dns_options {
       + dns_record_ip_type                             = (known after apply)
       + private_dns_only_for_inbound_resolver_endpoint = false
     }

   + timeouts {
       + create = "10m"
       + delete = "10m"
       + update = "10m"
     }
 }
```

For a resource that did not pass in a `dns_options`, like this:

```hcl
...
ecr_api = {
      service             = "ecr.api"
      private_dns_enabled = true
      subnet_ids          = module.vpc.private_subnets
      policy              = data.aws_iam_policy_document.generic_endpoint_policy.json
    },
...
```

I got this plan:
```
+ resource "aws_vpc_endpoint" "this" {
   + arn                   = (known after apply)
   + cidr_blocks           = (known after apply)
   + dns_entry             = (known after apply)
   + id                    = (known after apply)
   + ip_address_type       = (known after apply)
   + network_interface_ids = (known after apply)
   + owner_id              = (known after apply)
   + policy                = jsonencode(
         {
           + Statement = [
               + {
                   + Action    = "*"
                   + Condition = {
                       + StringNotEquals = {
                           + "aws:SourceVpc" = "vpc-0518b6428b706516d"
                         }
                     }
                   + Effect    = "Deny"
                   + Principal = "*"
                   + Resource  = "*"
                 },
             ]
           + Version   = "2012-10-17"
         }
     )
   + prefix_list_id        = (known after apply)
   + private_dns_enabled   = true
   + requester_managed     = (known after apply)
   + route_table_ids       = (known after apply)
   + security_group_ids    = [
       + "sg-050ed3bb7b46fd681",
     ]
   + service_name          = "com.amazonaws.us-east-1.ecr.api"
   + state                 = (known after apply)
   + subnet_ids            = [
       + "subnet-0af61b529ffb7940b",
       + "subnet-0dd27b92ffe0d02cd",
     ]
   + tags                  = {
       + "Name" = "ecr.api"
     }
   + tags_all              = {
       + "Name" = "ecr.api"
     }
   + vpc_endpoint_type     = "Interface"
   + vpc_id                = "vpc-0518b6428b706516d"

   + dns_options {
       + dns_record_ip_type = (known after apply)
     }

   + timeouts {
       + create = "10m"
       + delete = "10m"
       + update = "10m"
     }
 }
```

I think the removal of the `dynamic` block simplifies things now. It's easier to see what's going on. There should be no change for anyone that isn't setting `dns_options` as shown by my plan output above.


## Breaking Changes
None. For VPCE's that I had beforehand, nothing changed for them. Existing setup was respected.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
