### PR TITLE
feat: Allow setting custom tags on `aws_vpc_block_public_access_exclusion` resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.2
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/examples/block-public-access/README.md
+++ b/examples/block-public-access/README.md
@@ -30,8 +30,8 @@ Currently only `internet_gateway_block_mode` is supported, for which valid value
 
 VPC block public access exclusions can be applied at the VPC level e.g.:
 
-```
-vpc_block_public_access_exclusions = {
+```hcl
+  vpc_block_public_access_exclusions = {
     exclude_vpc = {
         exclude_vpc                     = true
         internet_gateway_exclusion_mode = "allow-bidirectional"
@@ -41,18 +41,16 @@ vpc_block_public_access_exclusions = {
 
 or at the subnet level e.g.:
 
-```
-vpc_block_public_access_exclusions = {
+```hcl
+  vpc_block_public_access_exclusions = {
     exclude_subnet_private1 = {
         exclude_subnet                  = true
-        exclude_name                    = "private-subnet-1"
         subnet_type                     = "private"
         subnet_index                    = 1
         internet_gateway_exclusion_mode = "allow-egress"
     }
     exclude_subnet_private2 = {
         exclude_subnet                  = true
-        exclude_name                    = "private-subnet-2"
         subnet_type                     = "private"
         subnet_index                    = 2
         internet_gateway_exclusion_mode = "allow-egress"
@@ -64,7 +62,6 @@ One of `exclude_vpc` or `exclude_subnet` must be set to true.
 Value of `subnet_type` can be `public`, `private`, `database`, `redshift`, `elasticache`, `intra` or `custom`.
 Value of `subnet_index` is the index of the subnet in the corresponding subnet list.
 Value of `internet_gateway_exclusion_mode` can be `allow-egress` and `allow-bidirectional`.
-Value of `exclude_name` is string value of the Name tag for the resource. If omitted, the default name of VPC Name-bpa-exclusion is applied.
 
 After deployment, VPC block public access options can be verified with the following command:
 

--- a/examples/block-public-access/README.md
+++ b/examples/block-public-access/README.md
@@ -45,12 +45,14 @@ or at the subnet level e.g.:
 vpc_block_public_access_exclusions = {
     exclude_subnet_private1 = {
         exclude_subnet                  = true
+        exclude_name                    = "private-subnet-1"
         subnet_type                     = "private"
         subnet_index                    = 1
         internet_gateway_exclusion_mode = "allow-egress"
     }
     exclude_subnet_private2 = {
         exclude_subnet                  = true
+        exclude_name                    = "private-subnet-2"
         subnet_type                     = "private"
         subnet_index                    = 2
         internet_gateway_exclusion_mode = "allow-egress"
@@ -62,6 +64,7 @@ One of `exclude_vpc` or `exclude_subnet` must be set to true.
 Value of `subnet_type` can be `public`, `private`, `database`, `redshift`, `elasticache`, `intra` or `custom`.
 Value of `subnet_index` is the index of the subnet in the corresponding subnet list.
 Value of `internet_gateway_exclusion_mode` can be `allow-egress` and `allow-bidirectional`.
+Value of `exclude_name` is string value of the Name tag for the resource. If omitted, the default name of VPC Name-bpa-exclusion is applied.
 
 After deployment, VPC block public access options can be verified with the following command:
 

--- a/examples/block-public-access/main.tf
+++ b/examples/block-public-access/main.tf
@@ -31,36 +31,16 @@ module "vpc" {
   azs             = local.azs
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
 
-  ### VPC Block Public Access Options
   vpc_block_public_access_options = {
     internet_gateway_block_mode = "block-bidirectional"
   }
 
-  ### VPC Block Public Access Exclusion at the VPC level
   vpc_block_public_access_exclusions = {
     exclude_vpc = {
       exclude_vpc                     = true
       internet_gateway_exclusion_mode = "allow-bidirectional"
     }
   }
-
-  ### VPC Block Public Access Exclusion at the subnet level
-  # vpc_block_public_access_exclusions = {
-  #   exclude_subnet_private1 = {
-  #     exclude_subnet                  = true
-  #     exclude_name                    = "private-subnet-1"
-  #     subnet_type                     = "private"
-  #     subnet_index                    = 1
-  #     internet_gateway_exclusion_mode = "allow-egress"
-  #   }
-  #   exclude_subnet_private2 = {
-  #     exclude_subnet                  = true
-  #     exclude_name                    = "private-subnet-2"
-  #     subnet_type                     = "private"
-  #     subnet_index                    = 2
-  #     internet_gateway_exclusion_mode = "allow-egress"
-  #   }
-  # }
 
   tags = local.tags
 }

--- a/examples/block-public-access/main.tf
+++ b/examples/block-public-access/main.tf
@@ -48,12 +48,14 @@ module "vpc" {
   # vpc_block_public_access_exclusions = {
   #   exclude_subnet_private1 = {
   #     exclude_subnet                  = true
+  #     exclude_name                    = "private-subnet-1"
   #     subnet_type                     = "private"
   #     subnet_index                    = 1
   #     internet_gateway_exclusion_mode = "allow-egress"
   #   }
   #   exclude_subnet_private2 = {
   #     exclude_subnet                  = true
+  #     exclude_name                    = "private-subnet-2"
   #     subnet_type                     = "private"
   #     subnet_index                    = 2
   #     internet_gateway_exclusion_mode = "allow-egress"

--- a/main.tf
+++ b/main.tf
@@ -68,9 +68,9 @@ resource "aws_vpc_block_public_access_options" "this" {
 resource "aws_vpc_block_public_access_exclusion" "this" {
   for_each = { for k, v in var.vpc_block_public_access_exclusions : k => v if local.create_vpc }
 
-  vpc_id = lookup(each.value, "exclude_vpc", false) ? local.vpc_id : null
+  vpc_id = try(each.value.exclude_vpc, false) ? local.vpc_id : null
 
-  subnet_id = lookup(each.value, "exclude_subnet", false) ? lookup(
+  subnet_id = try(each.value.exclude_subnet, false) ? lookup(
     {
       private     = aws_subnet.private[*].id,
       public      = aws_subnet.public[*].id,
@@ -87,8 +87,9 @@ resource "aws_vpc_block_public_access_exclusion" "this" {
   internet_gateway_exclusion_mode = each.value.internet_gateway_exclusion_mode
 
   tags = merge(
-    { "Name" = try(coalesce(each.value.exclude_name), "${var.name}-bpa-exclusion") },
-  var.tags, )
+    var.tags,
+    try(each.value.tags, {}),
+  )
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,9 @@ resource "aws_vpc_block_public_access_exclusion" "this" {
 
   internet_gateway_exclusion_mode = each.value.internet_gateway_exclusion_mode
 
-  tags = var.tags
+  tags = merge(
+    { "Name" = try(coalesce(each.value.exclude_name), "${var.name}-bpa-exclusion") },
+  var.tags, )
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Allows name tagging on aws_vpc_block_public_access_exclusion resource

Closes #1169 

## Motivation and Context
To be able to set the name tag on the AWS resource
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1169

## Breaking Changes
No breaking changes


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
