### PR TITLE
feat: Add support for `bgp_asn_extended` argument to the `customer_gateways` variable

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -64,6 +64,10 @@ module "vpc" {
       bgp_asn    = 65112
       ip_address = "5.6.7.8"
     }
+    IP3 = {
+      bgp_asn_extended = 2147483648
+      ip_address       = "5.6.7.8"
+    }
   }
 
   enable_vpn_gateway = true

--- a/main.tf
+++ b/main.tf
@@ -1290,10 +1290,11 @@ resource "aws_customer_gateway" "this" {
 
   region = var.region
 
-  bgp_asn     = each.value["bgp_asn"]
-  ip_address  = each.value["ip_address"]
-  device_name = lookup(each.value, "device_name", null)
-  type        = "ipsec.1"
+  bgp_asn          = lookup(each.value, "bgp_asn", null)
+  bgp_asn_extended = lookup(each.value, "bgp_asn_extended", null)
+  ip_address       = each.value["ip_address"]
+  device_name      = lookup(each.value, "device_name", null)
+  type             = "ipsec.1"
 
   tags = merge(
     { Name = "${var.name}-${each.key}" },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds the ability to pass in bgp_asn_extended to the aws_customer_gateway resource

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes this open issue:
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1247

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [] I have executed `pre-commit run -a` on my pull request
This created a few unrelated changes that I did not want to include in my PR in the Terraform Wrapper step.

<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
We have deployed this internally with no issues. I updated the complete example to show how this would work.
