### PR TITLE
fix: Change security group tags merge precedence in vpc-endpoints module

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -102,6 +102,10 @@ module "vpc_endpoints" {
     }
   }
 
+  security_group_tags = {
+    Name = "example-name-override"
+  }
+
   endpoints = {
     s3 = {
       service             = "s3"

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -83,8 +83,8 @@ resource "aws_security_group" "this" {
 
   tags = merge(
     var.tags,
-    var.security_group_tags,
     { "Name" = try(coalesce(var.security_group_name, var.security_group_name_prefix), "") },
+    var.security_group_tags
   )
 
   lifecycle {


### PR DESCRIPTION
## Description
The security group tags `merge` function precedence has been changed in the vpc-endpoints module.

## Motivation and Context
This ensures that a `Name` tag passed to the `security_group_tags` variable is preferred over `var.tags`, `var.security_group_name` or `var.security_group_name_prefix`

Currently, if `var.security_group_name_prefix` is used the `Name` tag has a trailing hyphen. e.g. ex-app-vpce-sg-euw1-

The hyphen can be dropped, but then the actual name does not have a hyphen between the prefix and the random suffix.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
