### PR TITLE
fix: NAT gw route table associations shouldn't be created when enable_nat_gateway=false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -277,7 +277,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  count = local.create_private_subnets ? local.len_private_subnets : 0
+  count = local.create_private_subnets && var.enable_nat_gateway ? local.len_private_subnets : 0
 
   subnet_id = element(aws_subnet.private[*].id, count.index)
   route_table_id = element(
@@ -411,7 +411,7 @@ resource "aws_route_table" "database" {
 }
 
 resource "aws_route_table_association" "database" {
-  count = local.create_database_subnets ? local.len_database_subnets : 0
+  count = local.create_database_subnets && var.enable_nat_gateway ? local.len_database_subnets : 0
 
   subnet_id = element(aws_subnet.database[*].id, count.index)
   route_table_id = element(
@@ -723,7 +723,7 @@ resource "aws_route_table" "elasticache" {
 }
 
 resource "aws_route_table_association" "elasticache" {
-  count = local.create_elasticache_subnets ? local.len_elasticache_subnets : 0
+  count = local.create_elasticache_subnets && var.enable_nat_gateway ? local.len_elasticache_subnets : 0
 
   subnet_id = element(aws_subnet.elasticache[*].id, count.index)
   route_table_id = element(


### PR DESCRIPTION
## Description
Fixes creating NAT gateway route table associations even when enable_nat_gateway=false

## Motivation and Context
More detailed description of the issue is here https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1031

## Breaking Changes
no breaking changes

## How Has This Been Tested?
Tested in production TGW environment with no NAT gw route table associations
