### PR TITLE
fix: Correction with IAM role policy associated with modules/flow-log

### DIFF
--- a/modules/flow-log/main.tf
+++ b/modules/flow-log/main.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "this" {
         "logs:DescribeLogStreams",
       ]
 
-      resources = local.create_cloudwatch_log_group ? aws_cloudwatch_log_group.this[*].arn : [var.log_destination]
+      resources = local.create_cloudwatch_log_group ? formatlist("%s:*", aws_cloudwatch_log_group.this[*].arn) : [var.log_destination]
     }
   }
 


### PR DESCRIPTION
## Description
In order for the Flow Log to be able to create log streams in Cloudwatch log group, the policy should have " :* "

## Motivation and Context
Resolves #1262 

## Breaking Changes
No Breaking Changes.

## How Has This Been Tested?
- [x] I have tested the same in one of my test aws account and have verified that the changes does change the IAM Policy and VPC flow log's IAM role is able to create logStream in logGroup.

- [X] I have executed `pre-commit run -a` on my pull request
