### PR TITLE
fix: Fixed service_region argument in the VPC endpoint module

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -13,7 +13,7 @@ data "aws_vpc_endpoint_service" "this" {
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)
-  service_regions = try([each.value.service_region], null)
+  service_regions = try(each.value.service_region != null ? [each.value.service_region] : null, null)
 
   filter {
     name   = "service-type"

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -13,7 +13,7 @@ data "aws_vpc_endpoint_service" "this" {
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)
-  service_regions = try(each.value.service_region != null ? [each.value.service_region] : null, null)
+  service_regions = try(each.value.service_region, null) != null ? [each.value.service_region] : null
 
   filter {
     name   = "service-type"

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -13,7 +13,7 @@ data "aws_vpc_endpoint_service" "this" {
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)
-  service_regions = try(each.value.service_region, null) != null ? [each.value.service_region] : null
+  service_regions = try(coalescelist(compact([each.value.service_region])), null)
 
   filter {
     name   = "service-type"


### PR DESCRIPTION
## Description
Currently, if we pass ` service_region=null` (rather than not passing it at all), the module fails as it passes on `[null]` rather than `null` to the underlying data source.

## Motivation and Context
See description and [the comment in this PR that added cross-region support](https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1161#issuecomment-2616115424) in the first place.

## Breaking Changes
Non breaking, makes things more robust and covers all all cases (no `service_region` passed, `service_region=null` passed, valid service region passed)

## How Has This Been Tested?
Tested passing no `service_region`, `service_region=null`, or a valid service region passed
