### PR TITLE
fix: ipv6 egress route for single nat

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1073,7 +1073,7 @@ resource "aws_egress_only_internet_gateway" "this" {
 }
 
 resource "aws_route" "private_ipv6_egress" {
-  count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 && local.len_private_subnets > 0 ? local.nat_gateway_count : 0
+  count = local.create_vpc && var.create_egress_only_igw && var.enable_ipv6 && local.len_private_subnets > 0 ? ( var.single_nat_gateway ? local.len_private_subnets : local.nat_gateway_count ) : 0
 
   route_table_id              = element(aws_route_table.private[*].id, count.index)
   destination_ipv6_cidr_block = "::/0"


### PR DESCRIPTION
## Description

After merged PR #1059, in the case of a single NAT with multiple private networks, only the route for the first network is retained; the others are removed. This behavior has changed.

Exemple

```
private_subnets = [
   "10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24",
   "10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24",
]
 
private_subnet_ipv6_prefixes = [
   1, 2, 3,
   4, 5, 6
]
enable_nat_gateway     = true
single_nat_gateway     = true
one_nat_gateway_per_az = false
create_egress_only_igw = true
```

## Motivation and Context

I'm upgrading from v2.78 to v5.21. The issue was introduced in v5.7.1.

### Why is this change required? What problem does it solve? 

Otherwise, the first private route resource is retained (NAT gateway count equals 1), while the subsequent private routes are removed.

## Breaking Changes
no

## How Has This Been Tested?
I have tested on my code

## Other thing

Could you create a new v5 version ?
