### PR TITLE
feat: add rds subnet groups for intra subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -859,6 +859,22 @@ resource "aws_subnet" "intra" {
   )
 }
 
+resource "aws_db_subnet_group" "intra" {
+  count = local.create_intra_subnets && var.create_intra_subnet_group ? 1 : 0
+
+  name        = lower(coalesce(var.intra_subnet_group_name, "${var.name}-intra"))
+  description = "Intra subnet group for ${var.name}"
+  subnet_ids  = aws_subnet.intra[*].id
+
+  tags = merge(
+    {
+      "Name" = lower(coalesce(var.intra_subnet_group_name, "${var.name}-intra"))
+    },
+    var.tags,
+    var.intra_subnet_group_tags,
+  )
+}
+
 locals {
   num_intra_route_tables = var.create_multiple_intra_route_tables ? local.len_intra_subnets : 1
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -505,6 +505,17 @@ output "intra_network_acl_arn" {
   value       = try(aws_network_acl.intra[0].arn, null)
 }
 
+output "intra_subnet_group" {
+  description = "ID of intra subnet group"
+  value       = try(aws_db_subnet_group.intra[0].id, null)
+}
+
+output "intra_subnet_group_name" {
+  description = "Name of intra subnet group"
+  value       = try(aws_db_subnet_group.intra[0].name, null)
+}
+
+
 ################################################################################
 # NAT Gateway
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -992,6 +992,24 @@ variable "intra_route_table_tags" {
   default     = {}
 }
 
+variable "create_intra_subnet_group" {
+  description = "Controls if RDS subnet group should be created (n.b. intra_subnets must also be set)"
+  type        = bool
+  default     = true
+}
+
+variable "intra_subnet_group_name" {
+  description = "Name of intra subnet group"
+  type        = string
+  default     = null
+}
+
+variable "intra_subnet_group_tags" {
+  description = "Additional tags for the intra subnet group"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Intra Network ACLs
 ################################################################################


### PR DESCRIPTION
## Description
Added an optional feature for creating an RDS subnet group using the existing intra subnets in the VPC. This enables users to use RDS without the need to create a separate database subnet group

## Motivation and Context
In previous projects, I had to manually create a separate subnet group using intra subnets every time I needed to deploy RDS resources. And before you say "just use database_subnet_groups", the point is, I want all services that don't require internet access (like RDS) to reside in the same isolated subnet group, such as intra_subnets. Creating and managing a separate database subnet group for this feels redundant.

## Breaking Changes
No breaking changes. Just an optional functionality.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
