### PR TITLE
docs: Specify service_type for Gateway endpoint

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -28,10 +28,10 @@ module "endpoints" {
       tags            = { Name = "dynamodb-vpc-endpoint" }
     },
     sns = {
-      service    = "sns"
-      service_type    = "Interface"
-      subnet_ids = ["subnet-12345678", "subnet-87654321"]
-      tags       = { Name = "sns-vpc-endpoint" }
+      service      = "sns"
+      service_type = "Interface"
+      subnet_ids   = ["subnet-12345678", "subnet-87654321"]
+      tags         = { Name = "sns-vpc-endpoint" }
     },
     sqs = {
       service             = "sqs"

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -17,21 +17,25 @@ module "endpoints" {
     s3 = {
       # interface endpoint
       service             = "s3"
+      service_type        = "Interface"
       tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {
       # gateway endpoint
       service         = "dynamodb"
+      service_type    = "Gateway"
       route_table_ids = ["rt-12322456", "rt-43433343", "rt-11223344"]
       tags            = { Name = "dynamodb-vpc-endpoint" }
     },
     sns = {
       service    = "sns"
+      service_type    = "Interface"
       subnet_ids = ["subnet-12345678", "subnet-87654321"]
       tags       = { Name = "sns-vpc-endpoint" }
     },
     sqs = {
       service             = "sqs"
+      service_type        = "Interface"
       private_dns_enabled = true
       security_group_ids  = ["sg-987654321"]
       subnet_ids          = ["subnet-12345678", "subnet-87654321"]


### PR DESCRIPTION


## Description
This commit adds `service_type` to example code at README since current sample code causes the following error:

> Error: no matching EC2 VPC Endpoint Service found ... data.aws_vpc_endpoint_service.this["dynamodb"]

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
