### PR TITLE
docs: Example policy for VPC endpoint needs Allow statement; S3 endpoint should be type 'Gateway'

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -106,10 +106,9 @@ module "vpc_endpoints" {
     s3 = {
       service             = "s3"
       private_dns_enabled = true
-      dns_options = {
-        private_dns_only_for_inbound_resolver_endpoint = false
-      }
-      tags = { Name = "s3-vpc-endpoint" }
+      type                = "Gateway"
+      route_table_ids     = flatten([module.vpc.intra_route_table_ids, module.vpc.private_route_table_ids, module.vpc.public_route_table_ids])
+      tags                = { Name = "s3-vpc-endpoint" }
     },
     dynamodb = {
       service         = "dynamodb"
@@ -208,6 +207,17 @@ data "aws_iam_policy_document" "generic_endpoint_policy" {
       variable = "aws:SourceVpc"
 
       values = [module.vpc.vpc_id]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["*"]
+    resources = ["*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
     }
   }
 }


### PR DESCRIPTION


## Description

I've been troubleshooting a problem with an EKS cluster running in a VPC created by terraform-aws-vpc.  Most of my setup was cribbed from your [complete](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/examples/complete/main.tf) example.  Attempts to pull images from ECR _in the same region_ were consistently denied while those in other regions worked fine.

AWS Support managed to identify the problem.  It was that ECR endpoints created using the `generic_endpoint_policy` from the example lack any `Allow` statement to permit access.  Allow statements [aren't implicit](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic_policy-eval-denyallow.html) in IAM policies so this defaulted to denying all requests.  

Calls to ECR in the same region therefore failed.  Ones to ECR in _other_ regions went out via my NAT gateway instead of using the local endpoint, so confusingly they still worked fine.

The PR fixes the issue by adding the missing `Allow` statement.  AWS support have also advised me S3 endpoints should typically be set as type `Gateway`, so I've modified the example to do this too.


## Motivation and Context

It solves the problem of ECR images failing to pull via VPC endpoints created following the example bundled with terraform-aws-vpc.

## Breaking Changes

No

## How Has This Been Tested?

Please describe how you tested your changes

- Running on my own environment
- [X] I have executed `pre-commit run -a` on my pull request

