### PR TITLE
feat: Allow the creation of CIDR block associations using IPAM pools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ No modules.
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
+| [aws_vpc_ipv4_cidr_block_association.ipam](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv4_cidr_block_association) | resource |
 | [aws_vpc_ipv4_cidr_block_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv4_cidr_block_association) | resource |
 | [aws_vpn_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway) | resource |
 | [aws_vpn_gateway_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_attachment) | resource |
@@ -572,6 +573,8 @@ No modules.
 | <a name="input_redshift_subnets"></a> [redshift\_subnets](#input\_redshift\_subnets) | A list of redshift subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_reuse_nat_ips"></a> [reuse\_nat\_ips](#input\_reuse\_nat\_ips) | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
+| <a name="input_secondary_ipam_pool_ids"></a> [secondary\_ipam\_pool\_ids](#input\_secondary\_ipam\_pool\_ids) | List of secondary IPAM pool IDs to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
+| <a name="input_secondary_ipam_pool_netmask"></a> [secondary\_ipam\_pool\_netmask](#input\_secondary\_ipam\_pool\_netmask) | List of secondary IPAM pool netmasks to associate with the VPC to extend the IP Address pool | `list(number)` | `[]` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_ipam_pool"></a> [use\_ipam\_pool](#input\_use\_ipam\_pool) | Determines whether IPAM pool is used for CIDR allocation | `bool` | `false` | no |
@@ -697,6 +700,7 @@ No modules.
 | <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC |
 | <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC |
 | <a name="output_vpc_secondary_cidr_blocks"></a> [vpc\_secondary\_cidr\_blocks](#output\_vpc\_secondary\_cidr\_blocks) | List of secondary CIDR blocks of the VPC |
+| <a name="output_vpc_secondary_cidr_blocks_ipam"></a> [vpc\_secondary\_cidr\_blocks\_ipam](#output\_vpc\_secondary\_cidr\_blocks\_ipam) | List of secondary CIDR blocks allocated from the IPAM for the VPC |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/ipam-secondary-cidr/README.md
+++ b/examples/ipam-secondary-cidr/README.md
@@ -1,0 +1,176 @@
+# VPC with IPAM pool
+
+The configuration in this directory creates a VPC resource using the CIDR provided by an IPAM pool for the primary CIDR and for additional secondary CIDRs, all sourced from IPAM.
+
+Note: Due to the nature of vending CIDR blocks from an IPAM pool, the IPAM pool must exist prior to creating a VPC using one of the CIDRs from the pool.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply -target=aws_vpc_ipam_preview_next_cidr.this # CIDR pool must exist before assigning CIDR from pool
+$ terraform apply
+```
+
+To destroy this example you can execute:
+
+```bash
+$ terraform destroy -target=module.vpc # destroy VPC that uses the IPAM pool CIDR first
+$ terraform destroy
+```
+
+Note that this example may create resources which can cost money (AWS Elastic IP, for example). Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.30 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.30 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc_ipam_secondary"></a> [vpc\_ipam\_secondary](#module\_vpc\_ipam\_secondary) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_vpc_ipam.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam) | resource |
+| [aws_vpc_ipam.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam) | resource |
+| [aws_vpc_ipam_pool.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool) | resource |
+| [aws_vpc_ipam_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool) | resource |
+| [aws_vpc_ipam_pool_cidr.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool_cidr) | resource |
+| [aws_vpc_ipam_pool_cidr.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_pool_cidr) | resource |
+| [aws_vpc_ipam_preview_next_cidr.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_preview_next_cidr) | resource |
+| [aws_vpc_ipam_preview_next_cidr.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_preview_next_cidr) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cgw_arns"></a> [cgw\_arns](#output\_cgw\_arns) | List of ARNs of Customer Gateway |
+| <a name="output_cgw_ids"></a> [cgw\_ids](#output\_cgw\_ids) | List of IDs of Customer Gateway |
+| <a name="output_database_internet_gateway_route_id"></a> [database\_internet\_gateway\_route\_id](#output\_database\_internet\_gateway\_route\_id) | ID of the database internet gateway route |
+| <a name="output_database_ipv6_egress_route_id"></a> [database\_ipv6\_egress\_route\_id](#output\_database\_ipv6\_egress\_route\_id) | ID of the database IPv6 egress route |
+| <a name="output_database_nat_gateway_route_ids"></a> [database\_nat\_gateway\_route\_ids](#output\_database\_nat\_gateway\_route\_ids) | List of IDs of the database nat gateway route |
+| <a name="output_database_network_acl_arn"></a> [database\_network\_acl\_arn](#output\_database\_network\_acl\_arn) | ARN of the database network ACL |
+| <a name="output_database_network_acl_id"></a> [database\_network\_acl\_id](#output\_database\_network\_acl\_id) | ID of the database network ACL |
+| <a name="output_database_route_table_association_ids"></a> [database\_route\_table\_association\_ids](#output\_database\_route\_table\_association\_ids) | List of IDs of the database route table association |
+| <a name="output_database_route_table_ids"></a> [database\_route\_table\_ids](#output\_database\_route\_table\_ids) | List of IDs of database route tables |
+| <a name="output_database_subnet_arns"></a> [database\_subnet\_arns](#output\_database\_subnet\_arns) | List of ARNs of database subnets |
+| <a name="output_database_subnet_group"></a> [database\_subnet\_group](#output\_database\_subnet\_group) | ID of database subnet group |
+| <a name="output_database_subnet_group_name"></a> [database\_subnet\_group\_name](#output\_database\_subnet\_group\_name) | Name of database subnet group |
+| <a name="output_database_subnets"></a> [database\_subnets](#output\_database\_subnets) | List of IDs of database subnets |
+| <a name="output_database_subnets_cidr_blocks"></a> [database\_subnets\_cidr\_blocks](#output\_database\_subnets\_cidr\_blocks) | List of cidr\_blocks of database subnets |
+| <a name="output_database_subnets_ipv6_cidr_blocks"></a> [database\_subnets\_ipv6\_cidr\_blocks](#output\_database\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of database subnets in an IPv6 enabled VPC |
+| <a name="output_default_network_acl_id"></a> [default\_network\_acl\_id](#output\_default\_network\_acl\_id) | The ID of the default network ACL |
+| <a name="output_default_route_table_id"></a> [default\_route\_table\_id](#output\_default\_route\_table\_id) | The ID of the default route table |
+| <a name="output_default_security_group_id"></a> [default\_security\_group\_id](#output\_default\_security\_group\_id) | The ID of the security group created by default on VPC creation |
+| <a name="output_default_vpc_arn"></a> [default\_vpc\_arn](#output\_default\_vpc\_arn) | The ARN of the Default VPC |
+| <a name="output_default_vpc_cidr_block"></a> [default\_vpc\_cidr\_block](#output\_default\_vpc\_cidr\_block) | The CIDR block of the Default VPC |
+| <a name="output_default_vpc_default_network_acl_id"></a> [default\_vpc\_default\_network\_acl\_id](#output\_default\_vpc\_default\_network\_acl\_id) | The ID of the default network ACL of the Default VPC |
+| <a name="output_default_vpc_default_route_table_id"></a> [default\_vpc\_default\_route\_table\_id](#output\_default\_vpc\_default\_route\_table\_id) | The ID of the default route table of the Default VPC |
+| <a name="output_default_vpc_default_security_group_id"></a> [default\_vpc\_default\_security\_group\_id](#output\_default\_vpc\_default\_security\_group\_id) | The ID of the security group created by default on Default VPC creation |
+| <a name="output_default_vpc_enable_dns_hostnames"></a> [default\_vpc\_enable\_dns\_hostnames](#output\_default\_vpc\_enable\_dns\_hostnames) | Whether or not the Default VPC has DNS hostname support |
+| <a name="output_default_vpc_enable_dns_support"></a> [default\_vpc\_enable\_dns\_support](#output\_default\_vpc\_enable\_dns\_support) | Whether or not the Default VPC has DNS support |
+| <a name="output_default_vpc_id"></a> [default\_vpc\_id](#output\_default\_vpc\_id) | The ID of the Default VPC |
+| <a name="output_default_vpc_instance_tenancy"></a> [default\_vpc\_instance\_tenancy](#output\_default\_vpc\_instance\_tenancy) | Tenancy of instances spin up within Default VPC |
+| <a name="output_default_vpc_main_route_table_id"></a> [default\_vpc\_main\_route\_table\_id](#output\_default\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with the Default VPC |
+| <a name="output_dhcp_options_id"></a> [dhcp\_options\_id](#output\_dhcp\_options\_id) | The ID of the DHCP options |
+| <a name="output_egress_only_internet_gateway_id"></a> [egress\_only\_internet\_gateway\_id](#output\_egress\_only\_internet\_gateway\_id) | The ID of the egress only Internet Gateway |
+| <a name="output_elasticache_network_acl_arn"></a> [elasticache\_network\_acl\_arn](#output\_elasticache\_network\_acl\_arn) | ARN of the elasticache network ACL |
+| <a name="output_elasticache_network_acl_id"></a> [elasticache\_network\_acl\_id](#output\_elasticache\_network\_acl\_id) | ID of the elasticache network ACL |
+| <a name="output_elasticache_route_table_association_ids"></a> [elasticache\_route\_table\_association\_ids](#output\_elasticache\_route\_table\_association\_ids) | List of IDs of the elasticache route table association |
+| <a name="output_elasticache_route_table_ids"></a> [elasticache\_route\_table\_ids](#output\_elasticache\_route\_table\_ids) | List of IDs of elasticache route tables |
+| <a name="output_elasticache_subnet_arns"></a> [elasticache\_subnet\_arns](#output\_elasticache\_subnet\_arns) | List of ARNs of elasticache subnets |
+| <a name="output_elasticache_subnet_group"></a> [elasticache\_subnet\_group](#output\_elasticache\_subnet\_group) | ID of elasticache subnet group |
+| <a name="output_elasticache_subnet_group_name"></a> [elasticache\_subnet\_group\_name](#output\_elasticache\_subnet\_group\_name) | Name of elasticache subnet group |
+| <a name="output_elasticache_subnets"></a> [elasticache\_subnets](#output\_elasticache\_subnets) | List of IDs of elasticache subnets |
+| <a name="output_elasticache_subnets_cidr_blocks"></a> [elasticache\_subnets\_cidr\_blocks](#output\_elasticache\_subnets\_cidr\_blocks) | List of cidr\_blocks of elasticache subnets |
+| <a name="output_elasticache_subnets_ipv6_cidr_blocks"></a> [elasticache\_subnets\_ipv6\_cidr\_blocks](#output\_elasticache\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of elasticache subnets in an IPv6 enabled VPC |
+| <a name="output_igw_arn"></a> [igw\_arn](#output\_igw\_arn) | The ARN of the Internet Gateway |
+| <a name="output_igw_id"></a> [igw\_id](#output\_igw\_id) | The ID of the Internet Gateway |
+| <a name="output_intra_network_acl_arn"></a> [intra\_network\_acl\_arn](#output\_intra\_network\_acl\_arn) | ARN of the intra network ACL |
+| <a name="output_intra_network_acl_id"></a> [intra\_network\_acl\_id](#output\_intra\_network\_acl\_id) | ID of the intra network ACL |
+| <a name="output_intra_route_table_association_ids"></a> [intra\_route\_table\_association\_ids](#output\_intra\_route\_table\_association\_ids) | List of IDs of the intra route table association |
+| <a name="output_intra_route_table_ids"></a> [intra\_route\_table\_ids](#output\_intra\_route\_table\_ids) | List of IDs of intra route tables |
+| <a name="output_intra_subnet_arns"></a> [intra\_subnet\_arns](#output\_intra\_subnet\_arns) | List of ARNs of intra subnets |
+| <a name="output_intra_subnets"></a> [intra\_subnets](#output\_intra\_subnets) | List of IDs of intra subnets |
+| <a name="output_intra_subnets_cidr_blocks"></a> [intra\_subnets\_cidr\_blocks](#output\_intra\_subnets\_cidr\_blocks) | List of cidr\_blocks of intra subnets |
+| <a name="output_intra_subnets_ipv6_cidr_blocks"></a> [intra\_subnets\_ipv6\_cidr\_blocks](#output\_intra\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of intra subnets in an IPv6 enabled VPC |
+| <a name="output_nat_ids"></a> [nat\_ids](#output\_nat\_ids) | List of allocation ID of Elastic IPs created for AWS NAT Gateway |
+| <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | List of public Elastic IPs created for AWS NAT Gateway |
+| <a name="output_natgw_ids"></a> [natgw\_ids](#output\_natgw\_ids) | List of NAT Gateway IDs |
+| <a name="output_outpost_network_acl_arn"></a> [outpost\_network\_acl\_arn](#output\_outpost\_network\_acl\_arn) | ARN of the outpost network ACL |
+| <a name="output_outpost_network_acl_id"></a> [outpost\_network\_acl\_id](#output\_outpost\_network\_acl\_id) | ID of the outpost network ACL |
+| <a name="output_outpost_subnet_arns"></a> [outpost\_subnet\_arns](#output\_outpost\_subnet\_arns) | List of ARNs of outpost subnets |
+| <a name="output_outpost_subnets"></a> [outpost\_subnets](#output\_outpost\_subnets) | List of IDs of outpost subnets |
+| <a name="output_outpost_subnets_cidr_blocks"></a> [outpost\_subnets\_cidr\_blocks](#output\_outpost\_subnets\_cidr\_blocks) | List of cidr\_blocks of outpost subnets |
+| <a name="output_outpost_subnets_ipv6_cidr_blocks"></a> [outpost\_subnets\_ipv6\_cidr\_blocks](#output\_outpost\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of outpost subnets in an IPv6 enabled VPC |
+| <a name="output_private_ipv6_egress_route_ids"></a> [private\_ipv6\_egress\_route\_ids](#output\_private\_ipv6\_egress\_route\_ids) | List of IDs of the ipv6 egress route |
+| <a name="output_private_nat_gateway_route_ids"></a> [private\_nat\_gateway\_route\_ids](#output\_private\_nat\_gateway\_route\_ids) | List of IDs of the private nat gateway route |
+| <a name="output_private_network_acl_arn"></a> [private\_network\_acl\_arn](#output\_private\_network\_acl\_arn) | ARN of the private network ACL |
+| <a name="output_private_network_acl_id"></a> [private\_network\_acl\_id](#output\_private\_network\_acl\_id) | ID of the private network ACL |
+| <a name="output_private_route_table_association_ids"></a> [private\_route\_table\_association\_ids](#output\_private\_route\_table\_association\_ids) | List of IDs of the private route table association |
+| <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | List of IDs of private route tables |
+| <a name="output_private_subnet_arns"></a> [private\_subnet\_arns](#output\_private\_subnet\_arns) | List of ARNs of private subnets |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
+| <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets |
+| <a name="output_private_subnets_ipv6_cidr_blocks"></a> [private\_subnets\_ipv6\_cidr\_blocks](#output\_private\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of private subnets in an IPv6 enabled VPC |
+| <a name="output_public_internet_gateway_ipv6_route_id"></a> [public\_internet\_gateway\_ipv6\_route\_id](#output\_public\_internet\_gateway\_ipv6\_route\_id) | ID of the IPv6 internet gateway route |
+| <a name="output_public_internet_gateway_route_id"></a> [public\_internet\_gateway\_route\_id](#output\_public\_internet\_gateway\_route\_id) | ID of the internet gateway route |
+| <a name="output_public_network_acl_arn"></a> [public\_network\_acl\_arn](#output\_public\_network\_acl\_arn) | ARN of the public network ACL |
+| <a name="output_public_network_acl_id"></a> [public\_network\_acl\_id](#output\_public\_network\_acl\_id) | ID of the public network ACL |
+| <a name="output_public_route_table_association_ids"></a> [public\_route\_table\_association\_ids](#output\_public\_route\_table\_association\_ids) | List of IDs of the public route table association |
+| <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | List of IDs of public route tables |
+| <a name="output_public_subnet_arns"></a> [public\_subnet\_arns](#output\_public\_subnet\_arns) | List of ARNs of public subnets |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
+| <a name="output_public_subnets_cidr_blocks"></a> [public\_subnets\_cidr\_blocks](#output\_public\_subnets\_cidr\_blocks) | List of cidr\_blocks of public subnets |
+| <a name="output_public_subnets_ipv6_cidr_blocks"></a> [public\_subnets\_ipv6\_cidr\_blocks](#output\_public\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of public subnets in an IPv6 enabled VPC |
+| <a name="output_redshift_network_acl_arn"></a> [redshift\_network\_acl\_arn](#output\_redshift\_network\_acl\_arn) | ARN of the redshift network ACL |
+| <a name="output_redshift_network_acl_id"></a> [redshift\_network\_acl\_id](#output\_redshift\_network\_acl\_id) | ID of the redshift network ACL |
+| <a name="output_redshift_public_route_table_association_ids"></a> [redshift\_public\_route\_table\_association\_ids](#output\_redshift\_public\_route\_table\_association\_ids) | List of IDs of the public redshift route table association |
+| <a name="output_redshift_route_table_association_ids"></a> [redshift\_route\_table\_association\_ids](#output\_redshift\_route\_table\_association\_ids) | List of IDs of the redshift route table association |
+| <a name="output_redshift_route_table_ids"></a> [redshift\_route\_table\_ids](#output\_redshift\_route\_table\_ids) | List of IDs of redshift route tables |
+| <a name="output_redshift_subnet_arns"></a> [redshift\_subnet\_arns](#output\_redshift\_subnet\_arns) | List of ARNs of redshift subnets |
+| <a name="output_redshift_subnet_group"></a> [redshift\_subnet\_group](#output\_redshift\_subnet\_group) | ID of redshift subnet group |
+| <a name="output_redshift_subnets"></a> [redshift\_subnets](#output\_redshift\_subnets) | List of IDs of redshift subnets |
+| <a name="output_redshift_subnets_cidr_blocks"></a> [redshift\_subnets\_cidr\_blocks](#output\_redshift\_subnets\_cidr\_blocks) | List of cidr\_blocks of redshift subnets |
+| <a name="output_redshift_subnets_ipv6_cidr_blocks"></a> [redshift\_subnets\_ipv6\_cidr\_blocks](#output\_redshift\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of redshift subnets in an IPv6 enabled VPC |
+| <a name="output_this_customer_gateway"></a> [this\_customer\_gateway](#output\_this\_customer\_gateway) | Map of Customer Gateway attributes |
+| <a name="output_vgw_arn"></a> [vgw\_arn](#output\_vgw\_arn) | The ARN of the VPN Gateway |
+| <a name="output_vgw_id"></a> [vgw\_id](#output\_vgw\_id) | The ID of the VPN Gateway |
+| <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | The ARN of the VPC |
+| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
+| <a name="output_vpc_enable_dns_hostnames"></a> [vpc\_enable\_dns\_hostnames](#output\_vpc\_enable\_dns\_hostnames) | Whether or not the VPC has DNS hostname support |
+| <a name="output_vpc_enable_dns_support"></a> [vpc\_enable\_dns\_support](#output\_vpc\_enable\_dns\_support) | Whether or not the VPC has DNS support |
+| <a name="output_vpc_flow_log_cloudwatch_iam_role_arn"></a> [vpc\_flow\_log\_cloudwatch\_iam\_role\_arn](#output\_vpc\_flow\_log\_cloudwatch\_iam\_role\_arn) | The ARN of the IAM role used when pushing logs to Cloudwatch log group |
+| <a name="output_vpc_flow_log_destination_arn"></a> [vpc\_flow\_log\_destination\_arn](#output\_vpc\_flow\_log\_destination\_arn) | The ARN of the destination for VPC Flow Logs |
+| <a name="output_vpc_flow_log_destination_type"></a> [vpc\_flow\_log\_destination\_type](#output\_vpc\_flow\_log\_destination\_type) | The type of the destination for VPC Flow Logs |
+| <a name="output_vpc_flow_log_id"></a> [vpc\_flow\_log\_id](#output\_vpc\_flow\_log\_id) | The ID of the Flow Log resource |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
+| <a name="output_vpc_instance_tenancy"></a> [vpc\_instance\_tenancy](#output\_vpc\_instance\_tenancy) | Tenancy of instances spin up within VPC |
+| <a name="output_vpc_ipv6_association_id"></a> [vpc\_ipv6\_association\_id](#output\_vpc\_ipv6\_association\_id) | The association ID for the IPv6 CIDR block |
+| <a name="output_vpc_ipv6_cidr_block"></a> [vpc\_ipv6\_cidr\_block](#output\_vpc\_ipv6\_cidr\_block) | The IPv6 CIDR block |
+| <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC |
+| <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC |
+| <a name="output_vpc_secondary_cidr_blocks"></a> [vpc\_secondary\_cidr\_blocks](#output\_vpc\_secondary\_cidr\_blocks) | List of secondary CIDR blocks of the VPC |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/ipam-secondary-cidr/main.tf
+++ b/examples/ipam-secondary-cidr/main.tf
@@ -1,0 +1,112 @@
+provider "aws" {
+  region = local.region
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  name   = "ex-${basename(path.cwd)}"
+  region = "eu-west-1"
+
+  azs                         = slice(data.aws_availability_zones.available.names, 0, 3)
+  preview_partition           = cidrsubnets(aws_vpc_ipam_preview_next_cidr.this.cidr, 2, 2, 2)
+  preview_partition_secondary = cidrsubnets(aws_vpc_ipam_preview_next_cidr.secondary.cidr, 2, 2, 2)
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-vpc"
+    GithubOrg  = "terraform-aws-modules"
+  }
+}
+
+################################################################################
+# VPC Module
+################################################################################
+
+# IPv4
+module "vpc_ipam_secondary" {
+  source = "../.."
+
+  name = "${local.name}-ipam-secondary"
+
+  use_ipam_pool       = true
+  ipv4_ipam_pool_id   = aws_vpc_ipam_pool.this.id
+  ipv4_netmask_length = 16
+  azs                 = local.azs
+
+  secondary_ipam_pool_ids     = [aws_vpc_ipam_pool.secondary.id]
+  secondary_ipam_pool_netmask = [8]
+
+  private_subnets = cidrsubnets(local.preview_partition[0], 2, 2, 2)
+  public_subnets  = cidrsubnets(local.preview_partition_secondary[0], 2, 2, 2)
+
+  tags = local.tags
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.this
+  ]
+}
+
+resource "aws_vpc_ipam" "this" {
+  operating_regions {
+    region_name = local.region
+  }
+
+  tags = local.tags
+}
+
+resource "aws_vpc_ipam_pool" "this" {
+  description                       = "IPv4 pool"
+  address_family                    = "ipv4"
+  ipam_scope_id                     = aws_vpc_ipam.this.private_default_scope_id
+  locale                            = local.region
+  allocation_default_netmask_length = 16
+
+  tags = local.tags
+}
+
+resource "aws_vpc_ipam_pool_cidr" "this" {
+  ipam_pool_id = aws_vpc_ipam_pool.this.id
+  cidr         = "10.0.0.0/8"
+}
+
+resource "aws_vpc_ipam_preview_next_cidr" "this" {
+  ipam_pool_id = aws_vpc_ipam_pool.this.id
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.this
+  ]
+}
+
+#Secondary CIDR
+
+resource "aws_vpc_ipam" "secondary" {
+  operating_regions {
+    region_name = local.region
+  }
+
+  tags = local.tags
+}
+
+resource "aws_vpc_ipam_pool" "secondary" {
+  description                       = "IPv4 pool"
+  address_family                    = "ipv4"
+  ipam_scope_id                     = aws_vpc_ipam.secondary.private_default_scope_id
+  locale                            = local.region
+  allocation_default_netmask_length = 16
+
+  tags = local.tags
+}
+
+resource "aws_vpc_ipam_pool_cidr" "secondary" {
+  ipam_pool_id = aws_vpc_ipam_pool.secondary.id
+  cidr         = "198.0.0.0/8"
+}
+
+resource "aws_vpc_ipam_preview_next_cidr" "secondary" {
+  ipam_pool_id = aws_vpc_ipam_pool.secondary.id
+
+  depends_on = [
+    aws_vpc_ipam_pool_cidr.secondary
+  ]
+}

--- a/examples/ipam-secondary-cidr/outputs.tf
+++ b/examples/ipam-secondary-cidr/outputs.tf
@@ -1,0 +1,535 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc_ipam_secondary.vpc_id
+}
+
+output "vpc_arn" {
+  description = "The ARN of the VPC"
+  value       = module.vpc_ipam_secondary.vpc_arn
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = module.vpc_ipam_secondary.vpc_cidr_block
+}
+
+output "default_security_group_id" {
+  description = "The ID of the security group created by default on VPC creation"
+  value       = module.vpc_ipam_secondary.default_security_group_id
+}
+
+output "default_network_acl_id" {
+  description = "The ID of the default network ACL"
+  value       = module.vpc_ipam_secondary.default_network_acl_id
+}
+
+output "default_route_table_id" {
+  description = "The ID of the default route table"
+  value       = module.vpc_ipam_secondary.default_route_table_id
+}
+
+output "vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within VPC"
+  value       = module.vpc_ipam_secondary.vpc_instance_tenancy
+}
+
+output "vpc_enable_dns_support" {
+  description = "Whether or not the VPC has DNS support"
+  value       = module.vpc_ipam_secondary.vpc_enable_dns_support
+}
+
+output "vpc_enable_dns_hostnames" {
+  description = "Whether or not the VPC has DNS hostname support"
+  value       = module.vpc_ipam_secondary.vpc_enable_dns_hostnames
+}
+
+output "vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with this VPC"
+  value       = module.vpc_ipam_secondary.vpc_main_route_table_id
+}
+
+output "vpc_ipv6_association_id" {
+  description = "The association ID for the IPv6 CIDR block"
+  value       = module.vpc_ipam_secondary.vpc_ipv6_association_id
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block"
+  value       = module.vpc_ipam_secondary.vpc_ipv6_cidr_block
+}
+
+output "vpc_secondary_cidr_blocks" {
+  description = "List of secondary CIDR blocks of the VPC"
+  value       = module.vpc_ipam_secondary.vpc_secondary_cidr_blocks
+}
+
+output "vpc_owner_id" {
+  description = "The ID of the AWS account that owns the VPC"
+  value       = module.vpc_ipam_secondary.vpc_owner_id
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc_ipam_secondary.private_subnets
+}
+
+output "private_subnet_arns" {
+  description = "List of ARNs of private subnets"
+  value       = module.vpc_ipam_secondary.private_subnet_arns
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of private subnets"
+  value       = module.vpc_ipam_secondary.private_subnets_cidr_blocks
+}
+
+output "private_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of private subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.private_subnets_ipv6_cidr_blocks
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc_ipam_secondary.public_subnets
+}
+
+output "public_subnet_arns" {
+  description = "List of ARNs of public subnets"
+  value       = module.vpc_ipam_secondary.public_subnet_arns
+}
+
+output "public_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of public subnets"
+  value       = module.vpc_ipam_secondary.public_subnets_cidr_blocks
+}
+
+output "public_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of public subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.public_subnets_ipv6_cidr_blocks
+}
+
+output "outpost_subnets" {
+  description = "List of IDs of outpost subnets"
+  value       = module.vpc_ipam_secondary.outpost_subnets
+}
+
+output "outpost_subnet_arns" {
+  description = "List of ARNs of outpost subnets"
+  value       = module.vpc_ipam_secondary.outpost_subnet_arns
+}
+
+output "outpost_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of outpost subnets"
+  value       = module.vpc_ipam_secondary.outpost_subnets_cidr_blocks
+}
+
+output "outpost_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of outpost subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.outpost_subnets_ipv6_cidr_blocks
+}
+
+output "database_subnets" {
+  description = "List of IDs of database subnets"
+  value       = module.vpc_ipam_secondary.database_subnets
+}
+
+output "database_subnet_arns" {
+  description = "List of ARNs of database subnets"
+  value       = module.vpc_ipam_secondary.database_subnet_arns
+}
+
+output "database_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of database subnets"
+  value       = module.vpc_ipam_secondary.database_subnets_cidr_blocks
+}
+
+output "database_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of database subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.database_subnets_ipv6_cidr_blocks
+}
+
+output "database_subnet_group" {
+  description = "ID of database subnet group"
+  value       = module.vpc_ipam_secondary.database_subnet_group
+}
+
+output "database_subnet_group_name" {
+  description = "Name of database subnet group"
+  value       = module.vpc_ipam_secondary.database_subnet_group_name
+}
+
+output "redshift_subnets" {
+  description = "List of IDs of redshift subnets"
+  value       = module.vpc_ipam_secondary.redshift_subnets
+}
+
+output "redshift_subnet_arns" {
+  description = "List of ARNs of redshift subnets"
+  value       = module.vpc_ipam_secondary.redshift_subnet_arns
+}
+
+output "redshift_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of redshift subnets"
+  value       = module.vpc_ipam_secondary.redshift_subnets_cidr_blocks
+}
+
+output "redshift_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of redshift subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.redshift_subnets_ipv6_cidr_blocks
+}
+
+output "redshift_subnet_group" {
+  description = "ID of redshift subnet group"
+  value       = module.vpc_ipam_secondary.redshift_subnet_group
+}
+
+output "elasticache_subnets" {
+  description = "List of IDs of elasticache subnets"
+  value       = module.vpc_ipam_secondary.elasticache_subnets
+}
+
+output "elasticache_subnet_arns" {
+  description = "List of ARNs of elasticache subnets"
+  value       = module.vpc_ipam_secondary.elasticache_subnet_arns
+}
+
+output "elasticache_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of elasticache subnets"
+  value       = module.vpc_ipam_secondary.elasticache_subnets_cidr_blocks
+}
+
+output "elasticache_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of elasticache subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.elasticache_subnets_ipv6_cidr_blocks
+}
+
+output "intra_subnets" {
+  description = "List of IDs of intra subnets"
+  value       = module.vpc_ipam_secondary.intra_subnets
+}
+
+output "intra_subnet_arns" {
+  description = "List of ARNs of intra subnets"
+  value       = module.vpc_ipam_secondary.intra_subnet_arns
+}
+
+output "intra_subnets_cidr_blocks" {
+  description = "List of cidr_blocks of intra subnets"
+  value       = module.vpc_ipam_secondary.intra_subnets_cidr_blocks
+}
+
+output "intra_subnets_ipv6_cidr_blocks" {
+  description = "List of IPv6 cidr_blocks of intra subnets in an IPv6 enabled VPC"
+  value       = module.vpc_ipam_secondary.intra_subnets_ipv6_cidr_blocks
+}
+
+output "elasticache_subnet_group" {
+  description = "ID of elasticache subnet group"
+  value       = module.vpc_ipam_secondary.elasticache_subnet_group
+}
+
+output "elasticache_subnet_group_name" {
+  description = "Name of elasticache subnet group"
+  value       = module.vpc_ipam_secondary.elasticache_subnet_group_name
+}
+
+output "public_route_table_ids" {
+  description = "List of IDs of public route tables"
+  value       = module.vpc_ipam_secondary.public_route_table_ids
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of private route tables"
+  value       = module.vpc_ipam_secondary.private_route_table_ids
+}
+
+output "database_route_table_ids" {
+  description = "List of IDs of database route tables"
+  value       = module.vpc_ipam_secondary.database_route_table_ids
+}
+
+output "redshift_route_table_ids" {
+  description = "List of IDs of redshift route tables"
+  value       = module.vpc_ipam_secondary.redshift_route_table_ids
+}
+
+output "elasticache_route_table_ids" {
+  description = "List of IDs of elasticache route tables"
+  value       = module.vpc_ipam_secondary.elasticache_route_table_ids
+}
+
+output "intra_route_table_ids" {
+  description = "List of IDs of intra route tables"
+  value       = module.vpc_ipam_secondary.intra_route_table_ids
+}
+
+output "public_internet_gateway_route_id" {
+  description = "ID of the internet gateway route"
+  value       = module.vpc_ipam_secondary.public_internet_gateway_route_id
+}
+
+output "public_internet_gateway_ipv6_route_id" {
+  description = "ID of the IPv6 internet gateway route"
+  value       = module.vpc_ipam_secondary.public_internet_gateway_ipv6_route_id
+}
+
+output "database_internet_gateway_route_id" {
+  description = "ID of the database internet gateway route"
+  value       = module.vpc_ipam_secondary.database_internet_gateway_route_id
+}
+
+output "database_nat_gateway_route_ids" {
+  description = "List of IDs of the database nat gateway route"
+  value       = module.vpc_ipam_secondary.database_nat_gateway_route_ids
+}
+
+output "database_ipv6_egress_route_id" {
+  description = "ID of the database IPv6 egress route"
+  value       = module.vpc_ipam_secondary.database_ipv6_egress_route_id
+}
+
+output "private_nat_gateway_route_ids" {
+  description = "List of IDs of the private nat gateway route"
+  value       = module.vpc_ipam_secondary.private_nat_gateway_route_ids
+}
+
+output "private_ipv6_egress_route_ids" {
+  description = "List of IDs of the ipv6 egress route"
+  value       = module.vpc_ipam_secondary.private_ipv6_egress_route_ids
+}
+
+output "private_route_table_association_ids" {
+  description = "List of IDs of the private route table association"
+  value       = module.vpc_ipam_secondary.private_route_table_association_ids
+}
+
+output "database_route_table_association_ids" {
+  description = "List of IDs of the database route table association"
+  value       = module.vpc_ipam_secondary.database_route_table_association_ids
+}
+
+output "redshift_route_table_association_ids" {
+  description = "List of IDs of the redshift route table association"
+  value       = module.vpc_ipam_secondary.redshift_route_table_association_ids
+}
+
+output "redshift_public_route_table_association_ids" {
+  description = "List of IDs of the public redshift route table association"
+  value       = module.vpc_ipam_secondary.redshift_public_route_table_association_ids
+}
+
+output "elasticache_route_table_association_ids" {
+  description = "List of IDs of the elasticache route table association"
+  value       = module.vpc_ipam_secondary.elasticache_route_table_association_ids
+}
+
+output "intra_route_table_association_ids" {
+  description = "List of IDs of the intra route table association"
+  value       = module.vpc_ipam_secondary.intra_route_table_association_ids
+}
+
+output "public_route_table_association_ids" {
+  description = "List of IDs of the public route table association"
+  value       = module.vpc_ipam_secondary.public_route_table_association_ids
+}
+
+output "dhcp_options_id" {
+  description = "The ID of the DHCP options"
+  value       = module.vpc_ipam_secondary.dhcp_options_id
+}
+
+output "nat_ids" {
+  description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
+  value       = module.vpc_ipam_secondary.nat_ids
+}
+
+output "nat_public_ips" {
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
+  value       = module.vpc_ipam_secondary.nat_public_ips
+}
+
+output "natgw_ids" {
+  description = "List of NAT Gateway IDs"
+  value       = module.vpc_ipam_secondary.natgw_ids
+}
+
+output "igw_id" {
+  description = "The ID of the Internet Gateway"
+  value       = module.vpc_ipam_secondary.igw_id
+}
+
+output "igw_arn" {
+  description = "The ARN of the Internet Gateway"
+  value       = module.vpc_ipam_secondary.igw_arn
+}
+
+output "egress_only_internet_gateway_id" {
+  description = "The ID of the egress only Internet Gateway"
+  value       = module.vpc_ipam_secondary.egress_only_internet_gateway_id
+}
+
+output "cgw_ids" {
+  description = "List of IDs of Customer Gateway"
+  value       = module.vpc_ipam_secondary.cgw_ids
+}
+
+output "cgw_arns" {
+  description = "List of ARNs of Customer Gateway"
+  value       = module.vpc_ipam_secondary.cgw_arns
+}
+
+output "this_customer_gateway" {
+  description = "Map of Customer Gateway attributes"
+  value       = module.vpc_ipam_secondary.this_customer_gateway
+}
+
+output "vgw_id" {
+  description = "The ID of the VPN Gateway"
+  value       = module.vpc_ipam_secondary.vgw_id
+}
+
+output "vgw_arn" {
+  description = "The ARN of the VPN Gateway"
+  value       = module.vpc_ipam_secondary.vgw_arn
+}
+
+output "default_vpc_id" {
+  description = "The ID of the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_id
+}
+
+output "default_vpc_arn" {
+  description = "The ARN of the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_arn
+}
+
+output "default_vpc_cidr_block" {
+  description = "The CIDR block of the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_cidr_block
+}
+
+output "default_vpc_default_security_group_id" {
+  description = "The ID of the security group created by default on Default VPC creation"
+  value       = module.vpc_ipam_secondary.default_vpc_default_security_group_id
+}
+
+output "default_vpc_default_network_acl_id" {
+  description = "The ID of the default network ACL of the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_default_network_acl_id
+}
+
+output "default_vpc_default_route_table_id" {
+  description = "The ID of the default route table of the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_default_route_table_id
+}
+
+output "default_vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_instance_tenancy
+}
+
+output "default_vpc_enable_dns_support" {
+  description = "Whether or not the Default VPC has DNS support"
+  value       = module.vpc_ipam_secondary.default_vpc_enable_dns_support
+}
+
+output "default_vpc_enable_dns_hostnames" {
+  description = "Whether or not the Default VPC has DNS hostname support"
+  value       = module.vpc_ipam_secondary.default_vpc_enable_dns_hostnames
+}
+
+output "default_vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with the Default VPC"
+  value       = module.vpc_ipam_secondary.default_vpc_main_route_table_id
+}
+
+output "public_network_acl_id" {
+  description = "ID of the public network ACL"
+  value       = module.vpc_ipam_secondary.public_network_acl_id
+}
+
+output "public_network_acl_arn" {
+  description = "ARN of the public network ACL"
+  value       = module.vpc_ipam_secondary.public_network_acl_arn
+}
+
+output "private_network_acl_id" {
+  description = "ID of the private network ACL"
+  value       = module.vpc_ipam_secondary.private_network_acl_id
+}
+
+output "private_network_acl_arn" {
+  description = "ARN of the private network ACL"
+  value       = module.vpc_ipam_secondary.private_network_acl_arn
+}
+
+output "outpost_network_acl_id" {
+  description = "ID of the outpost network ACL"
+  value       = module.vpc_ipam_secondary.outpost_network_acl_id
+}
+
+output "outpost_network_acl_arn" {
+  description = "ARN of the outpost network ACL"
+  value       = module.vpc_ipam_secondary.outpost_network_acl_arn
+}
+
+output "intra_network_acl_id" {
+  description = "ID of the intra network ACL"
+  value       = module.vpc_ipam_secondary.intra_network_acl_id
+}
+
+output "intra_network_acl_arn" {
+  description = "ARN of the intra network ACL"
+  value       = module.vpc_ipam_secondary.intra_network_acl_arn
+}
+
+output "database_network_acl_id" {
+  description = "ID of the database network ACL"
+  value       = module.vpc_ipam_secondary.database_network_acl_id
+}
+
+output "database_network_acl_arn" {
+  description = "ARN of the database network ACL"
+  value       = module.vpc_ipam_secondary.database_network_acl_arn
+}
+
+output "redshift_network_acl_id" {
+  description = "ID of the redshift network ACL"
+  value       = module.vpc_ipam_secondary.redshift_network_acl_id
+}
+
+output "redshift_network_acl_arn" {
+  description = "ARN of the redshift network ACL"
+  value       = module.vpc_ipam_secondary.redshift_network_acl_arn
+}
+
+output "elasticache_network_acl_id" {
+  description = "ID of the elasticache network ACL"
+  value       = module.vpc_ipam_secondary.elasticache_network_acl_id
+}
+
+output "elasticache_network_acl_arn" {
+  description = "ARN of the elasticache network ACL"
+  value       = module.vpc_ipam_secondary.elasticache_network_acl_arn
+}
+
+# VPC flow log
+output "vpc_flow_log_id" {
+  description = "The ID of the Flow Log resource"
+  value       = module.vpc_ipam_secondary.vpc_flow_log_id
+}
+
+output "vpc_flow_log_destination_arn" {
+  description = "The ARN of the destination for VPC Flow Logs"
+  value       = module.vpc_ipam_secondary.vpc_flow_log_destination_arn
+}
+
+output "vpc_flow_log_destination_type" {
+  description = "The type of the destination for VPC Flow Logs"
+  value       = module.vpc_ipam_secondary.vpc_flow_log_destination_type
+}
+
+output "vpc_flow_log_cloudwatch_iam_role_arn" {
+  description = "The ARN of the IAM role used when pushing logs to Cloudwatch log group"
+  value       = module.vpc_ipam_secondary.vpc_flow_log_cloudwatch_iam_role_arn
+}

--- a/examples/ipam-secondary-cidr/versions.tf
+++ b/examples/ipam-secondary-cidr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.30"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
   )
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
-  vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
+  vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc_ipv4_cidr_block_association.ipam[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
 }
@@ -57,6 +57,16 @@ resource "aws_vpc_ipv4_cidr_block_association" "this" {
   vpc_id = aws_vpc.this[0].id
 
   cidr_block = element(var.secondary_cidr_blocks, count.index)
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "ipam" {
+  count = local.create_vpc && length(var.secondary_ipam_pool_ids) > 0 ? length(var.secondary_ipam_pool_ids) : 0
+
+  # Do not turn this into `local.vpc_id`
+  vpc_id = aws_vpc.this[0].id
+
+  ipv4_ipam_pool_id   = element(var.secondary_ipam_pool_ids, count.index)
+  ipv4_netmask_length = element(var.secondary_ipam_pool_netmask, count.index)
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,6 +73,11 @@ output "vpc_secondary_cidr_blocks" {
   value       = compact(aws_vpc_ipv4_cidr_block_association.this[*].cidr_block)
 }
 
+output "vpc_secondary_cidr_blocks_ipam" {
+  description = "List of secondary CIDR blocks allocated from the IPAM for the VPC"
+  value       = compact(aws_vpc_ipv4_cidr_block_association.ipam[*].cidr_block)
+}
+
 output "vpc_owner_id" {
   description = "The ID of the AWS account that owns the VPC"
   value       = try(aws_vpc.this[0].owner_id, null)

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,18 @@ variable "secondary_cidr_blocks" {
   default     = []
 }
 
+variable "secondary_ipam_pool_ids" {
+  description = "List of secondary IPAM pool IDs to associate with the VPC to extend the IP Address pool"
+  type        = list(string)
+  default     = []
+}
+
+variable "secondary_ipam_pool_netmask" {
+  description = "List of secondary IPAM pool netmasks to associate with the VPC to extend the IP Address pool"
+  type        = list(number)
+  default     = []
+}
+
 variable "instance_tenancy" {
   description = "A tenancy option for instances launched into the VPC"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Enable the association of additional IPv4 CIDR blocks with a VPC using IPAM by exposing the native resource arguments `ipv4_ipam_pool_id` and `ipv4_netmask_length`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This update addresses a limitation where the association of additional IPv4 CIDR blocks with a VPC was previously restricted to static CIDR configurations. We can now configure a VPC to dynamically associate secondary CIDR blocks allocated from IPAM.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
