### PR TITLE
feat: Support NAT Gateway secondary EIP associations safely (Fixes #1005, #992)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ No modules.
 | [aws_iam_role_policy_attachment.vpc_flow_log_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_nat_gateway_eip_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway_eip_association) | resource |
 | [aws_network_acl.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
@@ -566,6 +567,7 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the region set in the provider configuration | `string` | `null` | no |
 | <a name="input_reuse_nat_ips"></a> [reuse\_nat\_ips](#input\_reuse\_nat\_ips) | Should be true if you don't want EIPs to be created for your NAT Gateways and will instead pass them in via the 'external\_nat\_ip\_ids' variable | `bool` | `false` | no |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to associate with the VPC to extend the IP Address pool | `list(string)` | `[]` | no |
+| <a name="input_secondary_nat_gateway_ips"></a> [secondary\_nat\_gateway\_ips](#input\_secondary\_nat\_gateway\_ips) | List of lists of secondary EIP allocation IDs to associate with NAT Gateways. The outer list corresponds to the NAT Gateway index, and the inner list contains the allocation IDs for that specific NAT Gateway. | `list(list(string))` | `[]` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_ipam_pool"></a> [use\_ipam\_pool](#input\_use\_ipam\_pool) | Determines whether IPAM pool is used for CIDR allocation | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,16 @@ locals {
   vpc_id = try(aws_vpc_ipv4_cidr_block_association.this[0].vpc_id, aws_vpc.this[0].id, "")
 
   create_vpc = var.create_vpc && var.putin_khuylo
+
+  # Flatten the secondary IPs to work with a single count loop for the association resource
+  nat_gateway_secondary_ips_flattened = flatten([
+    for gw_idx, ips in var.secondary_nat_gateway_ips : [
+      for ip in ips : {
+        gw_idx        = gw_idx
+        allocation_id = ip
+      }
+    ]
+  ])
 }
 
 ################################################################################
@@ -1251,6 +1261,17 @@ resource "aws_nat_gateway" "this" {
   )
 
   depends_on = [aws_internet_gateway.this]
+}
+
+################################################################################
+# NAT Gateway Secondary EIP Association
+################################################################################
+
+resource "aws_nat_gateway_eip_association" "this" {
+  count = local.create_vpc && var.enable_nat_gateway && length(local.nat_gateway_secondary_ips_flattened) > 0 ? length(local.nat_gateway_secondary_ips_flattened) : 0
+
+  nat_gateway_id = element(aws_nat_gateway.this[*].id, var.single_nat_gateway ? 0 : local.nat_gateway_secondary_ips_flattened[count.index].gw_idx)
+  allocation_id  = local.nat_gateway_secondary_ips_flattened[count.index].allocation_id
 }
 
 resource "aws_route" "private_nat_gateway" {

--- a/variables.tf
+++ b/variables.tf
@@ -1252,6 +1252,12 @@ variable "external_nat_ips" {
   default     = []
 }
 
+variable "secondary_nat_gateway_ips" {
+  description = "List of lists of secondary EIP allocation IDs to associate with NAT Gateways. The outer list corresponds to the NAT Gateway index, and the inner list contains the allocation IDs for that specific NAT Gateway."
+  type        = list(list(string))
+  default     = []
+}
+
 variable "nat_gateway_tags" {
   description = "Additional tags for the NAT gateways"
   type        = map(string)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -383,6 +383,7 @@ module "wrapper" {
   region                                                         = try(each.value.region, var.defaults.region, null)
   reuse_nat_ips                                                  = try(each.value.reuse_nat_ips, var.defaults.reuse_nat_ips, false)
   secondary_cidr_blocks                                          = try(each.value.secondary_cidr_blocks, var.defaults.secondary_cidr_blocks, [])
+  secondary_nat_gateway_ips                                      = try(each.value.secondary_nat_gateway_ips, var.defaults.secondary_nat_gateway_ips, [])
   single_nat_gateway                                             = try(each.value.single_nat_gateway, var.defaults.single_nat_gateway, false)
   tags                                                           = try(each.value.tags, var.defaults.tags, {})
   use_ipam_pool                                                  = try(each.value.use_ipam_pool, var.defaults.use_ipam_pool, false)


### PR DESCRIPTION
## Description
This PR introduces the ability to assign secondary Elastic IPs to NAT Gateways to alleviate SNAT port exhaustion, addressing issues #1005 and #992. 

**Architectural Note:** Historically, attempting to use the inline `secondary_allocation_ids` argument within the `aws_nat_gateway` resource resulted in unresolvable lifecycle deadlocks during deletion (Terraform would attempt to delete the EIP before the NAT Gateway was updated to disassociate it, resulting in `AuthFailure`/`InUse` API blocks). 

To ensure safe Day-2 operations, this PR utilizes the newly introduced `aws_nat_gateway_eip_association` resource. This explicitly decouples the association from the NAT Gateway resource, allowing Terraform to construct a clean dependency graph (`Create EIP` -> `Create NAT` -> `Associate` / `Disassociate` -> `Destroy EIP`).

I introduced `var.secondary_nat_gateway_ips` as a `list(list(string))` to perfectly map secondary allocations to their respective AZ-specific NAT gateways, flattened internally to support a clean `count` loop.

## Motivation and Context
Closes #1005.
Closes #992.
Provides enterprise users a scalable escape valve for source port exhaustion.

## Breaking Changes
None. Defaults to an empty list, preserving existing NAT Gateway behavior.

## How Has This Been Tested?
- [x] Tested against the `examples/complete` directory.
- [x] Executed a full, live `terraform plan`, `apply`, and `destroy` cycle against the AWS API. Confirmed that secondary EIPs attach correctly, and more importantly, that the `destroy` phase disassociates and deletes the EIPs flawlessly without encountering the dreaded EC2 `DisassociateAddress` state loop.