### PR TITLE
feat: Allow setting vpc endpoints as an input for each endpoint

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -24,7 +24,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = data.aws_vpc_endpoint_service.this[each.key].service_name
+  service_name      = try(each.value.service_endpoint_url, data.aws_vpc_endpoint_service.this[each.key].service_name)
   vpc_endpoint_type = try(each.value.service_type, "Interface")
   auto_accept       = try(each.value.auto_accept, null)
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -24,7 +24,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = try(each.value.service_endpoint_url, data.aws_vpc_endpoint_service.this[each.key].service_name)
+  service_name      = try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name)
   vpc_endpoint_type = try(each.value.service_type, "Interface")
   auto_accept       = try(each.value.auto_accept, null)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


Adds feature to allow overriding for each `aws_vpc_endpoint` `service_name` property, but defaulting to data if not defined.

Additionally this allows users to use specify fips endpoints if needed.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #1054 



## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Have a PR here for an example where this was tested using changes in my `.terraform` directory which I replicated in this fork.
https://github.com/defenseunicorns/terraform-aws-vpc/pull/113
