### PR TITLE
fix: Account for cases when we are using an existing cloudwatch log group for flow logs

### DIFF
--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -17,16 +17,22 @@ locals {
   # Only create flow log if user selected to create a VPC as well
   enable_flow_log = var.create_vpc && var.enable_flow_log
 
-  create_flow_log_cloudwatch_iam_role  = local.enable_flow_log && var.flow_log_destination_type != "s3" && var.create_flow_log_cloudwatch_iam_role
-  create_flow_log_cloudwatch_log_group = local.enable_flow_log && var.flow_log_destination_type != "s3" && var.create_flow_log_cloudwatch_log_group
+  create_flow_log_cloudwatch_iam_role        = local.enable_flow_log && var.flow_log_destination_type != "s3" && var.create_flow_log_cloudwatch_iam_role
+  create_flow_log_cloudwatch_log_group       = local.enable_flow_log && var.flow_log_destination_type != "s3" && var.create_flow_log_cloudwatch_log_group
+  use_existing_flow_log_cloudwatch_log_group = local.enable_flow_log && var.flow_log_destination_type == "cloud-watch-logs" && !var.create_flow_log_cloudwatch_log_group
 
   flow_log_destination_arn                  = local.create_flow_log_cloudwatch_log_group ? try(aws_cloudwatch_log_group.flow_log[0].arn, null) : var.flow_log_destination_arn
   flow_log_iam_role_arn                     = var.flow_log_destination_type != "s3" && local.create_flow_log_cloudwatch_iam_role ? try(aws_iam_role.vpc_flow_log_cloudwatch[0].arn, null) : var.flow_log_cloudwatch_iam_role_arn
   flow_log_cloudwatch_log_group_name_suffix = var.flow_log_cloudwatch_log_group_name_suffix == "" ? local.vpc_id : var.flow_log_cloudwatch_log_group_name_suffix
-  flow_log_group_arns = [
-    for log_group in aws_cloudwatch_log_group.flow_log :
-    "arn:${data.aws_partition.current[0].partition}:logs:${data.aws_region.current[0].name}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
-  ]
+  flow_log_group_arns = compact(
+    concat(
+      [
+        for log_group in aws_cloudwatch_log_group.flow_log :
+        "arn:${data.aws_partition.current[0].partition}:logs:${data.aws_region.current[0].name}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
+      ],
+      local.use_existing_flow_log_cloudwatch_log_group ? [var.flow_log_destination_arn] : []
+    )
+  )
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
When generating the flow log group ARNs to include in the policy, if we are using a pre-existing log group, take that into account and use the destination ARN passed in as a variable, rather than assuming that we created a log group ourselves.

## Motivation and Context
Since 5.12.0, if you are using an existing CloudWatch Log Group for your flow logs destination ARN, this module tries to update the relevant IAM policy with an invalid policy document, which fails. See PR https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1088.

This fixes https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1117

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I have tested this in our own workspaces using a fork of this module -- I am happy to go further with the examples here if needed/desired.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
