### PR TITLE
fix: Update flow log ARNs to use partition from aws_partition data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.flow_log_cloudwatch_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_flow_log_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -8,6 +8,11 @@ data "aws_caller_identity" "current" {
   count = var.create_vpc && var.enable_flow_log ? 1 : 0
 }
 
+data "aws_partition" "current" {
+  # Call this API only if create_vpc and enable_flow_log are true
+  count = var.create_vpc && var.enable_flow_log ? 1 : 0
+}
+
 locals {
   # Only create flow log if user selected to create a VPC as well
   enable_flow_log = var.create_vpc && var.enable_flow_log
@@ -20,7 +25,7 @@ locals {
   flow_log_cloudwatch_log_group_name_suffix = var.flow_log_cloudwatch_log_group_name_suffix == "" ? local.vpc_id : var.flow_log_cloudwatch_log_group_name_suffix
   flow_log_group_arns = [
     for log_group in aws_cloudwatch_log_group.flow_log :
-    "arn:aws:logs:${data.aws_region.current[0].name}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
+    "arn:${data.aws_partition.current[0].partition}:logs:${data.aws_region.current[0].name}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
   ]
 }
 


### PR DESCRIPTION
… ensuring compatibility with AWS GovCloud and other partitions

## Description
 Update flow log ARNs to use partition from aws_partition data source, ensuring compatibility with AWS GovCloud and other partitions. This was due to the least privilege change in 5.12.0, 5.11.0 and earlier are fine. See PR [#1088](https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1088)

## Motivation and Context
Currently when deploying to GovCloud with flow logs you get the following error
```
MalformedPolicyDocument: Partition "aws" is not valid for resource "arn:aws:logs:us-gov-west-1:0123456789:log-group:/aws/vpc-flow-log/vpc-012345:*"
```

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
