### PR TITLE
chore(nat-gateway): Add nat_gateway_tags_per_az variable for NAT gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ No modules.
 | <a name="input_nat_eip_tags"></a> [nat\_eip\_tags](#input\_nat\_eip\_tags) | Additional tags for the NAT EIP | `map(string)` | `{}` | no |
 | <a name="input_nat_gateway_destination_cidr_block"></a> [nat\_gateway\_destination\_cidr\_block](#input\_nat\_gateway\_destination\_cidr\_block) | Used to pass a custom destination route for private NAT Gateway. If not specified, the default 0.0.0.0/0 is used as a destination route | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_nat_gateway_tags"></a> [nat\_gateway\_tags](#input\_nat\_gateway\_tags) | Additional tags for the NAT gateways | `map(string)` | `{}` | no |
+| <a name="input_nat_gateway_tags_per_az"></a> [nat\_gateway\_tags\_per\_az](#input\_nat\_gateway\_tags\_per\_az) | Additional tags for the NAT gateways where the primary key is the AZ | `map(map(string))` | `{}` | no |
 | <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs` | `bool` | `false` | no |
 | <a name="input_outpost_acl_tags"></a> [outpost\_acl\_tags](#input\_outpost\_acl\_tags) | Additional tags for the outpost subnets network ACL | `map(string)` | `{}` | no |
 | <a name="input_outpost_arn"></a> [outpost\_arn](#input\_outpost\_arn) | ARN of Outpost you want to create a subnet in | `string` | `null` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -32,4 +32,10 @@ module "vpc" {
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
 
   tags = local.tags
+
+  nat_gateway_tags_per_az = {
+    for az in local.azs : az => {
+      Name = "NAT Gateway - ${az}"
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1129,6 +1129,7 @@ resource "aws_nat_gateway" "this" {
     },
     var.tags,
     var.nat_gateway_tags,
+    lookup(var.nat_gateway_tags_per_az, element(var.azs, count.index), {})
   )
 
   depends_on = [aws_internet_gateway.this]

--- a/variables.tf
+++ b/variables.tf
@@ -1252,6 +1252,12 @@ variable "nat_gateway_tags" {
   default     = {}
 }
 
+variable "nat_gateway_tags_per_az" {
+  description = "Additional tags for the NAT gateways where the primary key is the AZ"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "nat_eip_tags" {
   description = "Additional tags for the NAT EIP"
   type        = map(string)


### PR DESCRIPTION
## Description
Adding `nat_gateway_tags_per_az` variable for NAT gateways

## Motivation and Context
It is useful for cost related reports to be able to tag NAT gateways per AZ.

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
