### PR TITLE
fix: Allow IPv6 IPAM pool without requiring IPv4 IPAM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,11 +30,11 @@ resource "aws_vpc" "this" {
 
   region = var.region
 
-  cidr_block          = var.use_ipam_pool ? null : var.cidr
+  cidr_block          = var.use_ipam_pool && var.ipv4_ipam_pool_id != null ? null : var.cidr
   ipv4_ipam_pool_id   = var.ipv4_ipam_pool_id
   ipv4_netmask_length = var.ipv4_netmask_length
 
-  assign_generated_ipv6_cidr_block     = var.enable_ipv6 && !var.use_ipam_pool ? true : null
+  assign_generated_ipv6_cidr_block     = var.enable_ipv6 && !var.use_ipam_pool && var.ipv6_ipam_pool_id == null ? true : null
   ipv6_cidr_block                      = var.ipv6_cidr
   ipv6_ipam_pool_id                    = var.ipv6_ipam_pool_id
   ipv6_netmask_length                  = var.ipv6_netmask_length


### PR DESCRIPTION
## Description

Allow IPv6 IPAM pool to be used without requiring an IPv4 IPAM pool.

## Motivation and Context

When `use_ipam_pool = true` but only an IPv6 IPAM pool is configured (no `ipv4_ipam_pool_id`), two bugs occurred:
  - `cidr_block` was set to null, breaking IPv4 CIDR assignment
  - `assign_generated_ipv6_cidr_block` was omitted, breaking AWS-generated IPv6 CIDR assignment

Fixes [#1282](https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/1282)

## Breaking Changes

None. This is a bug fix that only affects configurations using `use_ipam_pool = true` with IPv6 IPAM but no IPv4 IPAM pool, a combination that was previously broken.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

The [`examples/ipam/`](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/examples/ipam/main.tf) example already has IPv6 IPAM infrastructure present but commented out due to BYOIP requirements. The fix applies to the logic in main.tf and was manually validated in a live environment.