### PR TITLE
fix: Added create_before_destroy to aws_customer_gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1127,7 +1127,6 @@ resource "aws_customer_gateway" "this" {
   lifecycle {
     create_before_destroy = true
   }
-
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -1123,6 +1123,11 @@ resource "aws_customer_gateway" "this" {
     var.tags,
     var.customer_gateway_tags,
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
 }
 
 ################################################################################


### PR DESCRIPTION


## Description
In case of customer_gateway is used with TGW this changes will allow us to replace ip_address in the single `terraform apply`


## Motivation and Context
```
│ Error: deleting EC2 Customer Gateway (cgw-xxxxxxxxx): IncorrectState: The customer gateway is in use.
│       status code: 400, request id: xxxxxx-994b-xxxx-xxx-xxxxxx
```

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Was tested on production system
