### PR TITLE
fix: Update aws_vpn_gateway_route_propagation private/intra count to …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1219,8 +1219,9 @@ resource "aws_vpn_gateway_route_propagation" "public" {
   )
 }
 
+# There are as many routing tables as the number of NAT gateways
 resource "aws_vpn_gateway_route_propagation" "private" {
-  count = local.create_vpc && var.propagate_private_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? local.len_private_subnets : 0
+  count = local.create_vpc && var.propagate_private_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? local.nat_gateway_count : 0
 
   route_table_id = element(aws_route_table.private[*].id, count.index)
   vpn_gateway_id = element(
@@ -1233,7 +1234,7 @@ resource "aws_vpn_gateway_route_propagation" "private" {
 }
 
 resource "aws_vpn_gateway_route_propagation" "intra" {
-  count = local.create_vpc && var.propagate_intra_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? local.len_intra_subnets : 0
+  count = local.create_vpc && var.propagate_intra_route_tables_vgw && (var.enable_vpn_gateway || var.vpn_gateway_id != "") ? local.num_intra_route_tables : 0
 
   route_table_id = element(aws_route_table.intra[*].id, count.index)
   vpn_gateway_id = element(


### PR DESCRIPTION
## Description
Update the `"aws_vpn_gateway_route_propagation" "private"/"intra"` resources to count the route tables instead of the subnet.

## Motivation and Context
Where there is a single route table and three subnets, e.g. when `"single_nat_gateway" = true`, the same propagation resource becomes managed multiple times under this module.

When switching an existing VPC from a single NAT gateway to three NAT gateways, terraform recreates the [1] and [2] under the new route tables, this removes the route from the original route table.

## Breaking Changes
If already using `"single_nat_gateway" = true`, two terraform applies are required. One to delete the additional propagations, and another to recreate the [0] propagation. Alternatively run terraform state rm on the extra propagations.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->