### PR TITLE
fix: security_group_tags for endpoints

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -82,9 +82,9 @@ resource "aws_security_group" "this" {
   vpc_id      = var.vpc_id
 
   tags = merge(
+    { "Name" = try(coalesce(var.security_group_name, var.security_group_name_prefix), "") },
     var.tags,
     var.security_group_tags,
-    { "Name" = try(coalesce(var.security_group_name, var.security_group_name_prefix), "") },
   )
 
   lifecycle {


### PR DESCRIPTION
## Description
Rearrange Security Group tags for Endpoints. Position generated Name tag before user input.

## Motivation and Context
This change fix a bug that makes impossible to define custom Name for the SG.


## Breaking Changes
none

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
