### PR TITLE
feat: Restrict flow log policy to use log group ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,10 @@ No modules.
 | [aws_vpn_gateway_route_propagation.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
 | [aws_vpn_gateway_route_propagation.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
 | [aws_vpn_gateway_route_propagation.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpn_gateway_route_propagation) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.flow_log_cloudwatch_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_log_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -1,3 +1,7 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 locals {
   # Only create flow log if user selected to create a VPC as well
   enable_flow_log = var.create_vpc && var.enable_flow_log
@@ -8,6 +12,10 @@ locals {
   flow_log_destination_arn                  = local.create_flow_log_cloudwatch_log_group ? try(aws_cloudwatch_log_group.flow_log[0].arn, null) : var.flow_log_destination_arn
   flow_log_iam_role_arn                     = var.flow_log_destination_type != "s3" && local.create_flow_log_cloudwatch_iam_role ? try(aws_iam_role.vpc_flow_log_cloudwatch[0].arn, null) : var.flow_log_cloudwatch_iam_role_arn
   flow_log_cloudwatch_log_group_name_suffix = var.flow_log_cloudwatch_log_group_name_suffix == "" ? local.vpc_id : var.flow_log_cloudwatch_log_group_name_suffix
+  flow_log_group_arns = [
+    for log_group in aws_cloudwatch_log_group.flow_log :
+    format("arn:aws:logs:${data.aws_region.current.name}:%s:log-group:%s:*", data.aws_caller_identity.current.account_id, log_group.name)
+  ]
 }
 
 ################################################################################
@@ -112,6 +120,6 @@ data "aws_iam_policy_document" "vpc_flow_log_cloudwatch" {
       "logs:DescribeLogStreams",
     ]
 
-    resources = ["*"]
+    resources = local.flow_log_group_arns
   }
 }

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -1,6 +1,12 @@
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  # Call this API only if create_vpc and enable_flow_log are true
+  count = var.create_vpc && var.enable_flow_log ? 1 : 0
+}
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+  # Call this API only if create_vpc and enable_flow_log are true
+  count = var.create_vpc && var.enable_flow_log ? 1 : 0
+}
 
 locals {
   # Only create flow log if user selected to create a VPC as well
@@ -14,7 +20,7 @@ locals {
   flow_log_cloudwatch_log_group_name_suffix = var.flow_log_cloudwatch_log_group_name_suffix == "" ? local.vpc_id : var.flow_log_cloudwatch_log_group_name_suffix
   flow_log_group_arns = [
     for log_group in aws_cloudwatch_log_group.flow_log :
-    format("arn:aws:logs:${data.aws_region.current.name}:%s:log-group:%s:*", data.aws_caller_identity.current.account_id, log_group.name)
+    "arn:aws:logs:${data.aws_region.current[0].name}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
   ]
 }
 


### PR DESCRIPTION
## Description
This pull request updates the AWS VPC terraform module to use log group ARNs instead of wildcard ("*") as the resource in the flow log policy. This change restricts the flow log policy to specific log groups, improving security and ensuring that only authorized log groups can receive flow log data.

## Motivation and Context
The previous implementation allowed logging to any log group in AWS CloudWatch Logs, which could potentially lead to unauthorized access to log data. The updated implementation ensures that flow log data is only sent to designated log groups specified by their ARNs.

## Breaking Changes
This change does not break backwards compatibility with the current major version.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request to ensure that all relevant pre-commit checks have passed.

Thank you.