### PR TITLE
fix: Create private_ipv6_egress routes only when having at least one private subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1021,7 +1021,7 @@ resource "aws_egress_only_internet_gateway" "this" {
 }
 
 resource "aws_route" "private_ipv6_egress" {
-  count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 ? local.nat_gateway_count : 0
+  count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 && local.len_private_subnets > 0 ? local.nat_gateway_count : 0
 
   route_table_id              = element(aws_route_table.private[*].id, count.index)
   destination_ipv6_cidr_block = "::/0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Private IPv6 Egress routes are now only created when having at least a private subnet

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Version 5.7.1 of the module solved the issue #1058 by limiting the amount of IPv6 egress routes created to the amount of NAT gateways provisioned (hence to the amount of Route Tables created).

However the condition that regulates the number of IPv6 egress routes created doesn't check if the creation of any private subnet is actually wanted 

<!--- If it fixes an open issue, please link to the issue here. -->
- Resolves #1061 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

