### PR TITLE
docs: Update README.md for VPC Endpoints submodule

### DIFF
--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -22,6 +22,7 @@ module "endpoints" {
     dynamodb = {
       # gateway endpoint
       service         = "dynamodb"
+      service_type    = "Gateway"
       route_table_ids = ["rt-12322456", "rt-43433343", "rt-11223344"]
       tags            = { Name = "dynamodb-vpc-endpoint" }
     },


### PR DESCRIPTION
## Description
Add missed parameter for VPC Endpoint Gateway service type in README

## Motivation and Context
Without this parameter, VPC Endpoint with type "Interface" will be created.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
N/A
