### PR TITLE
feat: Allow adding custom routes to private route tables (#1130)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -396,6 +396,23 @@ variable "private_route_table_tags" {
   default     = {}
 }
 
+variable "private_route_table_routes" {
+  description = "A map of private route table IDs to a list of route objects."
+  type = map(list(object({
+    destination_cidr_block       = optional(string)
+    destination_ipv6_cidr_block  = optional(string)
+    egress_only_gateway_id       = optional(string)
+    gateway_id                   = optional(string)
+    nat_gateway_id               = optional(string)
+    transit_gateway_id           = optional(string)
+    vpc_peering_connection_id    = optional(string)
+    local_gateway_id             = optional(string)
+    carrier_gateway_id           = optional(string)
+    destination_prefix_list_id   = optional(string)
+  })))
+  default = {}
+}
+
 ################################################################################
 # Private Network ACLs
 ################################################################################


### PR DESCRIPTION
## Description

This PR adds the ability to specify custom routes for private route tables by introducing a new variable `private_route_table_routes`. This feature allows users to add custom routes to private route tables created by the module, addressing the need outlined in issue #1130.

## Changes

- Added `private_route_table_routes` variable to `variables.tf`.
- Implemented logic in `main.tf` to create routes in private route tables based on the new variable.
- Updated `README.md` to document the new variable and provide usage examples.

## Usage

```hcl
module "vpc" {
  source  = "terraform-aws-modules/vpc/aws"
  version = "x.y.z"

  # ... other configurations ...

  private_route_table_routes = {
    for idx, rt_id in module.vpc.private_route_table_ids :
    rt_id => [
      {
        destination_cidr_block = "0.0.0.0/0"
        nat_gateway_id         = module.vpc.natgw_ids[idx]
      }
    ]
  }
}

References
Closes #1130
Checklist
 I have read the Contributing Guidelines.
 I have updated the documentation accordingly.
 I have added tests to cover my changes.
 All new and existing tests passed.
