### PR TITLE
feat: Conditionally enable public and private subnet tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,17 +111,23 @@ resource "aws_subnet" "public" {
   private_dns_hostname_type_on_launch            = var.public_subnet_private_dns_hostname_type_on_launch
   vpc_id                                         = local.vpc_id
 
-  tags = merge(
-    {
-      Name = try(
-        var.public_subnet_names[count.index],
-        format("${var.name}-${var.public_subnet_suffix}-%s", element(var.azs, count.index))
+  dynamic "tags" {
+    for_each = var.enable_public_subnet_tags ? [1] : []
+    content {
+      tags = merge(
+        {
+          Name = try(
+            var.public_subnet_names[count.index],
+            format("${var.name}-${var.public_subnet_suffix}-%s", element(var.azs, count.index))
+          )
+        },
+        var.tags,
+        var.public_subnet_tags,
+        lookup(var.public_subnet_tags_per_az, element(var.azs, count.index), {})
       )
-    },
-    var.tags,
-    var.public_subnet_tags,
-    lookup(var.public_subnet_tags_per_az, element(var.azs, count.index), {})
-  )
+    }
+  }
+
 }
 
 locals {
@@ -246,17 +252,24 @@ resource "aws_subnet" "private" {
   private_dns_hostname_type_on_launch            = var.private_subnet_private_dns_hostname_type_on_launch
   vpc_id                                         = local.vpc_id
 
-  tags = merge(
-    {
-      Name = try(
-        var.private_subnet_names[count.index],
-        format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+  dynamic "tags" {
+    for_each = var.enable_private_subnet_tags ? [1] : []
+    content {
+      tags = merge(
+        {
+          Name = try(
+            var.private_subnet_names[count.index],
+            format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+          )
+        },
+        var.tags,
+        var.private_subnet_tags,
+        lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {})
       )
-    },
-    var.tags,
-    var.private_subnet_tags,
-    lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {})
-  )
+    }
+  }
+
+
 }
 
 # There are as many routing tables as the number of NAT gateways

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,12 @@ variable "public_subnets" {
   default     = []
 }
 
+variable "enable_public_subnet_tags" {
+  description = "Indicates whether tags should be applied to public subnets. Default: `true`"
+  type        = bool
+  default     = true
+}
+
 variable "public_subnet_assign_ipv6_address_on_creation" {
   description = "Specify true to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. Default is `false`"
   type        = bool
@@ -316,6 +322,12 @@ variable "private_subnets" {
   description = "A list of private subnets inside the VPC"
   type        = list(string)
   default     = []
+}
+
+variable "enable_private_subnet_tags" {
+  description = "Indicates whether tags should be applied to private subnets. Default: `true`"
+  type        = bool
+  default     = true
 }
 
 variable "private_subnet_assign_ipv6_address_on_creation" {


### PR DESCRIPTION
## Description

Introduces 2 new variables `enable_private_subnet_tags` and `enable_public_subnet_tags`.

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1145

## Breaking Changes

These new variable are set to true by default so i assume it would not introduce any breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
