### PR TITLE
feat: Allow partial subnet naming

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -282,9 +282,9 @@ resource "aws_subnet" "private" {
   tags = merge(
     {
       Name = (
-       try(var.private_subnet_names[count.index], null) != null
-        ? var.private_subnet_names[count.index]
-        : format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+      try(var.private_subnet_names[count.index], null) != null
+      ? var.private_subnet_names[count.index]
+      : format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
       )
     },
     var.tags,

--- a/main.tf
+++ b/main.tf
@@ -281,9 +281,10 @@ resource "aws_subnet" "private" {
 
   tags = merge(
     {
-      Name = try(
-        var.private_subnet_names[count.index],
-        format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+      Name = (
+       try(var.private_subnet_names[count.index], null) != null
+        ? var.private_subnet_names[count.index]
+        : format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
       )
     },
     var.tags,

--- a/main.tf
+++ b/main.tf
@@ -282,9 +282,9 @@ resource "aws_subnet" "private" {
   tags = merge(
     {
       Name = (
-      try(var.private_subnet_names[count.index], null) != null
-      ? var.private_subnet_names[count.index]
-      : format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
+        try(var.private_subnet_names[count.index], null) != null
+        ? var.private_subnet_names[count.index]
+        : format("${var.name}-${var.private_subnet_suffix}-%s", element(var.azs, count.index))
       )
     },
     var.tags,


### PR DESCRIPTION
Implements the solution proposed by @RafaelWO in issue #1239.

## Description

This change updates the naming logic for private subnets to allow for partial custom naming. It enables the use of `null` values in the `private_subnet_names` list to fall back to the module's default auto-naming convention for specific subnets.

## How Has This Been Tested?

- Tested locally using the example test case with `private_subnet_names = [null, "my-custom-net-2", null]`.
- Confirmed that `terraform plan` produces the expected names for all three subnets (one custom, two auto-generated) and resolves the original issue.