### PR TITLE
feat: optional for public route_table_association

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  count = local.create_public_subnets ? local.len_public_subnets : 0
+  count = var.create_public_route_association && local.create_public_subnets ? local.len_public_subnets : 0
 
   subnet_id      = element(aws_subnet.public[*].id, count.index)
   route_table_id = element(aws_route_table.public[*].id, var.create_multiple_public_route_tables ? count.index : 0)

--- a/variables.tf
+++ b/variables.tf
@@ -274,6 +274,12 @@ variable "public_route_table_tags" {
   default     = {}
 }
 
+variable "create_public_route_association" {
+  description = "Option to associate public route tables"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Public Network ACLs
 ################################################################################


### PR DESCRIPTION
## Description
The current module does not provide an option to disable the creation of public route associations. This PR hopes to include a variable to control that.

## Motivation and Context
We create a network firewall outside of this module and associate the existing public subnet with the new firewall routing tables. 

However, this introduces drift since we can't disable the association from this module.

We need to set this as optional for the public route association.

## Breaking Changes
None as far as I can observe
var. create_public_route_association is default to true

## How Has This Been Tested?
We tested this internally.