### PR TITLE
feat: Add single_nat_gateway_subnet_index to choose NAT Gateway public subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ No modules.
 | <a name="input_reuse_nat_ips"></a> [reuse\_nat\_ips](#input\_reuse\_nat\_ips) | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
+| <a name="input_single_nat_gateway_subnet_index"></a> [single\_nat\_gateway\_subnet\_index](#input\_single\_nat\_gateway\_subnet\_index) | The index of the public subnet which should be used for the NAT Gateway. Only used when `single_nat_gateway` is true | `number` | `0` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_ipam_pool"></a> [use\_ipam\_pool](#input\_use\_ipam\_pool) | Determines whether IPAM pool is used for CIDR allocation | `bool` | `false` | no |
 | <a name="input_vpc_flow_log_iam_policy_name"></a> [vpc\_flow\_log\_iam\_policy\_name](#input\_vpc\_flow\_log\_iam\_policy\_name) | Name of the IAM policy | `string` | `"vpc-flow-log-to-cloudwatch"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -54,6 +54,8 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
+  single_nat_gateway_subnet_index = 1
+
   customer_gateways = {
     IP1 = {
       bgp_asn     = 65112

--- a/main.tf
+++ b/main.tf
@@ -1084,14 +1084,14 @@ resource "aws_nat_gateway" "this" {
   )
   subnet_id = element(
     aws_subnet.public[*].id,
-    var.single_nat_gateway ? 0 : count.index,
+    var.single_nat_gateway ? var.single_nat_gateway_subnet_index : count.index,
   )
 
   tags = merge(
     {
-      "Name" = format(
+      "Name" = var.single_nat_gateway ? var.name : format(
         "${var.name}-%s",
-        element(var.azs, var.single_nat_gateway ? 0 : count.index),
+        element(var.azs, count.index),
       )
     },
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -1210,6 +1210,12 @@ variable "single_nat_gateway" {
   default     = false
 }
 
+variable "single_nat_gateway_subnet_index" {
+  description = "The index of the public subnet used for the NAT Gateway. Only used when `single_nat_gateway` is true"
+  type        = number
+  default     = 0
+}
+
 variable "one_nat_gateway_per_az" {
   description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`"
   type        = bool


### PR DESCRIPTION
## Description
Add `single_nat_gateway_subnet_index` to choose in which public subnet the single NAT Gateway must be created.

## Motivation and Context
Currently, the single NAT Gateway is created in the first public subnet and, thus, in the first Availability Zone. This variable allows the user to choose which AZ the NAT Gateway will be created in.

## Breaking Changes
This is fully backward compatible and does not introduce any breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
