### PR TITLE
feat: Add route to `0.0.0.0/0` & `::/0` (when IPv6 is enabled) on all public route tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,9 +152,9 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route" "public_internet_gateway" {
-  count = local.create_public_subnets && var.create_igw ? 1 : 0
+  count = local.create_public_subnets && var.create_igw ? length(aws_route_table.public) : 0
 
-  route_table_id         = aws_route_table.public[0].id
+  route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.this[0].id
 
@@ -164,9 +164,9 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
-  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? 1 : 0
+  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? length(aws_route_table.public) : 0
 
-  route_table_id              = aws_route_table.public[0].id
+  route_table_id              = aws_route_table.public[count.index].id
   destination_ipv6_cidr_block = "::/0"
   gateway_id                  = aws_internet_gateway.this[0].id
 }

--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route" "public_internet_gateway" {
-  count = local.create_public_subnets && var.create_igw ? length(aws_route_table.public) : 0
+  count = local.create_public_subnets && var.create_igw ? local.num_public_route_tables : 0
 
   route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
@@ -164,7 +164,7 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
-  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? length(aws_route_table.public) : 0
+  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? local.num_public_route_tables : 0
 
   route_table_id              = aws_route_table.public[count.index].id
   destination_ipv6_cidr_block = "::/0"


### PR DESCRIPTION
## Description
Makes the count on `aws_route` dynamic instead of fixed at 1

## Motivation and Context
Fixes #1087 

## Breaking Changes
Not that I'm aware of.

## How Has This Been Tested?
- [X] I have tested and validated these changes in a VPC in my environment that have a single public route table as well as another VPC that has multiple public route tables
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
