### PR TITLE
fix: Updating AZ regex condition to support EU Sovereign Cloud AZ IDs.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,8 +148,8 @@ resource "aws_subnet" "public" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.public_subnet_ipv6_native ? true : var.public_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.public_subnet_ipv6_native ? null : element(concat(var.public_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.public_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.public_subnet_enable_resource_name_dns_aaaa_record_on_launch
@@ -296,8 +296,8 @@ resource "aws_subnet" "private" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.private_subnet_ipv6_native ? true : var.private_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.private_subnet_ipv6_native ? null : element(concat(var.private_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.private_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.private_subnet_enable_resource_name_dns_aaaa_record_on_launch
@@ -428,8 +428,8 @@ resource "aws_subnet" "database" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.database_subnet_ipv6_native ? true : var.database_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.database_subnet_ipv6_native ? null : element(concat(var.database_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.database_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.database_subnet_enable_resource_name_dns_aaaa_record_on_launch
@@ -632,8 +632,8 @@ resource "aws_subnet" "redshift" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.redshift_subnet_ipv6_native ? true : var.redshift_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.redshift_subnet_ipv6_native ? null : element(concat(var.redshift_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.redshift_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.redshift_subnet_enable_resource_name_dns_aaaa_record_on_launch
@@ -785,8 +785,8 @@ resource "aws_subnet" "elasticache" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.elasticache_subnet_ipv6_native ? true : var.elasticache_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.elasticache_subnet_ipv6_native ? null : element(concat(var.elasticache_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.elasticache_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.elasticache_subnet_enable_resource_name_dns_aaaa_record_on_launch
@@ -929,8 +929,8 @@ resource "aws_subnet" "intra" {
   region = var.region
 
   assign_ipv6_address_on_creation                = var.enable_ipv6 && var.intra_subnet_ipv6_native ? true : var.intra_subnet_assign_ipv6_address_on_creation
-  availability_zone                              = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
-  availability_zone_id                           = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) == 0 ? element(var.azs, count.index) : null
+  availability_zone                              = length(compact(split("-", element(var.azs, count.index)))) != 2 ? element(var.azs, count.index) : null
+  availability_zone_id                           = length(compact(split("-", element(var.azs, count.index)))) == 2 ? element(var.azs, count.index) : null
   cidr_block                                     = var.intra_subnet_ipv6_native ? null : element(concat(var.intra_subnets, [""]), count.index)
   enable_dns64                                   = var.enable_ipv6 && var.intra_subnet_enable_dns64
   enable_resource_name_dns_aaaa_record_on_launch = var.enable_ipv6 && var.intra_subnet_enable_resource_name_dns_aaaa_record_on_launch


### PR DESCRIPTION
## Description

AWS EU Sovereign cloud has different conventions for zone name and zone ids. Instead of asserting the regex on entire AZ id or AZ name, we resort to a simple logic -- split the az by hypen (`-`), if `length(splits) == 2` we assume its AZ id.  

```
{
    "AvailabilityZones": [
        {
            "OptInStatus": "opt-in-not-required",
            "Messages": [],
            "RegionName": "eusc-de-east-1",
            "ZoneName": "eusc-de-east-1a",
            "ZoneId": "euscdee1-az1",
            "GroupName": "eusc-de-east-1-zg-1",
            "NetworkBorderGroup": "eusc-de-east-1",
            "ZoneType": "availability-zone",
            "GroupLongName": "EU (Germany) 1",
            "State": "available"
        }
 ...
}
``` 

## Motivation and Context

AWS EUSC has different naming conventions for AZ name and id.

## Breaking Changes

None, I can think off.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I executed examples/simple for `us-east-1` and `eusc-de-east-1` by passing a mix of AZ names and AZ ids to `azs` list. 

- [x] I have executed `pre-commit run -a` on my pull request
