### PR TITLE
fix: replace deprecated log_group.name with id

### DIFF
--- a/vpc-flow-logs.tf
+++ b/vpc-flow-logs.tf
@@ -25,7 +25,7 @@ locals {
   flow_log_cloudwatch_log_group_name_suffix = var.flow_log_cloudwatch_log_group_name_suffix == "" ? local.vpc_id : var.flow_log_cloudwatch_log_group_name_suffix
   flow_log_group_arns = [
     for log_group in aws_cloudwatch_log_group.flow_log :
-    "arn:${data.aws_partition.current[0].partition}:logs:${data.aws_region.current[0].region}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.name}:*"
+    "arn:${data.aws_partition.current[0].partition}:logs:${data.aws_region.current[0].region}:${data.aws_caller_identity.current[0].account_id}:log-group:${log_group.id}:*"
   ]
 }
 


### PR DESCRIPTION
## Description
Replaced deprecated usage of `log_group.name` with `log_group.id` in `vpc-flow-logs.tf` to comply with the latest AWS provider recommendations.

## Motivation and Context
This change resolves a deprecation warning from the AWS provider related to the `name` attribute in CloudWatch Log Group ARNs. It improves compatibility with newer provider versions and ensures future stability.

## Breaking Changes
No breaking changes. This update is backward-compatible, as `log_group.id` returns the same ARN-friendly value as `name`.