### PR TITLE
feat: Define default name for VPC endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.96.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -46,7 +46,7 @@ resource "aws_vpc_endpoint" "this" {
 
   tags = merge(
     var.tags,
-    { "Name" = "${each.key}-vpc-endpoint" },
+    { "Name" = replace(try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name, ""), ".", "-"") },
     try(each.value.tags, {}),
   )
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -46,7 +46,7 @@ resource "aws_vpc_endpoint" "this" {
 
   tags = merge(
     var.tags,
-    { "Name" = replace(try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name, ""), ".", "-") },
+    { "Name" = replace(each.key, ".", "-") },
     try(each.value.tags, {}),
   )
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -44,7 +44,11 @@ resource "aws_vpc_endpoint" "this" {
     }
   }
 
-  tags = merge(var.tags, try(each.value.tags, {}))
+  tags = merge(
+    var.tags,
+    { "Name" = "${each.key}-vpc-endpoint" },
+    try(each.value.tags, {}),
+  )
 
   timeouts {
     create = try(var.timeouts.create, "10m")

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -46,7 +46,7 @@ resource "aws_vpc_endpoint" "this" {
 
   tags = merge(
     var.tags,
-    { "Name" = replace(try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name, ""), ".", "-"") },
+    { "Name" = replace(try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name, ""), ".", "-") },
     try(each.value.tags, {}),
   )
 


### PR DESCRIPTION
## Description

PR delivers feature for VPC endpoints - if name is not defined, then default name is constructed from service name.

## Motivation and Context

#1150 

## Breaking Changes

There are no breaking changes.

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
