### PR TITLE
docs: Updated links to examples in README

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -4,7 +4,7 @@ Terraform sub-module which creates VPC endpoint resources on AWS.
 
 ## Usage
 
-See [`examples`](../../examples) directory for working examples to reference:
+See [`examples`](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples) directory for working examples to reference:
 
 ```hcl
 module "endpoints" {
@@ -48,7 +48,7 @@ module "endpoints" {
 
 ## Examples
 
-- [Complete-VPC](../../examples/complete) with VPC Endpoints.
+- [Complete-VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/complete) with VPC Endpoints.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements


### PR DESCRIPTION


## Description
Changed relative links to absolute links, otherwise they don't work when displayed on registry.terraform.io

## Motivation and Context
It fixes broken links on the terraform registry

## Breaking Changes
No

## How Has This Been Tested?
Not
