### PR TITLE
feat: Skip VPC endpoint service lookup when service_endpoint is explicitly provided

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -9,7 +9,10 @@ locals {
 }
 
 data "aws_vpc_endpoint_service" "this" {
-  for_each = local.endpoints
+  for_each = {
+    for k, v in local.endpoints : k => v
+    if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
+  }
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)


### PR DESCRIPTION
## Description
This PR updates the aws_vpc_endpoint_service data source logic to conditionally evaluate only when service_endpoint is not defined in the VPC endpoint configuration.

This avoids lookup failures when using cross-account AWS PrivateLink services, which are not discoverable via the data source due to visibility restrictions.

## Motivation and Context
Fixes [#1215](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1215)

The module previously evaluated aws_vpc_endpoint_service for all endpoints unconditionally. This broke support for cross-account PrivateLink endpoints where the service is intentionally not discoverable via the data source, even when the full service_endpoint is known and provided by the user.

This change allows users to define endpoints with an explicitly provided service_endpoint, bypassing the data source completely, which resolves this limitation.

## Breaking Changes
No breaking changes.
This preserves existing behavior for users who do not define service_endpoint, while enabling new flexibility for cross-account usage.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ x ] I have executed `pre-commit run -a` on my pull request
