### PR TITLE
feat: Support for cross region VPC endpoints

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -56,13 +56,13 @@ module "endpoints" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -11,8 +11,8 @@ locals {
 data "aws_vpc_endpoint_service" "this" {
   for_each = local.endpoints
 
-  service      = try(each.value.service, null)
-  service_name = try(each.value.service_name, null)
+  service         = try(each.value.service, null)
+  service_name    = try(each.value.service_name, null)
   service_regions = try([each.value.service_region], null)
 
   filter {

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -13,6 +13,7 @@ data "aws_vpc_endpoint_service" "this" {
 
   service      = try(each.value.service, null)
   service_name = try(each.value.service_name, null)
+  service_regions = try([each.value.service_region], null)
 
   filter {
     name   = "service-type"
@@ -25,6 +26,7 @@ resource "aws_vpc_endpoint" "this" {
 
   vpc_id            = var.vpc_id
   service_name      = try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name)
+  service_region    = try(each.value.service_region, null)
   vpc_endpoint_type = try(each.value.service_type, "Interface")
   auto_accept       = try(each.value.auto_accept, null)
 

--- a/modules/vpc-endpoints/versions.tf
+++ b/modules/vpc-endpoints/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.83"
     }
   }
 }


### PR DESCRIPTION
## Description
Adds cross-region capabilities for VPC endpoints.

## Motivation and Context
AWS added cross-region support for VPC Private link in November 2024. Support for that feature was added in the AWS [Terraform provider release 5.83](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.83.0). 

## Breaking Changes
No breaking changes, backwards compatible.

## How Has This Been Tested?
Tested and validated both the old syntax (of not providing the `service_region` as part of `var.endpoints` as well as with adding it.
