### PR TITLE
Add support for multiple route tables to public and intra subnets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,12 @@ variable "public_subnet_enable_resource_name_dns_a_record_on_launch" {
   default     = false
 }
 
+variable "public_subnet_create_multiple_route_tables" {
+  description = "Indicates whether to create a separate route table for each public subnet. Default: `false`"
+  type        = bool
+  default     = false
+}
+
 variable "public_subnet_ipv6_prefixes" {
   description = "Assigns IPv6 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list"
   type        = list(string)
@@ -910,6 +916,12 @@ variable "intra_subnet_enable_resource_name_dns_aaaa_record_on_launch" {
 
 variable "intra_subnet_enable_resource_name_dns_a_record_on_launch" {
   description = "Indicates whether to respond to DNS queries for instance hostnames with DNS A records. Default: `false`"
+  type        = bool
+  default     = false
+}
+
+variable "intra_subnet_create_multiple_route_tables" {
+  description = "Indicates whether to create a separate route table for each intra subnet. Default: `false`"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Support for multiple route tables when creating public and intra subnets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Guarantee that the used route table for public and intra subnets on creation is different when a boolean variable is set to true.
Motivation from issue https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1020

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes, as the variables are optional and defaulted to `false`.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Changes were tested in a staging environment where existing public and intra subnets and route tables existed. Multiple route tables were enabled for both public and intra subnets. The existing route tables and associations were successfully updated and network traffic continued to flow as normal.
