### PR TITLE
fix: Add the NAT64 route public subnets need for DNS64 to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ No modules.
 | [aws_route.private_dns64_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private_ipv6_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.public_dns64_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -665,6 +666,7 @@ No modules.
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
 | <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets |
 | <a name="output_private_subnets_ipv6_cidr_blocks"></a> [private\_subnets\_ipv6\_cidr\_blocks](#output\_private\_subnets\_ipv6\_cidr\_blocks) | List of IPv6 cidr\_blocks of private subnets in an IPv6 enabled VPC |
+| <a name="output_public_dns64_nat_gateway_route_ids"></a> [public\_dns64\_nat\_gateway\_route\_ids](#output\_public\_dns64\_nat\_gateway\_route\_ids) | List of IDs of the public DNS64 NAT gateway routes |
 | <a name="output_public_internet_gateway_ipv6_route_id"></a> [public\_internet\_gateway\_ipv6\_route\_id](#output\_public\_internet\_gateway\_ipv6\_route\_id) | ID of the IPv6 internet gateway route |
 | <a name="output_public_internet_gateway_route_id"></a> [public\_internet\_gateway\_route\_id](#output\_public\_internet\_gateway\_route\_id) | ID of the internet gateway route |
 | <a name="output_public_network_acl_arn"></a> [public\_network\_acl\_arn](#output\_public\_network\_acl\_arn) | ARN of the public network ACL |

--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,24 @@ resource "aws_route" "public_internet_gateway" {
   }
 }
 
+# DNS64 makes the resolver synthesise addresses inside 64:ff9b::/96 for IPv4 only
+# destinations, and reaching them needs a NAT gateway to translate. Public subnets enable
+# DNS64 by default but had no such route, so on an IPv6 only public subnet names resolved
+# and connections then went nowhere. The private and database tiers already have this
+resource "aws_route" "public_dns64_nat_gateway" {
+  count = local.create_public_subnets && var.enable_nat_gateway && var.enable_ipv6 && (length(var.public_subnet_ipv6_prefixes) > 0 || var.public_subnet_ipv6_native) && var.public_subnet_enable_dns64 ? local.num_public_route_tables : 0
+
+  region = var.region
+
+  route_table_id              = element(aws_route_table.public[*].id, count.index)
+  destination_ipv6_cidr_block = "64:ff9b::/96"
+  nat_gateway_id              = element(aws_nat_gateway.this[*].id, count.index)
+
+  timeouts {
+    create = "5m"
+  }
+}
+
 resource "aws_route" "public_internet_gateway_ipv6" {
   count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? local.num_public_route_tables : 0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -145,6 +145,11 @@ output "public_internet_gateway_route_id" {
   value       = try(aws_route.public_internet_gateway[0].id, null)
 }
 
+output "public_dns64_nat_gateway_route_ids" {
+  description = "List of IDs of the public DNS64 NAT gateway routes"
+  value       = aws_route.public_dns64_nat_gateway[*].id
+}
+
 output "public_internet_gateway_ipv6_route_id" {
   description = "ID of the IPv6 internet gateway route"
   value       = try(aws_route.public_internet_gateway_ipv6[0].id, null)


### PR DESCRIPTION
## Description

DNS64 makes the Amazon resolver synthesise IPv6 addresses inside `64:ff9b::/96` for IPv4
only destinations. Those addresses are unreachable without a route sending that prefix to a
NAT gateway, which performs the translation.

`public_subnet_enable_dns64` defaults to `true`, but no NAT64 route was ever created for
public subnets. The private and database tiers already have one. So on an IPv6 only public
subnet, names resolve and connections then go nowhere, and nothing about the plan or the
apply looks wrong.

This adds the route, on the same conditions the private tier already uses: IPv6 enabled,
the tier has IPv6 prefixes or is IPv6 native, DNS64 enabled for the tier, and a NAT gateway
exists to do the translating.

## Motivation and Context

Fixes #972.

## Breaking Changes

**None.** `variables.tf` is untouched, so no default moves.

A caller without IPv6 sees no change at all. A caller who already has IPv6 public subnets
with DNS64 gains the route that was missing, rather than losing a setting they asked for.

Verified by plan: a VPC with IPv6 public and private subnets and a NAT gateway gains the
new public NAT64 route, and a VPC with no IPv6 gains nothing.

## How Has This Been Tested?

- [x] I have executed `pre-commit run -a` on my pull request

  Run as `LC_ALL=C pre-commit run -a`, fully passing.

- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

  Not applied against live credentials.

## Two related findings, deliberately not fixed here

Both would change behaviour, so they do not belong in a non breaking change.

**Five tiers enable DNS64 by default with no NAT64 route.** `public` is fixed here because
it has a NAT gateway available. `redshift`, `elasticache`, `intra` and `outpost` also
default `*_subnet_enable_dns64` to `true` and have no NAT64 route, and `intra` has no
egress path at all by design, so there is nothing to route to. Making those correct means
either changing defaults or adding routes to tiers that have none today.

**The database NAT64 route is gated on the private tier's settings.** Its `count` reads
`private_subnet_ipv6_prefixes`, `private_subnet_ipv6_native` and
`private_subnet_enable_dns64`, while the database subnet's own `enable_dns64` reads the
database equivalents. Enabling DNS64 on database subnets alone therefore gives them no
route. Correcting it would remove routes for anyone relying on the current behaviour.
