### PR TITLE
fix: Prefer user defined `security_group_tags` in the vpc endpoint module

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -102,6 +102,10 @@ module "vpc_endpoints" {
     }
   }
 
+  security_group_tags = {
+    Name = "example-name-override"
+  }
+
   endpoints = {
     s3 = {
       service             = "s3"

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -83,8 +83,8 @@ resource "aws_security_group" "this" {
 
   tags = merge(
     var.tags,
-    var.security_group_tags,
     { "Name" = try(coalesce(var.security_group_name, var.security_group_name_prefix), "") },
+    var.security_group_tags
   )
 
   lifecycle {


### PR DESCRIPTION
## Description
User defined tags, which could include a `Name`, for the VPC endpoint security group should be preferred over hardcoded tags. This aligns the functionality with other resources in this and other terraform-aws-modules; several examples are provided in https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/1231

## Motivation and Context
Resolves: https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1234

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
