### PR TITLE
feat: Allow custom VPC Flow Log IAM Role name and IAM Policy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ No modules.
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_ipam_pool"></a> [use\_ipam\_pool](#input\_use\_ipam\_pool) | Determines whether IPAM pool is used for CIDR allocation | `bool` | `false` | no |
+| <a name="input_vpc_flow_log_iam_policy_name"></a> [vpc\_flow\_log\_iam\_policy\_name](#input\_vpc\_flow\_log\_iam\_policy\_name) | Name of the IAM policy | `string` | `"vpc-flow-log-to-cloudwatch"` | no |
+| <a name="input_vpc_flow_log_iam_policy_use_name_prefix"></a> [vpc\_flow\_log\_iam\_policy\_use\_name\_prefix](#input\_vpc\_flow\_log\_iam\_policy\_use\_name\_prefix) | Determines whether the name of the IAM policy (`vpc_flow_log_iam_policy_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_vpc_flow_log_iam_role_name"></a> [vpc\_flow\_log\_iam\_role\_name](#input\_vpc\_flow\_log\_iam\_role\_name) | Name to use on the VPC Flow Log IAM role created | `string` | `"vpc-flow-log-role"` | no |
 | <a name="input_vpc_flow_log_iam_role_use_name_prefix"></a> [vpc\_flow\_log\_iam\_role\_use\_name\_prefix](#input\_vpc\_flow\_log\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`vpc_flow_log_iam_role_name_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_vpc_flow_log_permissions_boundary"></a> [vpc\_flow\_log\_permissions\_boundary](#input\_vpc\_flow\_log\_permissions\_boundary) | The ARN of the Permissions Boundary for the VPC Flow Log IAM Role | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ No modules.
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_ipam_pool"></a> [use\_ipam\_pool](#input\_use\_ipam\_pool) | Determines whether IPAM pool is used for CIDR allocation | `bool` | `false` | no |
+| <a name="input_vpc_flow_log_iam_role_name"></a> [vpc\_flow\_log\_iam\_role\_name](#input\_vpc\_flow\_log\_iam\_role\_name) | Name to use on the VPC Flow Log IAM role created | `string` | `"vpc-flow-log-role"` | no |
+| <a name="input_vpc_flow_log_iam_role_use_name_prefix"></a> [vpc\_flow\_log\_iam\_role\_use\_name\_prefix](#input\_vpc\_flow\_log\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`vpc_flow_log_iam_role_name_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_vpc_flow_log_permissions_boundary"></a> [vpc\_flow\_log\_permissions\_boundary](#input\_vpc\_flow\_log\_permissions\_boundary) | The ARN of the Permissions Boundary for the VPC Flow Log IAM Role | `string` | `null` | no |
 | <a name="input_vpc_flow_log_tags"></a> [vpc\_flow\_log\_tags](#input\_vpc\_flow\_log\_tags) | Additional tags for the VPC Flow Logs | `map(string)` | `{}` | no |
 | <a name="input_vpc_tags"></a> [vpc\_tags](#input\_vpc\_tags) | Additional tags for the VPC | `map(string)` | `{}` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -73,10 +73,12 @@ module "vpc" {
   dhcp_options_domain_name_servers = ["127.0.0.1", "10.10.0.2"]
 
   # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
-  enable_flow_log                      = true
-  create_flow_log_cloudwatch_log_group = true
-  create_flow_log_cloudwatch_iam_role  = true
-  flow_log_max_aggregation_interval    = 60
+  vpc_flow_log_iam_role_name            = "vpc-complete-example-role"
+  vpc_flow_log_iam_role_use_name_prefix = false
+  enable_flow_log                       = true
+  create_flow_log_cloudwatch_log_group  = true
+  create_flow_log_cloudwatch_iam_role   = true
+  flow_log_max_aggregation_interval     = 60
 
   tags = local.tags
 }

--- a/examples/vpc-flow-logs/README.md
+++ b/examples/vpc-flow-logs/README.md
@@ -41,6 +41,7 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_vpc_with_flow_logs_cloudwatch_logs"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs) | ../../ | n/a |
 | <a name="module_vpc_with_flow_logs_cloudwatch_logs_default"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs\_default](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs\_default) | ../../ | n/a |
+| <a name="module_vpc_with_flow_logs_cloudwatch_logs_prefix"></a> [vpc\_with\_flow\_logs\_cloudwatch\_logs\_prefix](#module\_vpc\_with\_flow\_logs\_cloudwatch\_logs\_prefix) | ../../ | n/a |
 | <a name="module_vpc_with_flow_logs_s3_bucket"></a> [vpc\_with\_flow\_logs\_s3\_bucket](#module\_vpc\_with\_flow\_logs\_s3\_bucket) | ../../ | n/a |
 | <a name="module_vpc_with_flow_logs_s3_bucket_parquet"></a> [vpc\_with\_flow\_logs\_s3\_bucket\_parquet](#module\_vpc\_with\_flow\_logs\_s3\_bucket\_parquet) | ../../ | n/a |
 

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -84,7 +84,7 @@ module "vpc_with_flow_logs_cloudwatch_logs_default" {
 }
 
 # CloudWatch Log Group and IAM prefix
-module "vpc_with_flow_logs_cloudwatch_logs_default" {
+module "vpc_with_flow_logs_cloudwatch_logs_prefix" {
   source = "../../"
 
   name = "${local.name}-cloudwatch-logs-prefix"

--- a/examples/vpc-flow-logs/main.tf
+++ b/examples/vpc-flow-logs/main.tf
@@ -83,6 +83,35 @@ module "vpc_with_flow_logs_cloudwatch_logs_default" {
   vpc_flow_log_tags = local.tags
 }
 
+# CloudWatch Log Group and IAM prefix
+module "vpc_with_flow_logs_cloudwatch_logs_default" {
+  source = "../../"
+
+  name = "${local.name}-cloudwatch-logs-prefix"
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 4)]
+
+  # Cloudwatch log group and IAM role will be created
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+
+  vpc_flow_log_iam_role_name              = "vpc-iam-prefix-example"
+  vpc_flow_log_iam_role_use_name_prefix   = true
+  vpc_flow_log_iam_policy_name            = "vpc-iam-prefix-example"
+  vpc_flow_log_iam_policy_use_name_prefix = true
+
+  flow_log_max_aggregation_interval         = 60
+  flow_log_cloudwatch_log_group_name_prefix = "/aws/my-amazing-vpc-flow-logz/"
+  flow_log_cloudwatch_log_group_name_suffix = "my-test"
+  flow_log_cloudwatch_log_group_class       = "INFREQUENT_ACCESS"
+
+  vpc_flow_log_tags = local.tags
+}
+
 # CloudWatch Log Group and IAM role created separately
 module "vpc_with_flow_logs_cloudwatch_logs" {
   source = "../../"

--- a/variables.tf
+++ b/variables.tf
@@ -1478,6 +1478,18 @@ variable "enable_flow_log" {
   default     = false
 }
 
+variable "vpc_flow_log_iam_role_name" {
+  description = "Name to use on the VPC Flow Log IAM role created"
+  type        = string
+  default     = "vpc-flow-log-role"
+}
+
+variable "vpc_flow_log_iam_role_use_name_prefix" {
+  description = "Determines whether the IAM role name (`vpc_flow_log_iam_role_name_name`) is used as a prefix"
+  type        = bool
+  default     = true
+}
+
 variable "vpc_flow_log_permissions_boundary" {
   description = "The ARN of the Permissions Boundary for the VPC Flow Log IAM Role"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1490,10 +1490,23 @@ variable "vpc_flow_log_iam_role_use_name_prefix" {
   default     = true
 }
 
+
 variable "vpc_flow_log_permissions_boundary" {
   description = "The ARN of the Permissions Boundary for the VPC Flow Log IAM Role"
   type        = string
   default     = null
+}
+
+variable "vpc_flow_log_iam_policy_name" {
+  description = "Name of the IAM policy"
+  type        = string
+  default     = "vpc-flow-log-to-cloudwatch"
+}
+
+variable "vpc_flow_log_iam_policy_use_name_prefix" {
+  description = "Determines whether the name of the IAM policy (`vpc_flow_log_iam_policy_name`) is used as a prefix"
+  type        = bool
+  default     = true
 }
 
 variable "flow_log_max_aggregation_interval" {

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -58,7 +58,9 @@ resource "aws_cloudwatch_log_group" "flow_log" {
 resource "aws_iam_role" "vpc_flow_log_cloudwatch" {
   count = local.create_flow_log_cloudwatch_iam_role ? 1 : 0
 
-  name_prefix          = "vpc-flow-log-role-"
+  name        = var.vpc_flow_log_iam_role_use_name_prefix ? null : var.vpc_flow_log_iam_role_name
+  name_prefix = var.vpc_flow_log_iam_role_use_name_prefix ? "${var.vpc_flow_log_iam_role_name}-" : null
+
   assume_role_policy   = data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0].json
   permissions_boundary = var.vpc_flow_log_permissions_boundary
 

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -94,7 +94,8 @@ resource "aws_iam_role_policy_attachment" "vpc_flow_log_cloudwatch" {
 resource "aws_iam_policy" "vpc_flow_log_cloudwatch" {
   count = local.create_flow_log_cloudwatch_iam_role ? 1 : 0
 
-  name_prefix = "vpc-flow-log-to-cloudwatch-"
+  name        = var.vpc_flow_log_iam_policy_use_name_prefix ? null : var.vpc_flow_log_iam_policy_name
+  name_prefix = var.vpc_flow_log_iam_policy_use_name_prefix ? "${var.vpc_flow_log_iam_policy_name}-" : null
   policy      = data.aws_iam_policy_document.vpc_flow_log_cloudwatch[0].json
   tags        = merge(var.tags, var.vpc_flow_log_tags)
 }


### PR DESCRIPTION
## Description
Allow custom IAM Role and Policy names for the VPC flow log either by specifying the entire name, or by providing a prefix.

## Motivation and Context
Some organizations require specific prefixes or naming schemes on IAM policies and roles. This allows support for that following the same pattern as in other `terraform-aws-modules`

## Breaking Changes
Not a breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request