### PR TITLE
fix: Db subnets can use private route tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,8 @@ resource "aws_network_acl_rule" "public_outbound" {
 ################################################################################
 
 locals {
-  create_private_subnets = local.create_vpc && local.len_private_subnets > 0
+  create_private_subnets     = local.create_vpc && local.len_private_subnets > 0
+  create_private_route_table = (local.create_private_subnets && local.max_subnet_length > 0) || (local.create_database_subnets && !local.create_database_route_table) || (local.create_redshift_subnets && !local.create_redshift_route_table) || (local.create_elasticache_subnets && !local.create_elasticache_route_table)
 }
 
 resource "aws_subnet" "private" {
@@ -251,7 +252,7 @@ resource "aws_subnet" "private" {
 
 # There are as many routing tables as the number of NAT gateways
 resource "aws_route_table" "private" {
-  count = local.create_private_subnets && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
+  count = local.create_private_route_table ? local.nat_gateway_count : 0
 
   vpc_id = local.vpc_id
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
database/redshift/elasticache subnets can use private route tables.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/944

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
